### PR TITLE
extract-token-from-authorization header

### DIFF
--- a/descope/auth/auth.go
+++ b/descope/auth/auth.go
@@ -402,8 +402,10 @@ func provideTokens(r *http.Request) (string, string) {
 	// First, check the header for Bearer token
 	// Header takes precedence over cookie
 	reqToken := r.Header.Get(api.AuthorizationHeaderName)
-	if splitToken := strings.Split(reqToken, api.BearerAuthorizationPrefix); len(splitToken) == 2 {
-		sessionToken = splitToken[1]
+	if bearerToken := strings.TrimPrefix(reqToken, api.BearerAuthorizationPrefix); bearerToken != "" {
+		if splitToken := strings.Split(bearerToken, ":"); len(splitToken) == 2 {
+			sessionToken = splitToken[1]
+		}
 	}
 
 	if sessionToken == "" {

--- a/descope/auth/auth_test.go
+++ b/descope/auth/auth_test.go
@@ -255,7 +255,7 @@ func TestValidateSessionRequestHeader(t *testing.T) {
 	a, err := newTestAuth(nil, DoOk(nil))
 	require.NoError(t, err)
 	request := &http.Request{Header: http.Header{}}
-	request.Header.Add(api.AuthorizationHeaderName, api.BearerAuthorizationPrefix+jwtTokenValid)
+	request.Header.Add(api.AuthorizationHeaderName, api.BearerAuthorizationPrefix+"prorject1:"+jwtTokenValid)
 	ok, token, err := a.ValidateSessionWithOptions(request)
 	require.NoError(t, err)
 	require.True(t, ok)


### PR DESCRIPTION
## Description

we are taking the project-id from authorization header as the token

we should include authorization header to have token only if it is in form of `Bearer <project-id>:<session-token>

lmk what you think  
