### PR TITLE
Support single token in validate and refresh

### DIFF
--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -290,34 +290,26 @@ func (auth *authenticationService) ValidateAndRefreshSessionWithRequest(request 
 		return false, nil, utils.NewInvalidArgumentError("request")
 	}
 	sessionToken, refreshToken := provideTokens(request)
-	if sessionToken == "" && refreshToken == "" {
-		return false, nil, descope.ErrMissingArguments.WithMessage("Request doesn't contain any tokens")
-	}
-	if refreshToken == "" {
-		return false, nil, descope.ErrMissingArguments.WithMessage("Request doesn't contain refresh token")
-	}
 	return auth.validateAndRefreshSessionWithTokens(sessionToken, refreshToken, w)
 }
 
 func (auth *authenticationService) ValidateAndRefreshSessionWithTokens(sessionToken, refreshToken string) (bool, *descope.Token, error) {
-	if sessionToken == "" && refreshToken == "" {
-		return false, nil, descope.ErrMissingArguments.WithMessage("Both sessionToken and refreshToken are empty")
-	}
-	if refreshToken == "" {
-		return false, nil, utils.NewInvalidArgumentError("refreshToken")
-	}
 	return auth.validateAndRefreshSessionWithTokens(sessionToken, refreshToken, nil)
 }
 
 func (auth *authenticationService) validateAndRefreshSessionWithTokens(sessionToken, refreshToken string, w http.ResponseWriter) (valid bool, token *descope.Token, err error) {
-	// Validate & refresh defaults to "refresh only" when not given a session token
+	if sessionToken == "" && refreshToken == "" {
+		return false, nil, descope.ErrMissingArguments.WithMessage("Both sessionToken and refreshToken are empty")
+	}
 	if sessionToken != "" {
 		if valid, token, err = auth.validateSession(sessionToken); valid {
 			return
 		}
 	}
-	if valid, token, err = auth.refreshSession(refreshToken, w); valid {
-		return
+	if refreshToken != "" {
+		if valid, token, err = auth.refreshSession(refreshToken, w); valid {
+			return
+		}
 	}
 	return false, nil, err
 }

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -336,6 +336,13 @@ func TestValidateAndRefreshSessionWithRequest(t *testing.T) {
 	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
+
+	// Refresh missing
+	request = &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.SessionCookieName, Value: jwtTokenValid})
+	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestValidateAndRefreshSessionWithRequestInvalidInput(t *testing.T) {
@@ -345,13 +352,6 @@ func TestValidateAndRefreshSessionWithRequestInvalidInput(t *testing.T) {
 	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.False(t, ok)
 	ok, _, err = a.ValidateAndRefreshSessionWithRequest(&http.Request{Header: http.Header{}}, nil)
-	require.ErrorIs(t, err, descope.ErrMissingArguments)
-	require.False(t, ok)
-
-	// test only session
-	request := &http.Request{Header: http.Header{}}
-	request.AddCookie(&http.Cookie{Name: descope.SessionCookieName, Value: jwtTokenValid})
-	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
 	require.ErrorIs(t, err, descope.ErrMissingArguments)
 	require.False(t, ok)
 }
@@ -368,6 +368,9 @@ func TestValidateAndRefreshSessionWithToken(t *testing.T) {
 	ok, _, err = a.ValidateAndRefreshSessionWithTokens("", jwtRTokenValid)
 	require.NoError(t, err)
 	require.True(t, ok)
+	ok, _, err = a.ValidateAndRefreshSessionWithTokens(jwtTokenValid, "")
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestValidateAndRefreshSessionWithTokenInvalidInput(t *testing.T) {
@@ -375,9 +378,6 @@ func TestValidateAndRefreshSessionWithTokenInvalidInput(t *testing.T) {
 	require.NoError(t, err)
 	ok, _, err := a.ValidateAndRefreshSessionWithTokens("", "")
 	require.ErrorIs(t, err, descope.ErrMissingArguments)
-	require.False(t, ok)
-	ok, _, err = a.ValidateAndRefreshSessionWithTokens(jwtTokenValid, "")
-	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.False(t, ok)
 }
 

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -314,10 +314,26 @@ func TestRefreshSessionWithTokenExpired(t *testing.T) {
 func TestValidateAndRefreshSessionWithRequest(t *testing.T) {
 	a, err := newTestAuth(nil, DoOk(nil))
 	require.NoError(t, err)
+	// Both tokens ok
 	request := &http.Request{Header: http.Header{}}
 	request.AddCookie(&http.Cookie{Name: descope.SessionCookieName, Value: jwtTokenValid})
 	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
 	ok, _, err := a.ValidateAndRefreshSessionWithRequest(request, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Session expired
+	request = &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.SessionCookieName, Value: jwtTokenExpired})
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
+	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Session missing
+	request = &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
+	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -338,13 +354,6 @@ func TestValidateAndRefreshSessionWithRequestInvalidInput(t *testing.T) {
 	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
 	require.ErrorIs(t, err, descope.ErrMissingArguments)
 	require.False(t, ok)
-
-	// test only refresh
-	request = &http.Request{Header: http.Header{}}
-	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
-	ok, _, err = a.ValidateAndRefreshSessionWithRequest(request, nil)
-	require.ErrorIs(t, err, descope.ErrMissingArguments)
-	require.False(t, ok)
 }
 
 func TestValidateAndRefreshSessionWithToken(t *testing.T) {
@@ -356,18 +365,18 @@ func TestValidateAndRefreshSessionWithToken(t *testing.T) {
 	ok, _, err = a.ValidateAndRefreshSessionWithTokens(jwtTokenExpired, jwtRTokenValid)
 	require.NoError(t, err)
 	require.True(t, ok)
+	ok, _, err = a.ValidateAndRefreshSessionWithTokens("", jwtRTokenValid)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestValidateAndRefreshSessionWithTokenInvalidInput(t *testing.T) {
 	a, err := newTestAuth(nil, DoOk(nil))
 	require.NoError(t, err)
 	ok, _, err := a.ValidateAndRefreshSessionWithTokens("", "")
-	require.ErrorIs(t, err, descope.ErrInvalidArguments)
+	require.ErrorIs(t, err, descope.ErrMissingArguments)
 	require.False(t, ok)
 	ok, _, err = a.ValidateAndRefreshSessionWithTokens(jwtTokenValid, "")
-	require.ErrorIs(t, err, descope.ErrInvalidArguments)
-	require.False(t, ok)
-	ok, _, err = a.ValidateAndRefreshSessionWithTokens("", jwtRTokenValid)
 	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.False(t, ok)
 }


### PR DESCRIPTION
## Description
Both "validate and refresh" functions support a single token behavior:
- If only the `sessionToken` is provided - default to a "validate only" behavior
- If only the `refreshToken` is provided - default to a "refresh only" behavior

## Must
- [X] Tests
- [X] Documentation (if applicable)
