### PR TITLE
Init log once

### DIFF
--- a/descope/client/config.go
+++ b/descope/client/config.go
@@ -25,8 +25,10 @@ type Config struct {
 	// CustomDefaultHeaders (optional, nil) - add custom headers to all requests used to communicate with descope services.
 	CustomDefaultHeaders map[string]string
 	// LogLevel (optional, LogNone) - set a log level (Debug/Info/None) for the sdk to use when logging.
+	// Note that this attribute will be used to init a global logger once, in a goroutine safe manner
 	LogLevel logger.LogLevel
 	// LoggerInterface (optional, log.Default()) - set the logger instance to use for logging with the sdk.
+	// Note that this attribute will be used to init a global logger once, in a goroutine safe manner
 	Logger logger.LoggerInterface
 	// State whether session jwt should be sent to client in cookie or let the calling function handle the transfer of the jwt,
 	// defaults to leaving it for calling function, use cookie if session jwt will stay small (less than 1k)

--- a/descope/types.go
+++ b/descope/types.go
@@ -97,7 +97,7 @@ func (to *Token) AuthFactors() []AuthFactor {
 				if ok {
 					afs = append(afs, AuthFactor(af))
 				} else {
-					logger.LogInfo("Unkown authfactor type [%T]", factorsArr[i]) //notest
+					logger.LogInfo("Unknown auth-factor type [%T]", factorsArr[i]) //notest
 				}
 			}
 		} else {


### PR DESCRIPTION
## Description
### Context
When two instance of Descope client are managed in a concurrent  manner, they may create a race condition where one may use the `instanceLogger`, and the other may override it

### Proposed solution
init logger once

### Alternative solution
Another approach may be to put a dedicate logger per client
![image](https://user-images.githubusercontent.com/10514677/217898157-69efd858-180c-470e-aef0-dbcbe4b2d183.png)

but then this logger will not be available outside the scope of this client, in places like
 - `Token` methods
 - `AuthenticationMiddleware` (where the client is passed as an argument with as `Authentication` interface, which not exposes the logging method)  
 
 I think that this is a good solution for now, that can be later enhanced according to specific use cases
