### PR TITLE
Move management key to Config struct or environment variable

### DIFF
--- a/descope/errors/errors.go
+++ b/descope/errors/errors.go
@@ -31,7 +31,7 @@ func NewError(code, message string) *WebError {
 }
 
 func NewInvalidArgumentError(arg string) *WebError {
-	return NewError(BadRequestErrorCode, fmt.Sprintf("invalid argument %s", arg))
+	return NewError(BadRequestErrorCode, fmt.Sprintf("the '%s' argument is invalid", arg))
 }
 
 func NewUnauthorizedError() *WebError {

--- a/descope/logger/log.go
+++ b/descope/logger/log.go
@@ -48,7 +48,7 @@ func LogDebug(format string, args ...interface{}) {
 }
 
 func LogError(format string, err error, args ...interface{}) {
-	loggerInstance.doLog(LogDebugLevel, "%s [error: %s]", append([]interface{}{fmt.Sprintf(format, args...)}, err)...)
+	loggerInstance.doLog(LogInfoLevel, "%s [error: %s]", append([]interface{}{fmt.Sprintf(format, args...)}, err)...)
 }
 
 func LogInfo(format string, args ...interface{}) {

--- a/descope/mgmt/mgmt.go
+++ b/descope/mgmt/mgmt.go
@@ -2,15 +2,18 @@ package mgmt
 
 import (
 	"github.com/descope/go-sdk/descope/api"
+	"github.com/descope/go-sdk/descope/logger"
+	"github.com/descope/go-sdk/descope/utils"
 )
 
-type MgmtParams struct {
-	ProjectID string
+type ManagementParams struct {
+	ProjectID     string
+	ManagementKey string
 }
 
 type managementBase struct {
 	client *api.Client
-	conf   *MgmtParams
+	conf   *ManagementParams
 }
 
 type managementService struct {
@@ -21,7 +24,7 @@ type managementService struct {
 	sso    SSO
 }
 
-func NewManagement(conf MgmtParams, c *api.Client) *managementService {
+func NewManagement(conf ManagementParams, c *api.Client) *managementService {
 	base := managementBase{conf: &conf, client: c}
 	service := &managementService{managementBase: base}
 	service.tenant = &tenant{managementBase: base}
@@ -31,13 +34,22 @@ func NewManagement(conf MgmtParams, c *api.Client) *managementService {
 }
 
 func (mgmt *managementService) Tenant() Tenant {
+	mgmt.ensureManagementKey()
 	return mgmt.tenant
 }
 
 func (mgmt *managementService) User() User {
+	mgmt.ensureManagementKey()
 	return mgmt.user
 }
 
 func (mgmt *managementService) SSO() SSO {
+	mgmt.ensureManagementKey()
 	return mgmt.sso
+}
+
+func (mgmt *managementService) ensureManagementKey() {
+	if mgmt.conf.ManagementKey == "" {
+		logger.LogInfo("management key is missing, make sure to add it in the Config struct or the environment variable \"%s\"", utils.EnvironmentVariableManagementKey) // notest
+	}
 }

--- a/descope/mgmt/mgmt_test.go
+++ b/descope/mgmt/mgmt_test.go
@@ -9,12 +9,12 @@ func newTestMgmt(clientParams *api.ClientParams, callback mocks.Do) *managementS
 	return newTestMgmtConf(nil, clientParams, callback)
 }
 
-func newTestMgmtConf(mgmtParams *MgmtParams, clientParams *api.ClientParams, callback mocks.Do) *managementService {
+func newTestMgmtConf(mgmtParams *ManagementParams, clientParams *api.ClientParams, callback mocks.Do) *managementService {
 	if clientParams == nil {
 		clientParams = &api.ClientParams{ProjectID: "a"}
 	}
 	if mgmtParams == nil {
-		mgmtParams = &MgmtParams{ProjectID: "a"}
+		mgmtParams = &ManagementParams{ProjectID: "a", ManagementKey: "key"}
 	}
 	clientParams.DefaultClient = mocks.NewTestClient(callback)
 	return NewManagement(*mgmtParams, api.NewClient(*clientParams))

--- a/descope/mgmt/sdk.go
+++ b/descope/mgmt/sdk.go
@@ -9,7 +9,7 @@ type Tenant interface {
 	//
 	// The tenant name must be unique per project. The tenant ID is generated automatically
 	// for the tenant.
-	Create(managementKey, name string, selfProvisioningDomains []string) (id string, err error)
+	Create(name string, selfProvisioningDomains []string) (id string, err error)
 
 	// Create a new tenant with the given name and ID.
 	//
@@ -17,18 +17,18 @@ type Tenant interface {
 	// tenant. Users authenticating from these domains will be associated with this tenant.
 	//
 	// Both the name and ID must be unique per project.
-	CreateWithID(managementKey, id, name string, selfProvisioningDomains []string) error
+	CreateWithID(id, name string, selfProvisioningDomains []string) error
 
 	// Update an existing tenant's name and domains.
 	//
 	// IMPORTANT: All parameters are required and will override whatever value is currently
 	// set in the existing tenant. Use carefully.
-	Update(managementKey, id, name string, selfProvisioningDomains []string) error
+	Update(id, name string, selfProvisioningDomains []string) error
 
 	// Delete an existing tenant.
 	//
 	// IMPORTANT: This action is irreversible. Use carefully.
-	Delete(managementKey, id string) error
+	Delete(id string) error
 }
 
 // Represents a tenant association for a User. The tenant ID is required to denote
@@ -50,7 +50,7 @@ type User interface {
 	// aren't associated with a tenant, while the tenants parameter can be used
 	// to specify which tenants to associate the user with and what roles the
 	// user has in each one.
-	Create(managementKey, identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error
+	Create(identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error
 
 	// Update an existing user.
 	//
@@ -58,12 +58,12 @@ type User interface {
 	//
 	// IMPORTANT: All parameters will override whatever values are currently set
 	// in the existing user. Use carefully.
-	Update(managementKey, identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error
+	Update(identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error
 
 	// Delete an existing user.
 	//
 	// IMPORTANT: This action is irreversible. Use carefully.
-	Delete(managementKey, identifier string) error
+	Delete(identifier string) error
 }
 
 // Represents a mapping between a set of groups of users and a role that will be assigned to them.
@@ -78,18 +78,18 @@ type SSO interface {
 	//
 	// All parameters are required. The idpURL is the URL for the identity provider and idpCert
 	// is the certificated provided by the identity provider.
-	ConfigureSettings(managementKey, tenantID string, enabled bool, idpURL, idpCert, entityID, redirectURL string) error
+	ConfigureSettings(tenantID string, enabled bool, idpURL, idpCert, entityID, redirectURL string) error
 
 	// Configure SSO setting for a tenant by fetching SSO settings from an IDP metadata URL.
-	ConfigureMetadata(managementKey, tenantID string, enabled bool, idpMetadataURL string) error
+	ConfigureMetadata(tenantID string, enabled bool, idpMetadataURL string) error
 
 	// Configure SSO role mapping from the IDP groups to the Descope roles.
-	ConfigureRoleMapping(managementKey, tenantID string, roleMappings []RoleMapping) error
+	ConfigureRoleMapping(tenantID string, roleMappings []RoleMapping) error
 }
 
-// Provides various APIs for managing a Descope project programmatically. All functions
-// expect a valid management key as the first parameter. Management keys can be
-// generated in the Descope console.
+// Provides various APIs for managing a Descope project programmatically. A management key must
+// be provided in the DecopeClient configuration or by setting the DESCOPE_MANAGEMENT_KEY
+// environment variable. Management keys can be generated in the Descope console.
 type Management interface {
 	// Provides functions for managing tenants in a project.
 	Tenant() Tenant

--- a/descope/mgmt/sso.go
+++ b/descope/mgmt/sso.go
@@ -9,7 +9,7 @@ type sso struct {
 	managementBase
 }
 
-func (s *sso) ConfigureSettings(managementKey, tenantID string, enabled bool, idpURL, idpCert, entityID, redirectURL string) error {
+func (s *sso) ConfigureSettings(tenantID string, enabled bool, idpURL, idpCert, entityID, redirectURL string) error {
 	if tenantID == "" {
 		return errors.NewInvalidArgumentError("tenantID")
 	}
@@ -30,11 +30,11 @@ func (s *sso) ConfigureSettings(managementKey, tenantID string, enabled bool, id
 		"entityId":    entityID,
 		"redirectURL": redirectURL,
 	}
-	_, err := s.client.DoPostRequest(api.Routes.ManagementSSOConfigure(), req, nil, managementKey)
+	_, err := s.client.DoPostRequest(api.Routes.ManagementSSOConfigure(), req, nil, s.conf.ManagementKey)
 	return err
 }
 
-func (s *sso) ConfigureMetadata(managementKey, tenantID string, enabled bool, idpMetadataURL string) error {
+func (s *sso) ConfigureMetadata(tenantID string, enabled bool, idpMetadataURL string) error {
 	if tenantID == "" {
 		return errors.NewInvalidArgumentError("tenantID")
 	}
@@ -46,11 +46,11 @@ func (s *sso) ConfigureMetadata(managementKey, tenantID string, enabled bool, id
 		"enabled":        enabled,
 		"idpMetadataURL": idpMetadataURL,
 	}
-	_, err := s.client.DoPostRequest(api.Routes.ManagementSSOMetadata(), req, nil, managementKey)
+	_, err := s.client.DoPostRequest(api.Routes.ManagementSSOMetadata(), req, nil, s.conf.ManagementKey)
 	return err
 }
 
-func (s *sso) ConfigureRoleMapping(managementKey, tenantID string, roleMappings []RoleMapping) error {
+func (s *sso) ConfigureRoleMapping(tenantID string, roleMappings []RoleMapping) error {
 	if tenantID == "" {
 		return errors.NewInvalidArgumentError("tenantID")
 	}
@@ -65,6 +65,6 @@ func (s *sso) ConfigureRoleMapping(managementKey, tenantID string, roleMappings 
 		"tenantId":    tenantID,
 		"roleMapping": mappings,
 	}
-	_, err := s.client.DoPostRequest(api.Routes.ManagementSSORoleMapping(), req, nil, managementKey)
+	_, err := s.client.DoPostRequest(api.Routes.ManagementSSORoleMapping(), req, nil, s.conf.ManagementKey)
 	return err
 }

--- a/descope/mgmt/sso_test.go
+++ b/descope/mgmt/sso_test.go
@@ -20,19 +20,19 @@ func TestSSOConfigureSettingsSuccess(t *testing.T) {
 		require.Equal(t, "entity", req["entityId"])
 		require.Equal(t, "https://redirect", req["redirectURL"])
 	}))
-	err := mgmt.SSO().ConfigureSettings("key", "abc", true, "http://idpURL", "mycert", "entity", "https://redirect")
+	err := mgmt.SSO().ConfigureSettings("abc", true, "http://idpURL", "mycert", "entity", "https://redirect")
 	require.NoError(t, err)
 }
 
 func TestSSOConfigureSettingsError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.SSO().ConfigureSettings("key", "", true, "http://idpURL", "mycert", "entity", "")
+	err := mgmt.SSO().ConfigureSettings("", true, "http://idpURL", "mycert", "entity", "")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureSettings("key", "abc", true, "", "mycert", "entity", "")
+	err = mgmt.SSO().ConfigureSettings("abc", true, "", "mycert", "entity", "")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureSettings("key", "abc", true, "http://idpURL", "", "entity", "")
+	err = mgmt.SSO().ConfigureSettings("abc", true, "http://idpURL", "", "entity", "")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureSettings("key", "abc", true, "http://idpURL", "mycert", "", "")
+	err = mgmt.SSO().ConfigureSettings("abc", true, "http://idpURL", "mycert", "", "")
 	require.Error(t, err)
 }
 
@@ -45,15 +45,15 @@ func TestSSOConfigureMetadataSuccess(t *testing.T) {
 		require.Equal(t, true, req["enabled"])
 		require.Equal(t, "http://idpURL", req["idpMetadataURL"])
 	}))
-	err := mgmt.SSO().ConfigureMetadata("key", "abc", true, "http://idpURL")
+	err := mgmt.SSO().ConfigureMetadata("abc", true, "http://idpURL")
 	require.NoError(t, err)
 }
 
 func TestSSOConfigureMetadataError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.SSO().ConfigureMetadata("key", "", true, "http://idpURL")
+	err := mgmt.SSO().ConfigureMetadata("", true, "http://idpURL")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureMetadata("key", "abc", true, "")
+	err = mgmt.SSO().ConfigureMetadata("abc", true, "")
 	require.Error(t, err)
 }
 
@@ -78,12 +78,12 @@ func TestSSOConfigureRoleMappingSuccess(t *testing.T) {
 			}
 		}
 	}))
-	err := mgmt.SSO().ConfigureRoleMapping("key", "abc", []RoleMapping{{Groups: []string{"foo"}, Role: "x"}, {Groups: []string{"bar"}, Role: "y"}})
+	err := mgmt.SSO().ConfigureRoleMapping("abc", []RoleMapping{{Groups: []string{"foo"}, Role: "x"}, {Groups: []string{"bar"}, Role: "y"}})
 	require.NoError(t, err)
 }
 
 func TestSSOConfigureRoleMappingError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.SSO().ConfigureRoleMapping("key", "", nil)
+	err := mgmt.SSO().ConfigureRoleMapping("", nil)
 	require.Error(t, err)
 }

--- a/descope/mgmt/tenant.go
+++ b/descope/mgmt/tenant.go
@@ -10,24 +10,24 @@ type tenant struct {
 	managementBase
 }
 
-func (t *tenant) Create(managementKey, name string, selfProvisioningDomains []string) (id string, err error) {
-	return t.createWithID(managementKey, "", name, selfProvisioningDomains)
+func (t *tenant) Create(name string, selfProvisioningDomains []string) (id string, err error) {
+	return t.createWithID("", name, selfProvisioningDomains)
 }
 
-func (t *tenant) CreateWithID(managementKey, id, name string, selfProvisioningDomains []string) error {
+func (t *tenant) CreateWithID(id, name string, selfProvisioningDomains []string) error {
 	if id == "" {
 		return errors.NewInvalidArgumentError("id")
 	}
-	_, err := t.createWithID(managementKey, id, name, selfProvisioningDomains)
+	_, err := t.createWithID(id, name, selfProvisioningDomains)
 	return err
 }
 
-func (t *tenant) createWithID(managementKey, id, name string, selfProvisioningDomains []string) (string, error) {
+func (t *tenant) createWithID(id, name string, selfProvisioningDomains []string) (string, error) {
 	if name == "" {
 		return "", errors.NewInvalidArgumentError("name")
 	}
 	req := makeCreateUpdateTenantRequest(id, name, selfProvisioningDomains)
-	httpRes, err := t.client.DoPostRequest(api.Routes.ManagementTenantCreate(), req, nil, managementKey)
+	httpRes, err := t.client.DoPostRequest(api.Routes.ManagementTenantCreate(), req, nil, t.conf.ManagementKey)
 	if err != nil {
 		return "", err
 	}
@@ -40,7 +40,7 @@ func (t *tenant) createWithID(managementKey, id, name string, selfProvisioningDo
 	return res.ID, nil
 }
 
-func (t *tenant) Update(managementKey, id, name string, selfProvisioningDomains []string) error {
+func (t *tenant) Update(id, name string, selfProvisioningDomains []string) error {
 	if id == "" {
 		return errors.NewInvalidArgumentError("id")
 	}
@@ -48,16 +48,16 @@ func (t *tenant) Update(managementKey, id, name string, selfProvisioningDomains 
 		return errors.NewInvalidArgumentError("name")
 	}
 	req := makeCreateUpdateTenantRequest(id, name, selfProvisioningDomains)
-	_, err := t.client.DoPostRequest(api.Routes.ManagementTenantUpdate(), req, nil, managementKey)
+	_, err := t.client.DoPostRequest(api.Routes.ManagementTenantUpdate(), req, nil, t.conf.ManagementKey)
 	return err
 }
 
-func (t *tenant) Delete(managementKey, id string) error {
+func (t *tenant) Delete(id string) error {
 	if id == "" {
 		return errors.NewInvalidArgumentError("id")
 	}
 	req := map[string]any{"id": id}
-	_, err := t.client.DoPostRequest(api.Routes.ManagementTenantDelete(), req, nil, managementKey)
+	_, err := t.client.DoPostRequest(api.Routes.ManagementTenantDelete(), req, nil, t.conf.ManagementKey)
 	return err
 }
 

--- a/descope/mgmt/tenant_test.go
+++ b/descope/mgmt/tenant_test.go
@@ -21,14 +21,14 @@ func TestTenantCreateSuccess(t *testing.T) {
 		require.Equal(t, "foo", selfProvisioningDomains[0])
 		require.Equal(t, "bar", selfProvisioningDomains[1])
 	}, response))
-	id, err := mgmt.Tenant().Create("key", "abc", []string{"foo", "bar"})
+	id, err := mgmt.Tenant().Create("abc", []string{"foo", "bar"})
 	require.NoError(t, err)
 	require.Equal(t, "qux", id)
 }
 
 func TestTenantCreateError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	id, err := mgmt.Tenant().Create("key", "", nil)
+	id, err := mgmt.Tenant().Create("", nil)
 	require.Error(t, err)
 	require.Empty(t, id)
 }
@@ -46,15 +46,15 @@ func TestTenantCreateWithIDSuccess(t *testing.T) {
 		require.Equal(t, "foo", selfProvisioningDomains[0])
 		require.Equal(t, "bar", selfProvisioningDomains[1])
 	}, response))
-	err := mgmt.Tenant().CreateWithID("key", "123", "abc", []string{"foo", "bar"})
+	err := mgmt.Tenant().CreateWithID("123", "abc", []string{"foo", "bar"})
 	require.NoError(t, err)
 }
 
 func TestTenantCreateWithIDError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.Tenant().CreateWithID("key", "", "abc", nil)
+	err := mgmt.Tenant().CreateWithID("", "abc", nil)
 	require.Error(t, err)
-	err = mgmt.Tenant().CreateWithID("key", "123", "", nil)
+	err = mgmt.Tenant().CreateWithID("123", "", nil)
 	require.Error(t, err)
 }
 
@@ -70,15 +70,15 @@ func TestTenantUpdateSuccess(t *testing.T) {
 		require.Equal(t, "foo", selfProvisioningDomains[0])
 		require.Equal(t, "bar", selfProvisioningDomains[1])
 	}))
