### PR TITLE
Logging and error capitalisation alignment

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -648,10 +648,10 @@ func (c *Client) DoRequest(method, uriPath string, body io.Reader, options *HTTP
 	req.Header.Set(AuthorizationHeaderName, BearerAuthorizationPrefix+bearer)
 	c.addDescopeHeaders(req)
 
-	logger.LogDebug("sending request to [%s]", url)
+	logger.LogDebug("Sending request to [%s]", url)
 	response, err := c.httpClient.Do(req)
 	if err != nil {
-		logger.LogError("failed sending request to [%s]", err, url)
+		logger.LogError("Failed sending request to [%s]", err, url)
 		return nil, err
 	}
 
@@ -660,19 +660,19 @@ func (c *Client) DoRequest(method, uriPath string, body io.Reader, options *HTTP
 	}
 	if !isResponseOK(response) {
 		err = c.parseDescopeError(response).WithInfo(descope.ErrorInfoKeys.HTTPResponseStatusCode, response.StatusCode)
-		logger.LogInfo("failed sending request to [%s], error: [%s]", url, err)
+		logger.LogInfo("Failed sending request to [%s], error: [%s]", url, err)
 		return nil, err
 	}
 
 	resBytes, err := c.parseBody(response)
 	if err != nil { // notest
-		logger.LogError("failed processing body from request to [%s]", err, url)
+		logger.LogError("Failed processing body from request to [%s]", err, url)
 		return nil, descope.ErrInvalidResponse
 	}
 
 	if options.ResBodyObj != nil {
 		if err = utils.Unmarshal(resBytes, &options.ResBodyObj); err != nil {
-			logger.LogError("failed parsing body from request to [%s]", err, url)
+			logger.LogError("Failed parsing body from request to [%s]", err, url)
 			return nil, descope.ErrInvalidResponse
 		}
 	}
@@ -697,13 +697,13 @@ func (c *Client) parseBody(response *http.Response) (resBytes []byte, err error)
 func (c *Client) parseDescopeError(response *http.Response) *descope.Error {
 	body, err := c.parseBody(response)
 	if err != nil { // notest
-		logger.LogError("failed to process error from server response", err)
+		logger.LogError("Failed to process error from server response", err)
 		return descope.ErrInvalidResponse
 	}
 
 	var descopeErr *descope.Error
 	if err := json.Unmarshal(body, &descopeErr); err != nil || descopeErr.Code == "" {
-		logger.LogError("failed to parse error from server response", err)
+		logger.LogError("Failed to parse error from server response", err)
 		return descope.ErrInvalidResponse
 	}
 

--- a/descope/client/client.go
+++ b/descope/client/client.go
@@ -42,10 +42,10 @@ func NewWithConfig(config *Config) (*DescopeClient, error) {
 	logger.Init(config.LogLevel, config.Logger)
 
 	if strings.TrimSpace(config.setProjectID()) == "" {
-		return nil, descope.ErrMissingProjectID.WithMessage("project id is missing, make sure to add it in the Config struct or the environment variable \"%s\"", descope.EnvironmentVariableProjectID)
+		return nil, descope.ErrMissingProjectID.WithMessage("Project ID is missing, make sure to add it in the Config struct or the environment variable \"%s\"", descope.EnvironmentVariableProjectID)
 	}
 	if config.setPublicKey() != "" {
-		logger.LogInfo("provided public key is set, forcing only provided public key validation")
+		logger.LogInfo("Provided public key is set, forcing only provided public key validation")
 	}
 	config.setManagementKey()
 

--- a/descope/client/client_test.go
+++ b/descope/client/client_test.go
@@ -61,7 +61,7 @@ func TestConcurrentClients(t *testing.T) {
 func TestEmptyProjectID(t *testing.T) {
 	_, err := New()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "project id is missing")
+	assert.Contains(t, err.Error(), "Project ID is missing")
 }
 
 func TestEmptyConfig(t *testing.T) {

--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -92,13 +92,13 @@ func (auth *authenticationService) Logout(request *http.Request, w http.Response
 
 	_, refreshToken := provideTokens(request)
 	if refreshToken == "" {
-		logger.LogDebug("unable to find tokens from cookies")
+		logger.LogDebug("Unable to find tokens from cookies")
 		return descope.ErrRefreshToken.WithMessage("Unable to find tokens from cookies")
 	}
 
 	_, err := auth.validateJWT(refreshToken)
 	if err != nil {
-		logger.LogDebug("invalid refresh token")
+		logger.LogDebug("Invalid refresh token")
 		return descope.ErrRefreshToken.WithMessage("Invalid refresh token")
 	}
 
@@ -145,13 +145,13 @@ func (auth *authenticationService) LogoutAll(request *http.Request, w http.Respo
 
 	_, refreshToken := provideTokens(request)
 	if refreshToken == "" {
-		logger.LogDebug("unable to find tokens from cookies")
+		logger.LogDebug("Unable to find tokens from cookies")
 		return descope.ErrRefreshToken.WithMessage("Unable to find tokens from cookies")
 	}
 
 	_, err := auth.validateJWT(refreshToken)
 	if err != nil {
-		logger.LogDebug("invalid refresh token")
+		logger.LogDebug("Invalid refresh token")
 		return descope.ErrRefreshToken.WithMessage("Invalid refresh token")
 	}
 
@@ -198,13 +198,13 @@ func (auth *authenticationService) Me(request *http.Request) (*descope.UserRespo
 
 	_, refreshToken := provideTokens(request)
 	if refreshToken == "" {
-		logger.LogDebug("unable to find tokens from cookies")
+		logger.LogDebug("Unable to find tokens from cookies")
 		return nil, descope.ErrRefreshToken.WithMessage("Unable to find tokens from cookies")
 	}
 
 	_, err := auth.validateJWT(refreshToken)
 	if err != nil {
-		logger.LogDebug("invalid refresh token")
+		logger.LogDebug("Invalid refresh token")
 		return nil, descope.ErrRefreshToken.WithMessage("Invalid refresh token")
 	}
 
@@ -317,7 +317,7 @@ func (auth *authenticationService) validateAndRefreshSessionWithTokens(sessionTo
 func (auth *authenticationService) ExchangeAccessKey(accessKey string) (success bool, SessionToken *descope.Token, err error) {
 	httpResponse, err := auth.client.DoPostRequest(api.Routes.ExchangeAccessKey(), nil, &api.HTTPRequest{}, accessKey)
 	if err != nil {
-		logger.LogError("failed to exchange access key", err)
+		logger.LogError("Failed to exchange access key", err)
 		return false, nil, err
 	}
 
@@ -369,7 +369,7 @@ func (auth *authenticationsBase) extractJWTResponse(bodyStr string) (*descope.JW
 	jRes := descope.JWTResponse{}
 	err := utils.Unmarshal([]byte(bodyStr), &jRes)
 	if err != nil {
-		logger.LogError("unable to parse jwt response", err)
+		logger.LogError("Unable to parse jwt response", err)
 		return nil, err
 	}
 	return &jRes, nil
@@ -382,7 +382,7 @@ func (auth *authenticationsBase) extractUserResponse(bodyStr string) (*descope.U
 	res := descope.UserResponse{}
 	err := utils.Unmarshal([]byte(bodyStr), &res)
 	if err != nil {
-		logger.LogError("unable to parse user response", err)
+		logger.LogError("Unable to parse user response", err)
 		return nil, err
 	}
 	return &res, nil
@@ -518,7 +518,7 @@ func (auth *authenticationsBase) generateAuthenticationInfoWithRefreshToken(http
 	}
 	tokens, err := auth.extractTokens(jwtResponse)
 	if err != nil {
-		logger.LogError("unable to extract tokens from request [%s]", err, httpResponse.Req.URL)
+		logger.LogError("Unable to extract tokens from request [%s]", err, httpResponse.Req.URL)
 		return nil, err
 	}
 
@@ -548,7 +548,7 @@ func (auth *authenticationsBase) generateAuthenticationInfoWithRefreshToken(http
 			if cookies[i].Name == descope.RefreshCookieName {
 				refreshToken, err = auth.validateJWT(cookies[i].Value)
 				if err != nil {
-					logger.LogDebug("validation of refresh token failed: %s", err.Error())
+					logger.LogDebug("Validation of refresh token failed: %s", err.Error())
 					return nil, err
 				}
 			}
@@ -562,7 +562,7 @@ func (auth *authenticationsBase) generateAuthenticationInfoWithRefreshToken(http
 func getValidRefreshToken(r *http.Request) (string, error) {
 	_, refreshToken := provideTokens(r)
 	if refreshToken == "" {
-		logger.LogDebug("unable to find tokens from cookies")
+		logger.LogDebug("Unable to find tokens from cookies")
 		return "", descope.ErrRefreshToken.WithMessage("Unable to find tokens from cookies")
 	}
 	return refreshToken, nil
@@ -667,7 +667,7 @@ func getAuthorizationClaimItems(token *descope.Token, tenant string, claim strin
 
 	// warn if it seems like programmer forgot the tenant ID
 	if len(items) == 0 && tenant == "" && len(token.GetTenants()) != 0 {
-		logger.LogDebug("no authorization items found but tenant might need to be specified")
+		logger.LogDebug("No authorization items found but tenant might need to be specified")
 	}
 
 	return items
@@ -676,7 +676,7 @@ func getAuthorizationClaimItems(token *descope.Token, tenant string, claim strin
 func getPendingRefFromResponse(httpResponse *api.HTTPResponse) (*descope.EnchantedLinkResponse, error) {
 	var response *descope.EnchantedLinkResponse
 	if err := utils.Unmarshal([]byte(httpResponse.BodyStr), &response); err != nil {
-		logger.LogError("failed to load pending reference from response", err)
+		logger.LogError("Failed to load pending reference from response", err)
 		return response, descope.ErrUnexpectedResponse.WithMessage("Failed to load pending reference")
 	}
 	return response, nil

--- a/descope/internal/auth/jwt.go
+++ b/descope/internal/auth/jwt.go
@@ -78,7 +78,7 @@ func (p *provider) requestKeys() error {
 		tempKeySet[pk.KeyID()] = pk
 	}
 
-	logger.LogDebug("refresh keys set with %d key(s)", len(tempKeySet))
+	logger.LogDebug("Refresh keys set with %d key(s)", len(tempKeySet))
 	p.keySet = tempKeySet
 	return nil
 }
@@ -91,7 +91,7 @@ func (p *provider) providedPublicKey() (jwk.Key, error) {
 	if p.conf.PublicKey != "" {
 		jk, err := jwk.ParseKey([]byte(p.conf.PublicKey))
 		if err != nil {
-			logger.LogDebug("unable to parse key")
+			logger.LogDebug("Unable to parse key")
 			return nil, err
 		}
 		p.providedKey, _ = jk.PublicKey()
@@ -115,7 +115,7 @@ func (p *provider) findKey(kid string) (jwk.Key, error) {
 	}
 
 	if err := p.requestKeys(); err != nil {
-		logger.LogDebug("failed to retrieve public keys from API [%s]", err)
+		logger.LogDebug("Failed to retrieve public keys from API [%s]", err)
 		return nil, err
 	}
 
@@ -133,7 +133,7 @@ func (p *provider) FetchKeys(_ context.Context, sink jws.KeySink, sig *jws.Signa
 	wantedKid := sig.ProtectedHeaders().KeyID()
 	v, ok := p.keySet[wantedKid]
 	if !ok {
-		logger.LogDebug("key was not found, looking for key id [%s]", wantedKid)
+		logger.LogDebug("Key was not found, looking for key id [%s]", wantedKid)
 		if key, err := p.findKey(wantedKid); key != nil {
 			v = key
 		} else {

--- a/descope/internal/auth/oauth.go
+++ b/descope/internal/auth/oauth.go
@@ -41,7 +41,7 @@ func (auth *oauth) Start(provider descope.OAuthProvider, redirectURL string, r *
 		res := &oauthStartResponse{}
 		err = utils.Unmarshal([]byte(httpResponse.BodyStr), res)
 		if err != nil {
-			logger.LogError("failed to parse location from response for [%s]", err, provider)
+			logger.LogError("Failed to parse location from response for [%s]", err, provider)
 			return "", err
 		}
 		url = res.URL

--- a/descope/internal/auth/saml.go
+++ b/descope/internal/auth/saml.go
@@ -43,7 +43,7 @@ func (auth *saml) Start(tenant string, redirectURL string, r *http.Request, logi
 		res := &samlStartResponse{}
 		err = utils.Unmarshal([]byte(httpResponse.BodyStr), res)
 		if err != nil {
-			logger.LogError("failed to parse saml location from response for [%s]", err, tenant)
+			logger.LogError("Failed to parse saml location from response for [%s]", err, tenant)
 			return "", err
 		}
 		url = res.URL

--- a/descope/internal/mgmt/mgmt.go
+++ b/descope/internal/mgmt/mgmt.go
@@ -86,6 +86,6 @@ func (mgmt *managementService) Group() sdk.Group {
 
 func (mgmt *managementService) ensureManagementKey() {
 	if mgmt.conf.ManagementKey == "" {
-		logger.LogInfo("management key is missing, make sure to add it in the Config struct or the environment variable \"%s\"", descope.EnvironmentVariableManagementKey) // notest
+		logger.LogInfo("Management key is missing, make sure to add it in the Config struct or the environment variable \"%s\"", descope.EnvironmentVariableManagementKey) // notest
 	}
 }

--- a/descope/sdk/middleware.go
+++ b/descope/sdk/middleware.go
@@ -25,7 +25,7 @@ func AuthenticationMiddleware(auth Authentication, onFailure func(http.ResponseW
 				}
 			} else {
 				if err != nil {
-					logger.LogError("request failed because token is invalid", err)
+					logger.LogError("Request failed because token is invalid", err)
 				}
 				if onFailure != nil {
 					onFailure(w, r, err)


### PR DESCRIPTION
## Description
Some small logging alignment I noticed during a previous PR on Descope go-sdk is that some of the log messages are lowercase and some uppercase, same for the error message (all are capital expect one)

this may be probably be automated and enforced with [custom linter](https://golangci-lint.run/contributing/new-linters/), but it may require more effort as well
