### PR TITLE
APIs that do not return the User & FirstSeen

### DIFF
--- a/descope/auth/auth.go
+++ b/descope/auth/auth.go
@@ -73,11 +73,11 @@ func (auth *authenticationService) LogoutWithOptions(request *http.Request, opti
 	return nil
 }
 
-func (auth *authenticationService) ValidateSession(request *http.Request, w http.ResponseWriter) (bool, *AuthenticationInfo, error) {
+func (auth *authenticationService) ValidateSession(request *http.Request, w http.ResponseWriter) (bool, *Token, error) {
 	return auth.ValidateSessionWithOptions(request, WithResponseOption(w))
 }
 
-func (auth *authenticationService) ValidateSessionWithOptions(request *http.Request, options ...Option) (bool, *AuthenticationInfo, error) {
+func (auth *authenticationService) ValidateSessionWithOptions(request *http.Request, options ...Option) (bool, *Token, error) {
 	if request == nil {
 		return false, nil, errors.MissingProviderError
 	}
@@ -113,7 +113,7 @@ func AuthenticationMiddleware(auth Authentication, onFailure func(http.ResponseW
 	}
 }
 
-func (auth *authenticationService) validateSession(sessionToken string, refreshToken string, options ...Option) (bool, *AuthenticationInfo, error) {
+func (auth *authenticationService) validateSession(sessionToken string, refreshToken string, options ...Option) (bool, *Token, error) {
 	token, err := auth.validateJWT(sessionToken)
 	if sessionToken != "" && !auth.publicKeysProvider.publicKeyExists() {
 		return false, nil, errors.NewNoPublicKeyError()
@@ -133,10 +133,10 @@ func (auth *authenticationService) validateSession(sessionToken string, refreshT
 		if err != nil {
 			return false, nil, err
 		}
-		return true, info, nil
+		return true, info.SessionToken, nil
 	}
 
-	return true, NewAuthenticationInfo(nil, token), nil
+	return true, token, nil
 }
 
 func (auth *authenticationService) extractJWTResponse(bodyStr string) (*JWTResponse, error) {

--- a/descope/auth/auth_test.go
+++ b/descope/auth/auth_test.go
@@ -232,10 +232,10 @@ func TestValidateSessionRequest(t *testing.T) {
 	request := &http.Request{Header: http.Header{}}
 	request.AddCookie(&http.Cookie{Name: SessionCookieName, Value: jwtTokenValid})
 	request.AddCookie(&http.Cookie{Name: RefreshCookieName, Value: jwtTokenValid})
-	ok, info, err := a.ValidateSessionWithOptions(request)
+	ok, token, err := a.ValidateSessionWithOptions(request)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.EqualValues(t, jwtTokenValid, info.SessionToken.JWT)
+	require.EqualValues(t, jwtTokenValid, token.JWT)
 }
 
 func TestValidateSessionRequestMissingCookie(t *testing.T) {
@@ -269,7 +269,7 @@ func TestValidateSessionRequestRefreshSession(t *testing.T) {
 	ok, userToken, err := a.ValidateSession(request, b)
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.EqualValues(t, mockAuthSessionCookie.Value, userToken.SessionToken.JWT)
+	assert.EqualValues(t, mockAuthSessionCookie.Value, userToken.JWT)
 	require.Len(t, b.Result().Cookies(), 1)
 	sessionCookie := b.Result().Cookies()[0]
 	require.NoError(t, err)

--- a/descope/auth/authmock.go
+++ b/descope/auth/authmock.go
@@ -13,7 +13,7 @@ type MockDescopeAuthentication struct {
 	UpdateUserPhoneOTPResponseError             error
 	VerifyCodeResponseError                     error
 	ValidateSessionResponseNotOK                bool
-	ValidateSessionResponseInfo                 *AuthenticationInfo
+	ValidateSessionResponseInfo                 *Token
 	ValidateSessionResponseError                error
 	GetMagicLinkSessionResponseInfo             *AuthenticationInfo
 	GetMagicLinkSessionResponseError            error
@@ -246,11 +246,11 @@ func (m MockDescopeAuthentication) VerifyMagicLinkWithOptions(token string, _ ..
 	return m.VerifyCodeResponseInfo, m.VerifyCodeResponseError
 }
 
-func (m MockDescopeAuthentication) ValidateSession(_ *http.Request, _ http.ResponseWriter) (bool, *AuthenticationInfo, error) {
+func (m MockDescopeAuthentication) ValidateSession(_ *http.Request, _ http.ResponseWriter) (bool, *Token, error) {
 	return !m.ValidateSessionResponseNotOK, m.ValidateSessionResponseInfo, m.ValidateSessionResponseError
 }
 
-func (m MockDescopeAuthentication) ValidateSessionWithOptions(_ *http.Request, _ ...Option) (bool, *AuthenticationInfo, error) {
+func (m MockDescopeAuthentication) ValidateSessionWithOptions(_ *http.Request, _ ...Option) (bool, *Token, error) {
 	return !m.ValidateSessionResponseNotOK, m.ValidateSessionResponseInfo, m.ValidateSessionResponseError
 }
 

--- a/descope/auth/sdk.go
+++ b/descope/auth/sdk.go
@@ -112,8 +112,8 @@ type Authentication interface {
 	// Use the ResponseWriter (optional) to apply the cookies to the response automatically.
 	// returns true upon success or false and an error upon failure.
 	// This is a shortcut for ValidateSessionWithOptions(r, WithResponseOption(w))
-	ValidateSession(request *http.Request, w http.ResponseWriter) (bool, *AuthenticationInfo, error)
-	ValidateSessionWithOptions(request *http.Request, options ...Option) (bool, *AuthenticationInfo, error)
+	ValidateSession(request *http.Request, w http.ResponseWriter) (bool, *Token, error)
+	ValidateSessionWithOptions(request *http.Request, options ...Option) (bool, *Token, error)
 
 	// SignUpWebAuthnStart - Use to start an authentication process with webauthn for the new user argument.
 	// returns a transaction id response on successs and error upon failure.

--- a/descope/descope_test.go
+++ b/descope/descope_test.go
@@ -47,7 +47,7 @@ func TestDescopeSDKMock(t *testing.T) {
 	api := DescopeClient{
 		Auth: auth.MockDescopeAuthentication{
 			ValidateSessionResponseNotOK: true,
-			ValidateSessionResponseInfo:  &auth.AuthenticationInfo{SessionToken: &auth.Token{JWT: "test"}},
+			ValidateSessionResponseInfo:  &auth.Token{JWT: "test"},
 			ValidateSessionResponseError: errors.NoPublicKeyError,
 		},
 	}


### PR DESCRIPTION
Should return a proper object on the SDK level
So user will not be confused and expect values that we know will always be nil