-	err := mgmt.Tenant().Update("key", "123", "abc", []string{"foo", "bar"})
+	err := mgmt.Tenant().Update("123", "abc", []string{"foo", "bar"})
 	require.NoError(t, err)
 }
 
 func TestTenantUpdateError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.Tenant().Update("key", "", "abc", nil)
+	err := mgmt.Tenant().Update("", "abc", nil)
 	require.Error(t, err)
-	err = mgmt.Tenant().Update("key", "123", "", nil)
+	err = mgmt.Tenant().Update("123", "", nil)
 	require.Error(t, err)
 }
 
@@ -89,12 +89,12 @@ func TestTenantDeleteSuccess(t *testing.T) {
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "abc", req["id"])
 	}))
-	err := mgmt.Tenant().Delete("key", "abc")
+	err := mgmt.Tenant().Delete("abc")
 	require.NoError(t, err)
 }
 
 func TestTenantDeleteError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.Tenant().Delete("key", "")
+	err := mgmt.Tenant().Delete("")
 	require.Error(t, err)
 }

--- a/descope/mgmt/user.go
+++ b/descope/mgmt/user.go
@@ -9,30 +9,30 @@ type user struct {
 	managementBase
 }
 
-func (u *user) Create(managementKey, identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error {
+func (u *user) Create(identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error {
 	if identifier == "" {
 		return errors.NewInvalidArgumentError("identifier")
 	}
 	req := makeCreateUpdateUserRequest(identifier, email, phone, displayName, roles, tenants)
-	_, err := u.client.DoPostRequest(api.Routes.ManagementUserCreate(), req, nil, managementKey)
+	_, err := u.client.DoPostRequest(api.Routes.ManagementUserCreate(), req, nil, u.conf.ManagementKey)
 	return err
 }
 
-func (u *user) Update(managementKey, identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error {
+func (u *user) Update(identifier, email, phone, displayName string, roles []string, tenants []UserTenants) error {
 	if identifier == "" {
 		return errors.NewInvalidArgumentError("identifier")
 	}
 	req := makeCreateUpdateUserRequest(identifier, email, phone, displayName, roles, tenants)
-	_, err := u.client.DoPostRequest(api.Routes.ManagementUserUpdate(), req, nil, managementKey)
+	_, err := u.client.DoPostRequest(api.Routes.ManagementUserUpdate(), req, nil, u.conf.ManagementKey)
 	return err
 }
 
-func (u *user) Delete(managementKey, identifier string) error {
+func (u *user) Delete(identifier string) error {
 	if identifier == "" {
 		return errors.NewInvalidArgumentError("identifier")
 	}
 	req := map[string]any{"identifier": identifier}
-	_, err := u.client.DoPostRequest(api.Routes.ManagementUserDelete(), req, nil, managementKey)
+	_, err := u.client.DoPostRequest(api.Routes.ManagementUserDelete(), req, nil, u.conf.ManagementKey)
 	return err
 }
 

--- a/descope/mgmt/user_test.go
+++ b/descope/mgmt/user_test.go
@@ -19,13 +19,13 @@ func TestUserCreateSuccess(t *testing.T) {
 		require.Len(t, roleNames, 1)
 		require.Equal(t, "foo", roleNames[0])
 	}))
-	err := mgmt.User().Create("key", "abc", "foo@bar.com", "", "", []string{"foo"}, nil)
+	err := mgmt.User().Create("abc", "foo@bar.com", "", "", []string{"foo"}, nil)
 	require.NoError(t, err)
 }
 
 func TestUserCreateError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.User().Create("key", "", "foo@bar.com", "", "", nil, nil)
+	err := mgmt.User().Create("", "foo@bar.com", "", "", nil, nil)
 	require.Error(t, err)
 }
 
@@ -51,13 +51,13 @@ func TestUserUpdateSuccess(t *testing.T) {
 			}
 		}
 	}))
