### PR TITLE
Upgrade management sso configuration to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,8 @@ idpURL := "https://idp.com"
 entityID := "my-idp-entity-id"
 idpCert := "<your-cert-here>"
 redirectURL := "https://my-app.com/handle-saml" // Global redirect URL for SSO/SAML
-err := descopeClient.Management.SSO().ConfigureSettings(tenantID, idpURL, entityID, idpCert, redirectURL)
+domain := "domain.com" // Users logging in from this domain will be logged in to this tenant
+err := descopeClient.Management.SSO().ConfigureSettings(tenantID, idpURL, entityID, idpCert, redirectURL, domain)
 
 // Alternatively, configure using an SSO metadata URL
 err := descopeClient.Management.SSO().ConfigureMetadata(tenantID, "https://idp.com/my-idp-metadata")

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -428,7 +428,7 @@ func (e *endpoints) ManagementAccessKeyDelete() string {
 }
 
 func (e *endpoints) ManagementSSOConfigure() string {
-	return path.Join(e.version, e.mgmt.ssoConfigure)
+	return path.Join(e.versionV2, e.mgmt.ssoConfigure)
 }
 
 func (e *endpoints) ManagementSSOMetadata() string {

--- a/descope/internal/mgmt/sso.go
+++ b/descope/internal/mgmt/sso.go
@@ -10,7 +10,7 @@ type sso struct {
 	managementBase
 }
 
-func (s *sso) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL string) error {
+func (s *sso) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL, domain string) error {
 	if tenantID == "" {
 		return utils.NewInvalidArgumentError("tenantID")
 	}
@@ -29,6 +29,7 @@ func (s *sso) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL
 		"idpCert":     idpCert,
 		"entityId":    entityID,
 		"redirectURL": redirectURL,
+		"domain":      domain,
 	}
 	_, err := s.client.DoPostRequest(api.Routes.ManagementSSOConfigure(), req, nil, s.conf.ManagementKey)
 	return err

--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -19,20 +19,21 @@ func TestSSOConfigureSettingsSuccess(t *testing.T) {
 		require.Equal(t, "mycert", req["idpCert"])
 		require.Equal(t, "entity", req["entityId"])
 		require.Equal(t, "https://redirect", req["redirectURL"])
+		require.Equal(t, "domain.com", req["domain"])
 	}))
-	err := mgmt.SSO().ConfigureSettings("abc", "http://idpURL", "mycert", "entity", "https://redirect")
+	err := mgmt.SSO().ConfigureSettings("abc", "http://idpURL", "mycert", "entity", "https://redirect", "domain.com")
 	require.NoError(t, err)
 }
 
 func TestSSOConfigureSettingsError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.SSO().ConfigureSettings("", "http://idpURL", "mycert", "entity", "")
+	err := mgmt.SSO().ConfigureSettings("", "http://idpURL", "mycert", "entity", "", "")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureSettings("abc", "", "mycert", "entity", "")
+	err = mgmt.SSO().ConfigureSettings("abc", "", "mycert", "entity", "", "")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureSettings("abc", "http://idpURL", "", "entity", "")
+	err = mgmt.SSO().ConfigureSettings("abc", "http://idpURL", "", "entity", "", "")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureSettings("abc", "http://idpURL", "mycert", "", "")
+	err = mgmt.SSO().ConfigureSettings("abc", "http://idpURL", "mycert", "", "", "")
 	require.Error(t, err)
 }
 

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -189,9 +189,11 @@ type AccessKey interface {
 type SSO interface {
 	// Configure SSO setting for a tenant manually.
 	//
-	// All parameters are required. The idpURL is the URL for the identity provider and idpCert
+	// tenantID, idpURL, idpCert, entityID, are required. The idpURL is the URL for the identity provider and idpCert
 	// is the certificated provided by the identity provider.
-	ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL string) error
+	// redirectURL is optional, however if not given it has to be set when starting an SSO authentication via the request.
+	// domain is optional, it is used to map users to this tenant when authenticating via SSO.
+	ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL, domain string) error
 
 	// Configure SSO setting for a tenant by fetching SSO settings from an IDP metadata URL.
 	ConfigureMetadata(tenantID, idpMetadataURL string) error

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -66,7 +66,7 @@ func (m *MockJWT) UpdateJWTWithCustomClaims(jwt string, customClaims map[string]
 // Mock SSO
 
 type MockSSO struct {
-	ConfigureSettingsAssert func(tenantID, idpURL, idpCert, entityID, redirectURL string)
+	ConfigureSettingsAssert func(tenantID, idpURL, idpCert, entityID, redirectURL, domain string)
 	ConfigureSettingsError  error
 
 	ConfigureMetadataAssert func(tenantID, idpMetadataURL string)
@@ -76,9 +76,9 @@ type MockSSO struct {
 	ConfigureMappingError  error
 }
 
-func (m *MockSSO) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL string) error {
+func (m *MockSSO) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL, domain string) error {
 	if m.ConfigureSettingsAssert != nil {
-		m.ConfigureSettingsAssert(tenantID, idpURL, idpCert, entityID, redirectURL)
+		m.ConfigureSettingsAssert(tenantID, idpURL, idpCert, entityID, redirectURL, domain)
 	}
 	return m.ConfigureSettingsError
 }


### PR DESCRIPTION
## Description
Upgrade management SSO configuration to v2, which now supports the `domain` parameter. This is a **_BREAKING CHANGE_** albeit a minor one - so to speak. A parameter was added. The behavior remains largely the same with the new addition.

## Must
- [X] Tests
- [X] Documentation (if applicable)
