### PR TITLE
Improve errors infra and handle api rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ for i := retriesCount; i > 0; i-- {
         // Otherwise they're available via authInfo
         break
     }
-    if err == errors.EnchantedLinkUnauthorized && i > 1 {
+    if errors.EnchantedLinkUnauthorized.Is(err) && i > 1 {
         // poll again after X seconds
         time.Sleep(time.Second * time.Duration(retryInterval))
         continue
@@ -692,7 +692,7 @@ ok, info, err := api.Auth.ValidateSession(nil, nil)
 assert.False(t, ok)
 assert.NotEmpty(t, info)
 assert.EqualValues(t, validateSessionResponse, info.JWT)
-assert.ErrorIs(t, err, errors.NoPublicKeyError)
+assert.True(t, err, errors.NoPublicKeyError.Is(err))
 
 res, err := api.Management.JWT().UpdateJWTWithCustomClaims("some jwt", nil)
 require.NoError(t, err)

--- a/descope/auth/auth.go
+++ b/descope/auth/auth.go
@@ -250,7 +250,7 @@ func (auth *authenticationService) RefreshSession(request *http.Request, w http.
 func (auth *authenticationService) ExchangeAccessKey(accessKey string) (success bool, SessionToken *Token, err error) {
 	httpResponse, err := auth.client.DoPostRequest(api.Routes.ExchangeAccessKey(), nil, &api.HTTPRequest{}, accessKey)
 	if err != nil {
-		if errors.ApiRateLimitExceeded.Is(err) {
+		if errors.APIRateLimitExceeded.Is(err) {
 			return false, nil, err
 		}
 		logger.LogError("failed to exchange access key", err)
@@ -359,7 +359,7 @@ func (auth *authenticationService) validateSession(sessionToken string, refreshT
 		// auto-refresh session token
 		httpResponse, err := auth.client.DoPostRequest(api.Routes.RefreshToken(), nil, &api.HTTPRequest{}, refreshToken)
 		if err != nil {
-			if errors.ApiRateLimitExceeded.Is(err) {
+			if errors.APIRateLimitExceeded.Is(err) {
 				return false, nil, err
 			}
 			return false, nil, errors.FailedToRefreshTokenError

--- a/descope/auth/auth_test.go
+++ b/descope/auth/auth_test.go
@@ -873,3 +873,16 @@ func TestMeNoToken(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, user)
 }
+
+func TestValidationErrorIsFunction(t *testing.T) {
+	err := errors.ApiRateLimitExceeded
+	require.False(t, errors.FailedToRefreshTokenError.Is(err))
+	fErr := errors.FailedToRefreshTokenError
+	require.True(t, errors.FailedToRefreshTokenError.Is(fErr))
+}
+
+func TestErrorStringIncludeDescriptionWhenExist(t *testing.T) {
+	err := errors.ApiRateLimitExceeded
+	err.Description = "API rate limit"
+	require.Equal(t, "[E130429] API rate limit, API rate limit exceeded", err.Error())
+}

--- a/descope/auth/auth_test.go
+++ b/descope/auth/auth_test.go
@@ -366,7 +366,7 @@ func TestValidateSessionRequestFailRefreshSessionApiRateLimitError(t *testing.T)
 	request.AddCookie(&http.Cookie{Name: SessionCookieName, Value: jwtTokenExpired})
 	ok, cookies, err := a.ValidateSession(request, nil)
 	require.Error(t, err)
-	require.True(t, errors.ApiRateLimitExceeded.Is(err))
+	require.True(t, errors.APIRateLimitExceeded.Is(err))
 	require.False(t, ok)
 	require.Empty(t, cookies)
 }
@@ -765,7 +765,7 @@ func TestExchangeAccessKeyRateLimitError(t *testing.T) {
 	require.NoError(t, err)
 
 	ok, token, err := a.ExchangeAccessKey("foo")
-	require.True(t, errors.ApiRateLimitExceeded.Is(err))
+	require.True(t, errors.APIRateLimitExceeded.Is(err))
 	require.False(t, ok)
 	require.Nil(t, token)
 }
@@ -875,14 +875,14 @@ func TestMeNoToken(t *testing.T) {
 }
 
 func TestValidationErrorIsFunction(t *testing.T) {
-	err := errors.ApiRateLimitExceeded
+	err := errors.APIRateLimitExceeded
 	require.False(t, errors.FailedToRefreshTokenError.Is(err))
 	fErr := errors.FailedToRefreshTokenError
 	require.True(t, errors.FailedToRefreshTokenError.Is(fErr))
 }
 
 func TestErrorStringIncludeDescriptionWhenExist(t *testing.T) {
-	err := errors.ApiRateLimitExceeded
+	err := errors.APIRateLimitExceeded
 	err.Description = "API rate limit"
 	require.Equal(t, "[E130429] API rate limit, API rate limit exceeded", err.Error())
 }

--- a/descope/auth/enchantedlink.go
+++ b/descope/auth/enchantedlink.go
@@ -62,7 +62,7 @@ func (auth *enchantedLink) GetSession(pendingRef string, w http.ResponseWriter) 
 	var err error
 	httpResponse, err := auth.client.DoPostRequest(composeGetSession(), newAuthenticationGetMagicLinkSessionBody(pendingRef), nil, "")
 	if err != nil {
-		if err == errors.UnauthorizedError {
+		if errors.UnauthorizedError.Is(err) {
 			return nil, errors.EnchantedLinkUnauthorized
 		}
 		return nil, err

--- a/descope/auth/enchantedlink_test.go
+++ b/descope/auth/enchantedlink_test.go
@@ -30,7 +30,7 @@ func TestSignInEnchantedLinkStepupNoJwt(t *testing.T) {
 	require.NoError(t, err)
 	_, err = a.EnchantedLink().SignIn(email, "", nil, &LoginOptions{Stepup: true})
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errors.InvalidStepupJwtError)
+	assert.True(t, errors.InvalidStepupJwtError.Is(err))
 }
 
 func TestSignInEnchantedLink(t *testing.T) {

--- a/descope/auth/magiclink_test.go
+++ b/descope/auth/magiclink_test.go
@@ -48,7 +48,7 @@ func TestSignInMagicLinkStepupNoJWT(t *testing.T) {
 	require.NoError(t, err)
 	err = a.MagicLink().SignIn(MethodEmail, email, "", nil, &LoginOptions{Stepup: true})
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errors.InvalidStepupJwtError)
+	assert.True(t, errors.InvalidStepupJwtError.Is(err))
 }
 
 func TestSignInMagicLinkEmail(t *testing.T) {
@@ -426,5 +426,5 @@ func TestUpdatePhoneMagicLinkFailures(t *testing.T) {
 	r.AddCookie(&http.Cookie{Name: "somename", Value: jwtTokenValid})
 	err = a.MagicLink().UpdateUserPhone(MethodSMS, "id", "+111111111111", "", r)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.RefreshTokenError)
+	assert.True(t, errors.RefreshTokenError.Is(err))
 }

--- a/descope/auth/oauth_test.go
+++ b/descope/auth/oauth_test.go
@@ -67,7 +67,7 @@ func TestOAuthStartForwardResponseStepupNoJWT(t *testing.T) {
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	_, err = a.OAuth().Start(provider, landingURL, nil, &LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
-	assert.ErrorIs(t, err, errors.InvalidStepupJwtError)
+	assert.True(t, errors.InvalidStepupJwtError.Is(err))
 }
 
 func TestOAuthStartInvalidForwardResponse(t *testing.T) {

--- a/descope/auth/otp_test.go
+++ b/descope/auth/otp_test.go
@@ -175,7 +175,7 @@ func TestInvalidSignInStepupNoJWT(t *testing.T) {
 	require.NoError(t, err)
 	err = a.OTP().SignIn(MethodSMS, phone, nil, &LoginOptions{Stepup: true})
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errors.InvalidStepupJwtError)
+	assert.True(t, errors.InvalidStepupJwtError.Is(err))
 }
 
 func TestEmptyEmailVerifyCodeEmail(t *testing.T) {
@@ -390,7 +390,7 @@ func TestUpdateEmailOTPFailures(t *testing.T) {
 	r.AddCookie(&http.Cookie{Name: "somename", Value: jwtTokenValid})
 	err = a.OTP().UpdateUserEmail("id", "test@test.com", r)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.RefreshTokenError)
+	assert.True(t, errors.RefreshTokenError.Is(err))
 }
 
 func TestUpdatePhoneOTP(t *testing.T) {
@@ -435,5 +435,5 @@ func TestUpdatePhoneOTPFailures(t *testing.T) {
 	r.AddCookie(&http.Cookie{Name: "somename", Value: jwtTokenValid})
 	err = a.OTP().UpdateUserPhone(MethodSMS, "id", "+11111111111", r)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.RefreshTokenError)
+	assert.True(t, errors.RefreshTokenError.Is(err))
 }

--- a/descope/auth/saml_test.go
+++ b/descope/auth/saml_test.go
@@ -65,5 +65,5 @@ func TestSAMLStartInvalidForwardResponse(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = a.SAML().Start("test", "", nil, &LoginOptions{Stepup: true}, w)
-	assert.ErrorIs(t, err, errors.InvalidStepupJwtError)
+	assert.True(t, errors.InvalidStepupJwtError.Is(err))
 }

--- a/descope/auth/webauthn_test.go
+++ b/descope/auth/webauthn_test.go
@@ -106,7 +106,7 @@ func TestSignInWebAuthnStepupNoJWT(t *testing.T) {
 	res, err := a.WebAuthn().SignInStart("a", "https://example.com", nil, &LoginOptions{Stepup: true})
 	require.Error(t, err)
 	assert.Empty(t, res)
-	assert.ErrorIs(t, err, errors.InvalidStepupJwtError)
+	assert.True(t, errors.InvalidStepupJwtError.Is(err))
 }
 
 func TestSignUpFinish(t *testing.T) {

--- a/descope/descope_test.go
+++ b/descope/descope_test.go
@@ -81,7 +81,7 @@ func TestDescopeSDKMock(t *testing.T) {
 	assert.False(t, ok)
 	assert.NotEmpty(t, info)
 	assert.EqualValues(t, validateSessionResponse, info.JWT)
-	assert.ErrorIs(t, err, errors.NoPublicKeyError)
+	assert.True(t, errors.NoPublicKeyError.Is(err))
 
 	res, err := api.Management.JWT().UpdateJWTWithCustomClaims("some jwt", nil)
 	require.NoError(t, err)

--- a/descope/errors/errors.go
+++ b/descope/errors/errors.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	BadRequestErrorCode           = "E01000"
-	ApiRateLimitExceededErrorCode = "E130429"
+	APIRateLimitExceededErrorCode = "E130429"
 )
 
 var (
@@ -19,7 +19,7 @@ var (
 	MissingRequestError        = NewValidationError("nil request provided")
 	MissingResponseWriterError = NewValidationError("nil response writer provided")
 	InvalidStepupJwtError      = NewValidationError("refresh JWT must be provided for stepup actions")
-	ApiRateLimitExceeded       = NewError(ApiRateLimitExceededErrorCode, "API rate limit exceeded")
+	APIRateLimitExceeded       = NewError(APIRateLimitExceededErrorCode, "API rate limit exceeded")
 )
 
 type WebError struct {

--- a/descope/errors/errors.go
+++ b/descope/errors/errors.go
@@ -3,7 +3,8 @@ package errors
 import "fmt"
 
 const (
-	BadRequestErrorCode = "E01000"
+	BadRequestErrorCode           = "E01000"
+	ApiRateLimitExceededErrorCode = "E130429"
 )
 
 var (
@@ -18,6 +19,7 @@ var (
 	MissingRequestError        = NewValidationError("nil request provided")
 	MissingResponseWriterError = NewValidationError("nil response writer provided")
 	InvalidStepupJwtError      = NewValidationError("refresh JWT must be provided for stepup actions")
+	ApiRateLimitExceeded       = NewError(ApiRateLimitExceededErrorCode, "API rate limit exceeded")
 )
 
 type WebError struct {
@@ -43,7 +45,19 @@ func NewNoPublicKeyError() *PublicKeyValidationError {
 }
 
 func (e *WebError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("[%s] %s, %s", e.Code, e.Description, e.Message)
+	}
 	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+}
+
+func (e *WebError) Is(err error) bool {
+	if wErr, ok := err.(*WebError); ok {
+		if wErr.Code == e.Code {
+			return true
+		}
+	}
+	return false
 }
 
 type PublicKeyValidationError struct {
@@ -58,12 +72,30 @@ func (e *PublicKeyValidationError) Error() string {
 	return e.Message
 }
 
+func (e *PublicKeyValidationError) Is(err error) bool {
+	if vErr, ok := err.(*PublicKeyValidationError); ok {
+		if vErr.Message == e.Message {
+			return true
+		}
+	}
+	return false
+}
+
 type ValidationError struct {
 	Message string `json:"message,omitempty"`
 }
 
 func (e *ValidationError) Error() string {
 	return e.Message
+}
+
+func (e *ValidationError) Is(err error) bool {
+	if vErr, ok := err.(*ValidationError); ok {
+		if vErr.Message == e.Message {
+			return true
+		}
+	}
+	return false
 }
 
 func NewValidationError(message string, args ...interface{}) *ValidationError {


### PR DESCRIPTION
## Description
Improve errors infrastructure so all error types will have "Is" function so they can be compare easily and optimized,
Handle API Rate limit error so this is the error that will back instead of the generic error (like "Failed to refresh token")

## Must
- [ X] Tests
- [ X] Documentation (if applicable)