-	err := mgmt.User().Update("key", "abc", "foo@bar.com", "", "", nil, []UserTenants{{TenantID: "x", Roles: []string{"foo"}}, {TenantID: "y", Roles: []string{"bar"}}})
+	err := mgmt.User().Update("abc", "foo@bar.com", "", "", nil, []UserTenants{{TenantID: "x", Roles: []string{"foo"}}, {TenantID: "y", Roles: []string{"bar"}}})
 	require.NoError(t, err)
 }
 
 func TestUserUpdateError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.User().Update("key", "", "foo@bar.com", "", "", nil, nil)
+	err := mgmt.User().Update("", "foo@bar.com", "", "", nil, nil)
 	require.Error(t, err)
 }
 
@@ -68,12 +68,12 @@ func TestUserDeleteSuccess(t *testing.T) {
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "abc", req["identifier"])
 	}))
-	err := mgmt.User().Delete("key", "abc")
+	err := mgmt.User().Delete("abc")
 	require.NoError(t, err)
 }
 
 func TestUserDeleteError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.User().Delete("key", "")
+	err := mgmt.User().Delete("")
 	require.Error(t, err)
 }

--- a/descope/utils/helpers.go
+++ b/descope/utils/helpers.go
@@ -15,10 +15,14 @@ func Unmarshal(bs []byte, obj interface{}) error {
 	return json.Unmarshal(bs, obj)
 }
 
