### PR TITLE
Use loginIDs instead of externalIDs in response user

### DIFF
--- a/descope/auth/totp_test.go
+++ b/descope/auth/totp_test.go
@@ -98,7 +98,7 @@ func TestVerifyTOTP(t *testing.T) {
 		resp := &JWTResponse{
 			RefreshJwt: jwtTokenValid,
 			User: &UserResponse{
-				ExternalIDs: []string{externalID},
+				LoginIDs: []string{externalID},
 			},
 			FirstSeen: true,
 		}
@@ -111,7 +111,7 @@ func TestVerifyTOTP(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, authInfo)
 	assert.True(t, authInfo.FirstSeen)
-	assert.EqualValues(t, externalID, authInfo.User.ExternalIDs[0])
+	assert.EqualValues(t, externalID, authInfo.User.LoginIDs[0])
 }
 
 func TestVerifyTOTPLoginOptions(t *testing.T) {
@@ -136,7 +136,7 @@ func TestVerifyTOTPLoginOptions(t *testing.T) {
 		resp := &JWTResponse{
 			RefreshJwt: jwtTokenValid,
 			User: &UserResponse{
-				ExternalIDs: []string{externalID},
+				LoginIDs: []string{externalID},
 			},
 			FirstSeen: true,
 		}
@@ -149,7 +149,7 @@ func TestVerifyTOTPLoginOptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, authInfo)
 	assert.True(t, authInfo.FirstSeen)
-	assert.EqualValues(t, externalID, authInfo.User.ExternalIDs[0])
+	assert.EqualValues(t, externalID, authInfo.User.LoginIDs[0])
 }
 
 func TestVerifyTOTPFailure(t *testing.T) {

--- a/descope/auth/types.go
+++ b/descope/auth/types.go
@@ -183,7 +183,7 @@ type WebauthnUserRequest struct {
 type UserResponse struct {
 	User          `json:",inline"`
 	UserID        string              `json:"userId,omitempty"`
-	ExternalIDs   []string            `json:"externalIds,omitempty"`
+	LoginIDs      []string            `json:"loginIds,omitempty"`
 	VerifiedEmail bool                `json:"verifiedEmail,omitempty"`
 	VerifiedPhone bool                `json:"verifiedPhone,omitempty"`
 	RoleNames     []string            `json:"roleNames,omitempty"`

--- a/examples/managementcli/main.go
+++ b/examples/managementcli/main.go
@@ -39,7 +39,7 @@ func prepare() (err error) {
 		// generate a management key in the Company section of the admin console: https://app.descope.com/settings/company
 		return errors.New("the DESCOPE_MANAGEMENT_KEY environment variable must be set")
 	}
-	descopeClient, err = descope.NewDescopeClientWithConfig(&descope.Config{DescopeBaseURL: "http://localhost:8000"})
+	descopeClient, err = descope.NewDescopeClient()
 	return err
 }
 

--- a/examples/webapp/main.go
+++ b/examples/webapp/main.go
@@ -427,7 +427,7 @@ func handleStepupConfVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	helpTxt := "Great !\n"
-	helpTxt += "Now lets update our user with a phone number go to /stepup/conf/update?identifier=" + authInfo.User.ExternalIDs[0] + "&sms=<phone>"
+	helpTxt += "Now lets update our user with a phone number go to /stepup/conf/update?identifier=" + authInfo.User.LoginIDs[0] + "&sms=<phone>"
 	setResponse(w, http.StatusOK, helpTxt)
 }
 
@@ -462,7 +462,7 @@ func handleStepupConfUpdateVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	helpTxt := "Great, we have a user with 2 factors, now lets start the actual step flow !\n"
-	helpTxt += "go to /stepup/login?email=" + authInfo.User.ExternalIDs[0]
+	helpTxt += "go to /stepup/login?email=" + authInfo.User.LoginIDs[0]
 	setResponse(w, http.StatusOK, helpTxt)
 }
 
@@ -495,7 +495,7 @@ func handleStepupLoginVerify(w http.ResponseWriter, r *http.Request) {
 	helpTxt := "You have logged in !\n"
 	mr, _ := json.MarshalIndent(authInfo, "", "")
 	helpTxt += string(mr) + "\n\n"
-	helpTxt += "Now lets stepup go to /stepup/stepup?sms=" + authInfo.User.ExternalIDs[0]
+	helpTxt += "Now lets stepup go to /stepup/stepup?sms=" + authInfo.User.LoginIDs[0]
 	setResponse(w, http.StatusOK, helpTxt)
 }
 


### PR DESCRIPTION
## Description

Use loginIDs instead of externalIDs in response user

## Must
- [X] Tests
- [ ] Documentation (if applicable)
