### PR TITLE
Move session JWT to auth header

### DIFF
--- a/descope/auth/enchantedlink_test.go
+++ b/descope/auth/enchantedlink_test.go
@@ -177,10 +177,13 @@ func TestGetSession(t *testing.T) {
 	info, err := a.EnchantedLink().GetSession(pendingRef, w)
 	require.NoError(t, err)
 	assert.NotEmpty(t, info.SessionToken.JWT)
-	require.Len(t, w.Result().Cookies(), 1)
-	sessionCookie := w.Result().Cookies()[0]
-	require.NoError(t, err)
-	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionCookie.Value)
+	require.Len(t, w.Result().Cookies(), 0)
+	authHeader := w.Header().Get(api.AuthorizationHeaderName)
+	require.NotEmpty(t, authHeader)
+	tokens := strings.Split(authHeader, api.BearerAuthorizationPrefix)
+	require.EqualValues(t, 2, len(tokens))
+	sessionJWT := tokens[1]
+	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionJWT)
 }
 
 func TestGetEnchantedLinkSessionError(t *testing.T) {

--- a/descope/auth/magiclink_test.go
+++ b/descope/auth/magiclink_test.go
@@ -315,10 +315,13 @@ func TestVerifyMagicLinkCodeWithSession(t *testing.T) {
 	info, err := a.MagicLink().Verify(token, w)
 	require.NoError(t, err)
 	assert.NotEmpty(t, info.SessionToken.JWT)
-	require.Len(t, w.Result().Cookies(), 1)
-	sessionCookie := w.Result().Cookies()[0]
-	require.NoError(t, err)
-	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionCookie.Value)
+	require.Len(t, w.Result().Cookies(), 0)
+	authHeader := w.Header().Get(api.AuthorizationHeaderName)
+	require.NotEmpty(t, authHeader)
+	tokens := strings.Split(authHeader, api.BearerAuthorizationPrefix)
+	require.EqualValues(t, 2, len(tokens))
+	sessionJWT := tokens[1]
+	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionJWT)
 	assert.True(t, info.FirstSeen)
 	assert.EqualValues(t, name, info.User.Name)
 	assert.EqualValues(t, phone, info.User.Phone)

--- a/descope/auth/otp_test.go
+++ b/descope/auth/otp_test.go
@@ -318,10 +318,13 @@ func TestVerifyCodeEmailResponseOption(t *testing.T) {
 	w := httptest.NewRecorder()
 	info, err := a.OTP().VerifyCode(MethodEmail, email, code, w)
 	require.NoError(t, err)
-	require.Len(t, w.Result().Cookies(), 1)
-	sessionCookie := w.Result().Cookies()[0]
-	require.NoError(t, err)
-	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionCookie.Value)
+	require.Len(t, w.Result().Cookies(), 0)
+	authHeader := w.Header().Get(api.AuthorizationHeaderName)
+	require.NotEmpty(t, authHeader)
+	tokens := strings.Split(authHeader, api.BearerAuthorizationPrefix)
+	require.EqualValues(t, 2, len(tokens))
+	sessionJWT := tokens[1]
+	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionJWT)
 	assert.True(t, info.FirstSeen)
 	assert.EqualValues(t, name, info.User.Name)
 	assert.EqualValues(t, phone, info.User.Phone)