-func GetPublicKeyEnvVariable() string {
-	return os.Getenv(EnvironmentVariablePublicKey)
-}
-
 func GetProjectIDEnvVariable() string {
 	return os.Getenv(EnvironmentVariableProjectID)
+}
+
+func GetManagementKeyEnvVariable() string {
+	return os.Getenv(EnvironmentVariableManagementKey)
+}
+
+func GetPublicKeyEnvVariable() string {
+	return os.Getenv(EnvironmentVariablePublicKey)
 }

--- a/descope/utils/types.go
+++ b/descope/utils/types.go
@@ -1,6 +1,7 @@
 package utils
 
 const (
-	EnvironmentVariablePublicKey = "DESCOPE_PUBLIC_KEY"
-	EnvironmentVariableProjectID = "DESCOPE_PROJECT_ID"
+	EnvironmentVariableProjectID     = "DESCOPE_PROJECT_ID"
+	EnvironmentVariablePublicKey     = "DESCOPE_PUBLIC_KEY"
+	EnvironmentVariableManagementKey = "DESCOPE_MANAGEMENT_KEY"
 )


### PR DESCRIPTION
## Description
Update management API so that management keys are provided during DescopeClient initialization via Config or env variable, rather than as a function parameter to every management function call.

This change seemed to make the usage of management APIs more ergonomic when I was writing sample code.

## Must
- [X] Tests
- [X] Documentation (if applicable)
