### PR TITLE
Set session refresh expiration even when validating

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Alternatively, tokens can be validated directly:
 
 ```go
 // Validate the session. Will return an error if expired
-if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionWithToken(sessionToken); !authorized {
+if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionWithToken(sessionToken, refreshToken); !authorized {
     // unauthorized error
 }
 

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -208,9 +208,10 @@ type Authentication interface {
 
 	// ValidateSessionWithToken - Use to validate a session token directly.
 	// Should be called before any private API call that requires authorization.
+	// RefreshToken here is optional, and will only be used to update the session token metadata.
 	// Alternatively use ValidateSessionWithRequest with the incoming request.
 	// returns true upon success or false, the session token and an error upon failure.
-	ValidateSessionWithToken(sessionToken string) (bool, *descope.Token, error)
+	ValidateSessionWithToken(sessionToken, refreshToken string) (bool, *descope.Token, error)
 
 	// ValidateSessionWithRequest - Use to refresh an expired session of a given request.
 	// Should be called when a session has expired (failed validation) to renew it.

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -435,7 +435,7 @@ type MockSession struct {
 	ValidateSessionResponse        *descope.Token
 	ValidateSessionResponseFailure bool
 
-	ValidateSessionTokenAssert          func(sessionToken string)
+	ValidateSessionTokenAssert          func(sessionToken, refreshToken string)
 	ValidateSessionTokenError           error
 	ValidateSessionTokenResponse        *descope.Token
 	ValidateSessionTokenResponseFailure bool
@@ -483,9 +483,9 @@ func (m *MockSession) ValidateSessionWithRequest(r *http.Request) (bool, *descop
 	return !m.ValidateSessionResponseFailure, m.ValidateSessionResponse, m.ValidateSessionError
 }
 
-func (m *MockSession) ValidateSessionWithToken(sessionToken string) (bool, *descope.Token, error) {
+func (m *MockSession) ValidateSessionWithToken(sessionToken, refreshToken string) (bool, *descope.Token, error) {
 	if m.ValidateSessionTokenAssert != nil {
-		m.ValidateSessionTokenAssert(sessionToken)
+		m.ValidateSessionTokenAssert(sessionToken, refreshToken)
 	}
 	return !m.ValidateSessionTokenResponseFailure, m.ValidateSessionTokenResponse, m.ValidateSessionTokenError
 }


### PR DESCRIPTION
## Description
Session validation will accept an option refresh token and use it to update the refresh expiration on the session token.

## Must
- [X] Tests
- [X] Documentation (if applicable)