--- a/descope/auth/webauthn_test.go
+++ b/descope/auth/webauthn_test.go
@@ -49,8 +49,13 @@ func TestSignInFinish(t *testing.T) {
 	res, err := a.WebAuthn().SignInFinish(expectedResponse, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, jwtTokenValid, res.SessionToken.JWT)
-	require.Len(t, w.Result().Cookies(), 1)
-	assert.EqualValues(t, jwtTokenValid, w.Result().Cookies()[0].Value)
+	require.Len(t, w.Result().Cookies(), 0)
+	authHeader := w.Header().Get(api.AuthorizationHeaderName)
+	require.NotEmpty(t, authHeader)
+	tokens := strings.Split(authHeader, api.BearerAuthorizationPrefix)
+	require.EqualValues(t, 2, len(tokens))
+	sessionJWT := tokens[1]
+	assert.EqualValues(t, jwtTokenValid, sessionJWT)
 }
 
 func TestSignInStart(t *testing.T) {
@@ -118,8 +123,13 @@ func TestSignUpFinish(t *testing.T) {
 	res, err := a.WebAuthn().SignUpFinish(expectedResponse, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, jwtTokenValid, res.SessionToken.JWT)
-	require.Len(t, w.Result().Cookies(), 1)
-	assert.EqualValues(t, jwtTokenValid, w.Result().Cookies()[0].Value)
+	require.Len(t, w.Result().Cookies(), 0)
+	authHeader := w.Header().Get(api.AuthorizationHeaderName)
+	require.NotEmpty(t, authHeader)
+	tokens := strings.Split(authHeader, api.BearerAuthorizationPrefix)
+	require.EqualValues(t, 2, len(tokens))
+	sessionJWT := tokens[1]
+	assert.EqualValues(t, jwtTokenValid, sessionJWT)
 }
 
 func TestSignUpOrInStart(t *testing.T) {

--- a/descope/descope.go
+++ b/descope/descope.go
@@ -33,6 +33,10 @@ type Config struct {
 	LogLevel logger.LogLevel
 	// LoggerInterface (optional, log.Default()) - set the logger instance to use for logging with the sdk.
 	Logger logger.LoggerInterface
+	// State whether session jwt should be sent to client in header or in the cookie,
+	// defaults to header, use cookie if session jwt will stay small (less than 1k)
+	// session cookie can grow bigger, in case of using authorization, or adding custom claims
+	SessionJWTViaCookie bool
 }
 
 func (c *Config) setProjectID() string {
@@ -107,7 +111,7 @@ func NewDescopeClientWithConfig(config *Config) (*DescopeClient, error) {
 
 	c := api.NewClient(api.ClientParams{BaseURL: config.DescopeBaseURL, CustomDefaultHeaders: config.CustomDefaultHeaders, DefaultClient: config.DefaultClient, ProjectID: config.ProjectID})
 
-	authService, err := auth.NewAuth(auth.AuthParams{ProjectID: config.ProjectID, PublicKey: config.PublicKey}, c)
+	authService, err := auth.NewAuth(auth.AuthParams{ProjectID: config.ProjectID, PublicKey: config.PublicKey, SessionJWTViaCookie: config.SessionJWTViaCookie}, c)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/ginwebapp/main.go
+++ b/examples/ginwebapp/main.go
@@ -36,7 +36,7 @@ func main() {
 	var err error
 	// Leave projectId param empty to get it from DESCOPE_PROJECT_ID env variable
 	projectID := ""
-	client, err = descope.NewDescopeClientWithConfig(&descope.Config{ProjectID: projectID})
+	client, err = descope.NewDescopeClientWithConfig(&descope.Config{ProjectID: projectID, SessionJWTViaCookie: true})
 	if err != nil {
 		log.Println("failed to init: " + err.Error())
 		os.Exit(1)

--- a/examples/webapp/main.go
+++ b/examples/webapp/main.go
@@ -39,7 +39,7 @@ func main() {
 	router := mux.NewRouter()
 	// Leave projectId param empty to get it from DESCOPE_PROJECT_ID env variable
 	projectID := ""
-	client, err = descope.NewDescopeClientWithConfig(&descope.Config{ProjectID: projectID})
+	client, err = descope.NewDescopeClientWithConfig(&descope.Config{ProjectID: projectID, SessionJWTViaCookie: true})
 	if err != nil {
 		log.Println("failed to init: " + err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Add option to still send it on cookie
Default to header
Samples are on cookie
Related to https://github.com/descope/etc/issues/1095

