### PR TITLE
Split session refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,12 +282,24 @@ The session and refresh JWTs should be returned to the caller, and passed with e
 ### Session Validation
 
 Every secure request performed between your client and server needs to be validated. The client sends
-the session and refresh tokens with every request, and they are validated using:
+the session and refresh tokens with every request, and they are validated using one of the following:
 
 When using cookies you can call:
 
 ```go
-if authorized, sessionToken, err := descopeClient.Auth.ValidateSession(r, w); !authorized {
+// Validate the session. Will return an error if expired
+if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionWithRequest(r, w); !authorized {
+    // unauthorized error
+}
+
+// If ValidateSessionWithRequest raises an exception, you will need to refresh the session using
+if authorized, sessionToken, err := descopeClient.Auth.RefreshSessionWithRequest(r, w); !authorized {
+    // unauthorized error
+}
+
+// Alternatively, you could combine the two and
+// have the session validated and automatically refreshed when expired
+if authorized, sessionToken, err := descopeClient.Auth.ValidateAndRefreshSessionWithRequest(r, w); !authorized {
     // unauthorized error
 }
 ```
@@ -295,16 +307,27 @@ if authorized, sessionToken, err := descopeClient.Auth.ValidateSession(r, w); !a
 Alternatively, tokens can be validated directly:
 
 ```go
-if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionTokens(sessionToken, refreshToken); !authorized {
+// Validate the session. Will return an error if expired
+if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionWithToken(sessionToken); !authorized {
+    // unauthorized error
+}
+
+// If ValidateSessionWithRequest raises an exception, you will need to refresh the session using
+if authorized, sessionToken, err := descopeClient.Auth.RefreshSessionWithToken(refreshToken); !authorized {
+    // unauthorized error
+}
+
+// Alternatively, you could combine the two and
+// have the session validated and automatically refreshed when expired
+if authorized, sessionToken, err := descopeClient.Auth.ValidateAndRefreshSessionWithTokens(sessionToken, refreshToken); !authorized {
     // unauthorized error
 }
 ```
 
-These function will validate the session and also refresh it in the event it has expired.
-It returns the given session token if it's still valid, or a new one if it was refreshed.
-Make sure to return the session token from the response to the client if tokens are validated directly.
+Choose the right session validation and refresh combination that suits your needs.
 
-The `refreshToken` is optional here to validate a session, but is required to refresh the session in the event it has expired.
+Refreshed sessions return the same response as is returned when users first sign up / log in,
+Make sure to return the session token from the response to the client if tokens are validated directly.
 
 Usually, the tokens can be passed in and out via HTTP headers or via a cookie.
 The implementation can defer according to your implementation. See our [examples](#code-examples) for a few examples.

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ api := DescopeClient{
         },
     },
 }
-ok, info, err := api.Auth.ValidateSession(nil, nil)
+ok, info, err := api.Auth.ValidateAndRefreshSessionWithRequest(nil, nil)
 assert.False(t, ok)
 assert.NotEmpty(t, info)
 assert.EqualValues(t, validateSessionResponse, info.JWT)

