### PR TITLE
Add more SDK logs

### DIFF
--- a/descope/auth/auth.go
+++ b/descope/auth/auth.go
@@ -178,6 +178,7 @@ func AuthenticationMiddleware(auth Authentication, onFailure func(http.ResponseW
 func (auth *authenticationService) validateSession(sessionToken string, refreshToken string, options ...Option) (bool, *Token, error) {
 	token, err := auth.validateJWT(sessionToken)
 	if sessionToken != "" && !auth.publicKeysProvider.publicKeyExists() {
+		logger.LogError("Cannot validate session, no public key available", err)
 		return false, nil, errors.NewNoPublicKeyError()
 	}
 	if err != nil {

--- a/descope/auth/jwt.go
+++ b/descope/auth/jwt.go
@@ -108,7 +108,9 @@ func (p *provider) findKey(kid string) (jwk.Key, error) {
 		if key.KeyID() == kid {
 			return key, nil
 		}
-		return nil, errors.NewNoPublicKeyError()
+		err = errors.NewNoPublicKeyError()
+		logger.LogError("Provided public key does not match required public key", err)
+		return nil, err
 	}
 
 	if err := p.requestKeys(); err != nil {
@@ -118,7 +120,9 @@ func (p *provider) findKey(kid string) (jwk.Key, error) {
 
 	key, ok := p.keySet[kid]
 	if !ok {
-		return nil, errors.NewNoPublicKeyError()
+		err := errors.NewNoPublicKeyError()
+		logger.LogError("Required public key does not exists in key set (key set size [%d])", err, len(p.keySet))
+		return nil, err
 	}
 
 	return key, nil


### PR DESCRIPTION
On cases of no public key available, so we can be smarter when this happens in tests

