### PR TITLE
Add SignUpOrIn function to Webauthn object in SDK

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -44,10 +44,11 @@ var (
 			exchangeTokenOAuth       string
 			samlStart                string
 			exchangeTokenSAML        string
-			webauthnSignupStart      string
-			webauthnSignupFinish     string
-			webauthnSigninStart      string
-			webauthnSigninFinish     string
+			webauthnSignUpStart      string
+			webauthnSignUpFinish     string
+			webauthnSignInStart      string
+			webauthnSignInFinish     string
+			webauthnSignUpOrInStart  string
 			webauthnUpdateStart      string
 			webauthnUpdateFinish     string
 			getMagicLinkSession      string
@@ -72,10 +73,11 @@ var (
 			exchangeTokenOAuth:       "auth/oauth/exchange",
 			samlStart:                "auth/saml/authorize",
 			exchangeTokenSAML:        "auth/saml/exchange",
-			webauthnSignupStart:      "auth/webauthn/signup/start",
-			webauthnSignupFinish:     "auth/webauthn/signup/finish",
-			webauthnSigninStart:      "auth/webauthn/signin/start",
-			webauthnSigninFinish:     "auth/webauthn/signin/finish",
+			webauthnSignUpStart:      "auth/webauthn/signup/start",
+			webauthnSignUpFinish:     "auth/webauthn/signup/finish",
+			webauthnSignInStart:      "auth/webauthn/signin/start",
+			webauthnSignInFinish:     "auth/webauthn/signin/finish",
+			webauthnSignUpOrInStart:  "auth/webauthn/signup-in/start",
 			webauthnUpdateStart:      "auth/webauthn/update/start",
 			webauthnUpdateFinish:     "auth/webauthn/update/finish",
 			getMagicLinkSession:      "auth/magiclink/pending-session",
@@ -110,10 +112,11 @@ type endpoints struct {
 		exchangeTokenOAuth       string
 		samlStart                string
 		exchangeTokenSAML        string
-		webauthnSignupStart      string
-		webauthnSignupFinish     string
-		webauthnSigninStart      string
-		webauthnSigninFinish     string
+		webauthnSignUpStart      string
+		webauthnSignUpFinish     string
+		webauthnSignInStart      string
+		webauthnSignInFinish     string
+		webauthnSignUpOrInStart  string
 		webauthnUpdateStart      string
 		webauthnUpdateFinish     string
 		getMagicLinkSession      string
@@ -174,17 +177,20 @@ func (e *endpoints) SAMLStart() string {
 func (e *endpoints) ExchangeTokenSAML() string {
 	return path.Join(e.version, e.auth.exchangeTokenSAML)
 }
-func (e *endpoints) WebAuthnSignupStart() string {
-	return path.Join(e.version, e.auth.webauthnSignupStart)
+func (e *endpoints) WebAuthnSignUpStart() string {
+	return path.Join(e.version, e.auth.webauthnSignUpStart)
 }
-func (e *endpoints) WebAuthnSignupFinish() string {
-	return path.Join(e.version, e.auth.webauthnSignupFinish)
+func (e *endpoints) WebAuthnSignUpFinish() string {
+	return path.Join(e.version, e.auth.webauthnSignUpFinish)
 }
-func (e *endpoints) WebAuthnSigninStart() string {
-	return path.Join(e.version, e.auth.webauthnSigninStart)
+func (e *endpoints) WebAuthnSignInStart() string {
+	return path.Join(e.version, e.auth.webauthnSignInStart)
 }
-func (e *endpoints) WebAuthnSigninFinish() string {
-	return path.Join(e.version, e.auth.webauthnSigninFinish)
+func (e *endpoints) WebAuthnSignInFinish() string {
+	return path.Join(e.version, e.auth.webauthnSignInFinish)
+}
+func (e *endpoints) WebAuthnSignUpOrInStart() string {
+	return path.Join(e.version, e.auth.webauthnSignUpOrInStart)
 }
 func (e *endpoints) WebAuthnUpdateUserDeviceStart() string {
 	return path.Join(e.version, e.auth.webauthnUpdateStart)

--- a/descope/auth/authmock.go
+++ b/descope/auth/authmock.go
@@ -95,6 +95,8 @@ type MockDescopeAuthenticationWebAuthn struct {
 	SignInWebAuthnStartResponseTransaction           *WebAuthnTransactionResponse
 	SignInWebAuthnFinishResponseError                error
 	SignInWebAuthnFinishResponseInfo                 *AuthenticationInfo
+	SignUpOrInWebAuthnStartResponseError             error
+	SignUpOrInWebAuthnStartResponseTransaction       *WebAuthnTransactionResponse
 	UpdateUserDeviceWebAuthnStartResponseError       error
 	UpdateUserDeviceWebAuthnStartResponseTransaction *WebAuthnTransactionResponse
 	UpdateUserDeviceWebAuthnFinishResponseError      error
@@ -385,6 +387,10 @@ func (m MockDescopeAuthenticationWebAuthn) SignInStart(_ string, _ string, _ *ht
 
 func (m MockDescopeAuthenticationWebAuthn) SignInFinish(_ *WebAuthnFinishRequest, _ http.ResponseWriter) (*AuthenticationInfo, error) {
 	return m.SignInWebAuthnFinishResponseInfo, m.SignInWebAuthnFinishResponseError
+}
+
+func (m MockDescopeAuthenticationWebAuthn) SignUpOrInStart(_ string, _ string) (*WebAuthnTransactionResponse, error) {
+	return m.SignUpOrInWebAuthnStartResponseTransaction, m.SignUpOrInWebAuthnStartResponseError
 }
 
 func (m MockDescopeAuthenticationWebAuthn) UpdateUserDeviceStart(_ string, _ string, _ *http.Request) (*WebAuthnTransactionResponse, error) {

--- a/descope/auth/sdk.go
+++ b/descope/auth/sdk.go
@@ -173,6 +173,15 @@ type WebAuthn interface {
 	// Use the ResponseWriter (optional) to apply the cookies to the response automatically.
 	SignInFinish(finishRequest *WebAuthnFinishRequest, w http.ResponseWriter) (*AuthenticationInfo, error)
 
+	// SignUpOrInStart - Use to start an authentication validation with webauthn, if user does not exist, a new user will be created
+	// with the given identifier. The Create field in the response object determines which browser API should be called,
+	// either navigator.credentials.create or navigator.credentials.get as well as whether to call SignUpFinish (if
+	// Create is true) or SignInFinish (if Create is false) later to finalize the operation.
+	// Origin is the origin of the URL for the web page where the webauthn operation is taking place, as returned
+	// by calling document.location.origin via javascript.
+	// returns a transaction id response on successs and error upon failure.
+	SignUpOrInStart(identifier string, origin string) (*WebAuthnTransactionResponse, error)
+
 	// UpdateUserDeviceStart - Use to start an add webauthn device process for an existing user with the given identifier.
 	// Request is needed to obtain JWT and send it to Descope, for verification.
 	// Origin is the origin of the URL for the web page where the webauthn operation is taking place, as returned

--- a/descope/auth/types.go
+++ b/descope/auth/types.go
@@ -25,6 +25,7 @@ type AuthenticationInfo struct {
 type WebAuthnTransactionResponse struct {
 	TransactionID string `json:"transactionId,omitempty"`
 	Options       string `json:"options,omitempty"`
+	Create        bool   `json:"create,omitempty"`
 }
 
 type WebAuthnFinishRequest struct {
@@ -197,6 +198,11 @@ type authenticationWebAuthnSignInRequestBody struct {
 	ExternalID   string        `json:"externalId,omitempty"`
 	Origin       string        `json:"origin"`
 	LoginOptions *LoginOptions `json:"loginOptions,omitempty"`
+}
+
+type authenticationWebAuthnSignUpOrInRequestBody struct {
+	ExternalID string `json:"externalId,omitempty"`
+	Origin     string `json:"origin"`
 }
 
 type authenticationWebAuthnAddDeviceRequestBody struct {

--- a/descope/auth/webauthn.go
+++ b/descope/auth/webauthn.go
@@ -20,7 +20,7 @@ func (auth *webAuthn) SignUpStart(identifier string, user *User, origin string) 
 	if user != nil {
 		uRes.Name = user.Name
 	}
-	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignupStart(), authenticationWebAuthnSignUpRequestBody{User: uRes, Origin: origin}, nil, "")
+	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignUpStart(), authenticationWebAuthnSignUpRequestBody{User: uRes, Origin: origin}, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func (auth *webAuthn) SignUpStart(identifier string, user *User, origin string) 
 }
 
 func (auth *webAuthn) SignUpFinish(request *WebAuthnFinishRequest, w http.ResponseWriter) (*AuthenticationInfo, error) {
-	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignupFinish(), request, nil, "")
+	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignUpFinish(), request, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (auth *webAuthn) SignInStart(identifier string, origin string, r *http.Requ
 		}
 	}
 
-	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSigninStart(), authenticationWebAuthnSignInRequestBody{ExternalID: identifier, Origin: origin, LoginOptions: loginOptions}, nil, pswd)
+	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignInStart(), authenticationWebAuthnSignInRequestBody{ExternalID: identifier, Origin: origin, LoginOptions: loginOptions}, nil, pswd)
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +63,26 @@ func (auth *webAuthn) SignInStart(identifier string, origin string, r *http.Requ
 }
 
 func (auth *webAuthn) SignInFinish(request *WebAuthnFinishRequest, w http.ResponseWriter) (*AuthenticationInfo, error) {
-	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSigninFinish(), request, nil, "")
+	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignInFinish(), request, nil, "")
 	if err != nil {
 		return nil, err
 	}
 	return auth.generateAuthenticationInfo(res, w)
+}
+
+func (auth *webAuthn) SignUpOrInStart(identifier string, origin string) (*WebAuthnTransactionResponse, error) {
+	if identifier == "" {
+		return nil, errors.NewInvalidArgumentError("identifier")
+	}
+
+	res, err := auth.client.DoPostRequest(api.Routes.WebAuthnSignUpOrInStart(), authenticationWebAuthnSignInRequestBody{ExternalID: identifier, Origin: origin}, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	webAuthnResponse := &WebAuthnTransactionResponse{}
+	err = utils.Unmarshal([]byte(res.BodyStr), webAuthnResponse)
+	return webAuthnResponse, err
 }
 
 func (auth *webAuthn) UpdateUserDeviceStart(identifier string, origin string, r *http.Request) (*WebAuthnTransactionResponse, error) {


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/817

## Related PRs
https://github.com/descope/webauthnservice/pull/219

## Description
- Add SignUpOrIn function to Webauthn object in SDK

## Must
- [X] Tests
- [X] Documentation (if applicable)