--- a/descope/client/client.go
+++ b/descope/client/client.go
@@ -51,7 +51,7 @@ func NewWithConfig(config *Config) (*DescopeClient, error) {
 
 	c := api.NewClient(api.ClientParams{BaseURL: config.DescopeBaseURL, CustomDefaultHeaders: config.CustomDefaultHeaders, DefaultClient: config.DefaultClient, ProjectID: config.ProjectID})
 
-	authService, err := auth.NewAuth(auth.AuthParams{ProjectID: config.ProjectID, PublicKey: config.PublicKey, SessionJWTViaCookie: config.SessionJWTViaCookie}, c)
+	authService, err := auth.NewAuth(auth.AuthParams{ProjectID: config.ProjectID, PublicKey: config.PublicKey, SessionJWTViaCookie: config.SessionJWTViaCookie, CookieDomain: config.SessionJWTCookieDomain}, c)
 	if err != nil {
 		return nil, err
 	}

--- a/descope/client/client_test.go
+++ b/descope/client/client_test.go
@@ -60,9 +60,9 @@ func TestDescopeSDKMock(t *testing.T) {
 	api := DescopeClient{
 		Auth: &mocksauth.MockAuthentication{
 			MockSession: mocksauth.MockSession{
-				ValidateSessionResponseFailure: true,
-				ValidateSessionResponse:        &descope.Token{JWT: validateSessionResponse},
-				ValidateSessionError:           descope.ErrPublicKey,
+				ValidateAndRefreshSessionResponseFailure: true,
+				ValidateAndRefreshSessionResponse:        &descope.Token{JWT: validateSessionResponse},
+				ValidateAndRefreshSessionError:           descope.ErrPublicKey,
 			},
 		},
 		Management: &mocksmgmt.MockManagement{
@@ -75,7 +75,7 @@ func TestDescopeSDKMock(t *testing.T) {
 			},
 		},
 	}
-	ok, info, err := api.Auth.ValidateSession(nil, nil)
+	ok, info, err := api.Auth.ValidateAndRefreshSessionWithRequest(nil, nil)
 	assert.False(t, ok)
 	assert.NotEmpty(t, info)
 	assert.EqualValues(t, validateSessionResponse, info.JWT)

--- a/descope/client/config.go
+++ b/descope/client/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	// defaults to leaving it for calling function, use cookie if session jwt will stay small (less than 1k)
 	// session cookie can grow bigger, in case of using authorization, or adding custom claims
 	SessionJWTViaCookie bool
+	// When using cookies, set the cookie domain here. Alternatively this can be done via the Descope console.
+	SessionJWTCookieDomain string
 }
 
 func (c *Config) setProjectID() string {

--- a/descope/gin/api.go
+++ b/descope/gin/api.go
@@ -10,7 +10,7 @@ import (
 
 func AuthenticationMiddleware(auth sdk.Authentication, onFailure func(*gin.Context, error), onSuccess func(*gin.Context, *descope.Token)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if ok, token, err := auth.ValidateSession(c.Request, c.Writer); ok {
+		if ok, token, err := auth.ValidateAndRefreshSessionWithRequest(c.Request, c.Writer); ok {
 			if onSuccess != nil {
 				onSuccess(c, token)
 			} else {

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -452,7 +452,7 @@ func TestValidateSessionRequestHeader(t *testing.T) {
 }
 
 func TestValidateSessionRequestRefreshSession(t *testing.T) {
-	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+	a, err := newTestAuthConf(&AuthParams{ProjectID: "a", PublicKey: publicKey, CookieDomain: "cookiedomain.com"}, nil, func(r *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(mockAuthSessionBody))}, nil
 	})
 	a.conf.SessionJWTViaCookie = true
@@ -469,6 +469,9 @@ func TestValidateSessionRequestRefreshSession(t *testing.T) {
 	require.Len(t, b.Result().Cookies(), 2)
 	sessionCookie := b.Result().Cookies()[0]
 	require.NoError(t, err)
+	assert.Equal(t, "cookiedomain.com", sessionCookie.Domain)
+	// Change domain so we can easily compare the rest of the values
+	sessionCookie.Domain = mockAuthSessionCookie.Domain
 	assert.EqualValues(t, mockAuthSessionCookie.Value, sessionCookie.Value)
 }
 

--- a/descope/sdk/middleware.go
+++ b/descope/sdk/middleware.go
@@ -15,7 +15,7 @@ import (
 func AuthenticationMiddleware(auth Authentication, onFailure func(http.ResponseWriter, *http.Request, error), onSuccess func(http.ResponseWriter, *http.Request, http.Handler, *descope.Token)) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if ok, token, err := auth.ValidateSession(r, w); ok {
+			if ok, token, err := auth.ValidateAndRefreshSessionWithRequest(r, w); ok {
 				if onSuccess != nil {
 					onSuccess(w, r, next, token)
 				} else {


### PR DESCRIPTION
## Description

**_BREAKING CHANGES_**

Session validation and refresh have been split in order to allow more control over session management. 3 new functions have been added with 2 variations each (a total of 6) with a more predictable and straightforward behavior:

- `ValidateSessionWithRequest` - only validates the session - searches for session token in the request
- `ValidateSessionWithToken` - only validates the session - receives token as input
- `RefreshSessionWithRequest` - refreshes a session - searches for session token in the request
- `RefreshSessionWithToken` - refreshes a session - receives token as input
- `ValidateAndRefreshSessionWithRequest` - combines the two, validate and refresh as needed - searches for tokens in the request
- `ValidateAndRefreshSessionWithTokens` - combines the two, validate and refresh as needed - receives tokens as input

These function replace the following which have been removed:
- `ValidateSession`: replaced by `ValidateAndRefreshSessionWithRequest` with the change of requiring both tokens
- `ValidateSessionTokens`: replaced by `ValidateAndRefreshSessionWithTokens` with the change of requiring both tokens
- `RefreshSession`: replace by `RefreshSessionWithRequest`, behavior remains with more consistent naming and input validation. Also added `RefreshSessionWithToken` as a variant.

**_NON-BREAKING CHANGES_**

- Cookie domain can now be set via the Descope client config. This will take precedence over the domain configured in the Descope console.

## Must

- [X] Tests
- [X] Documentation (if applicable)
