### PR TITLE
Add page to search users

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,8 @@ userRes, err := descopeClient.Management.User().Load("desmond@descope.com")
 userRes, err := descopeClient.Management.User().LoadByUserID("<user-id>")
 
 // Search all users, optionally according to tenant and/or role filter
-usersResp, err := descopeClient.Management.User().SearchAll([]string{"my-tenant-id"}, nil, 0)
+// Results can be paginated using the limit and page parameters
+usersResp, err := descopeClient.Management.User().SearchAll([]string{"my-tenant-id"}, nil, 0, 0)
 if err == nil {
     for _, user := range usersResp {
         // Do something

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ userRes, err := descopeClient.Management.User().LoadByUserID("<user-id>")
 
 // Search all users, optionally according to tenant and/or role filter
 // Results can be paginated using the limit and page parameters
-usersResp, err := descopeClient.Management.User().SearchAll([]string{"my-tenant-id"}, nil, 0, 0)
+usersResp, err := descopeClient.Management.User().SearchAll(&descope.UserSearchOptions{TenantIDs: []string{"my-tenant-id"}})
 if err == nil {
     for _, user := range usersResp {
         // Do something

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -68,8 +68,16 @@ func (u *user) load(loginID, userID string) (*descope.UserResponse, error) {
 	return unmarshalUserResponse(res)
 }
 
-func (u *user) SearchAll(tenantIDs, roles []string, limit int32) ([]*descope.UserResponse, error) {
-	req := makeSearchAllRequest(tenantIDs, roles, limit)
+func (u *user) SearchAll(tenantIDs, roles []string, limit, page int32) ([]*descope.UserResponse, error) {
+	if limit < 0 {
+		return nil, utils.NewInvalidArgumentError("limit")
+	}
+
+	if page < 0 {
+		return nil, utils.NewInvalidArgumentError("page")
+	}
+
+	req := makeSearchAllRequest(tenantIDs, roles, limit, page)
 	res, err := u.client.DoPostRequest(api.Routes.ManagementUserSearchAll(), req, nil, u.conf.ManagementKey)
 	if err != nil {
 		return nil, err
@@ -231,11 +239,12 @@ func makeUpdateUserRolesRequest(loginID, tenantID string, roles []string) map[st
 	}
 }
 
-func makeSearchAllRequest(tenantIDs, roles []string, limit int32) map[string]any {
+func makeSearchAllRequest(tenantIDs, roles []string, limit, page int32) map[string]any {
 	return map[string]any{
 		"tenantIds": tenantIDs,
 		"roleNames": roles,
 		"limit":     limit,
+		"page":      page,
 	}
 }
 

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -68,16 +68,23 @@ func (u *user) load(loginID, userID string) (*descope.UserResponse, error) {
 	return unmarshalUserResponse(res)
 }
 
-func (u *user) SearchAll(tenantIDs, roles []string, limit, page int32) ([]*descope.UserResponse, error) {
-	if limit < 0 {
+func (u *user) SearchAll(options *descope.UserSearchOptions) ([]*descope.UserResponse, error) {
+	// Init empty options if non given
+	if options == nil {
+		options = &descope.UserSearchOptions{}
+	}
+
+	// Make sure limit is non-negative
+	if options.Limit < 0 {
 		return nil, utils.NewInvalidArgumentError("limit")
 	}
 
-	if page < 0 {
+	// Make sure page is non-negative
+	if options.Page < 0 {
 		return nil, utils.NewInvalidArgumentError("page")
 	}
 
-	req := makeSearchAllRequest(tenantIDs, roles, limit, page)
+	req := makeSearchAllRequest(options)
 	res, err := u.client.DoPostRequest(api.Routes.ManagementUserSearchAll(), req, nil, u.conf.ManagementKey)
 	if err != nil {
 		return nil, err
@@ -239,12 +246,12 @@ func makeUpdateUserRolesRequest(loginID, tenantID string, roles []string) map[st
 	}
 }
 
-func makeSearchAllRequest(tenantIDs, roles []string, limit, page int32) map[string]any {
+func makeSearchAllRequest(options *descope.UserSearchOptions) map[string]any {
 	return map[string]any{
-		"tenantIds": tenantIDs,
-		"roleNames": roles,
-		"limit":     limit,
-		"page":      page,
+		"tenantIds": options.TenantIDs,
+		"roleNames": options.Roles,
+		"limit":     options.Limit,
+		"page":      options.Page,
 	}
 }
 

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -167,7 +167,7 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 		require.EqualValues(t, roleNames[0], req["roleNames"].([]any)[0])
 		require.EqualValues(t, 100, req["limit"])
 	}, response))
-	res, err := m.User().SearchAll(tenantIDs, roleNames, 100)
+	res, err := m.User().SearchAll(tenantIDs, roleNames, 100, 0)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res, 1)
@@ -176,8 +176,21 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 
 func TestSearchAllUsersError(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
-	res, err := m.User().SearchAll(nil, nil, 100)
+	res, err := m.User().SearchAll(nil, nil, 100, 0)
 	require.Error(t, err)
+	require.Nil(t, res)
+}
+
+func TestSearchAllUsersBadRequest(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	res, err := m.User().SearchAll(nil, nil, -1, 0)
+	require.ErrorIs(t, err, descope.ErrInvalidArguments)
+	require.Contains(t, err.Error(), "limit")
+	require.Nil(t, res)
+
+	res, err = m.User().SearchAll(nil, nil, 100, -1)
+	require.ErrorIs(t, err, descope.ErrInvalidArguments)
+	require.Contains(t, err.Error(), "page")
 	require.Nil(t, res)
 }
 

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -166,8 +166,9 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 		require.EqualValues(t, tenantIDs[0], req["tenantIds"].([]any)[0])
 		require.EqualValues(t, roleNames[0], req["roleNames"].([]any)[0])
 		require.EqualValues(t, 100, req["limit"])
+		require.EqualValues(t, 0, req["page"])
 	}, response))
-	res, err := m.User().SearchAll(tenantIDs, roleNames, 100, 0)
+	res, err := m.User().SearchAll(&descope.UserSearchOptions{TenantIDs: tenantIDs, Roles: roleNames, Limit: 100})
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Len(t, res, 1)
@@ -176,19 +177,19 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 
 func TestSearchAllUsersError(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
-	res, err := m.User().SearchAll(nil, nil, 100, 0)
+	res, err := m.User().SearchAll(nil)
 	require.Error(t, err)
 	require.Nil(t, res)
 }
 
 func TestSearchAllUsersBadRequest(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
-	res, err := m.User().SearchAll(nil, nil, -1, 0)
+	res, err := m.User().SearchAll(&descope.UserSearchOptions{Limit: -1})
 	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.Contains(t, err.Error(), "limit")
 	require.Nil(t, res)
 
-	res, err = m.User().SearchAll(nil, nil, 100, -1)
+	res, err = m.User().SearchAll(&descope.UserSearchOptions{Page: -1})
 	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.Contains(t, err.Error(), "page")
 	require.Nil(t, res)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -81,7 +81,9 @@ type User interface {
 	//
 	// The limit parameter limits the number of returned users. Leave at 0 to return the
 	// default amount.
-	SearchAll(tenantIDs, roles []string, limit int32) ([]*descope.UserResponse, error)
+	//
+	// The page parameter allow to paginate over the results. Pages start at 0 and must non-negative.
+	SearchAll(tenantIDs, roles []string, limit, page int32) ([]*descope.UserResponse, error)
 
 	// Activate an existing user.
 	Activate(loginID string) (*descope.UserResponse, error)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -75,15 +75,10 @@ type User interface {
 
 	// Search all users according to given filters
 	//
-	// The tenantIDs parameter is an optional array of tenant IDs to filter by.
-	//
-	// The roles parameter is an optional array of role names to filter by.
-	//
-	// The limit parameter limits the number of returned users. Leave at 0 to return the
-	// default amount.
-	//
-	// The page parameter allow to paginate over the results. Pages start at 0 and must non-negative.
-	SearchAll(tenantIDs, roles []string, limit, page int32) ([]*descope.UserResponse, error)
+	// The options optional parameter allows to fine-tune the search filters
+	// and results. Using nil will result in a filter-less query with a set amount of
+	// results.
+	SearchAll(options *descope.UserSearchOptions) ([]*descope.UserResponse, error)
 
 	// Activate an existing user.
 	Activate(loginID string) (*descope.UserResponse, error)

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -115,7 +115,7 @@ type MockUser struct {
 	LoadResponse *descope.UserResponse
 	LoadError    error
 
-	SearchAllAssert   func(tenantIDs, roles []string, limit, page int32)
+	SearchAllAssert   func(options *descope.UserSearchOptions)
 	SearchAllResponse []*descope.UserResponse
 	SearchAllError    error
 
@@ -199,9 +199,9 @@ func (m *MockUser) LoadByUserID(userID string) (*descope.UserResponse, error) {
 	return m.LoadResponse, m.LoadError
 }
 
-func (m *MockUser) SearchAll(tenantIDs, roles []string, limit, page int32) ([]*descope.UserResponse, error) {
+func (m *MockUser) SearchAll(options *descope.UserSearchOptions) ([]*descope.UserResponse, error) {
 	if m.SearchAllAssert != nil {
-		m.SearchAllAssert(tenantIDs, roles, limit, page)
+		m.SearchAllAssert(options)
 	}
 	return m.SearchAllResponse, m.SearchAllError
 }

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -115,7 +115,7 @@ type MockUser struct {
 	LoadResponse *descope.UserResponse
 	LoadError    error
 
-	SearchAllAssert   func(tenantIDs, roles []string, limit int32)
+	SearchAllAssert   func(tenantIDs, roles []string, limit, page int32)
 	SearchAllResponse []*descope.UserResponse
 	SearchAllError    error
 
@@ -199,9 +199,9 @@ func (m *MockUser) LoadByUserID(userID string) (*descope.UserResponse, error) {
 	return m.LoadResponse, m.LoadError
 }
 
-func (m *MockUser) SearchAll(tenantIDs, roles []string, limit int32) ([]*descope.UserResponse, error) {
+func (m *MockUser) SearchAll(tenantIDs, roles []string, limit, page int32) ([]*descope.UserResponse, error) {
 	if m.SearchAllAssert != nil {
-		m.SearchAllAssert(tenantIDs, roles, limit)
+		m.SearchAllAssert(tenantIDs, roles, limit, page)
 	}
 	return m.SearchAllResponse, m.SearchAllError
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -246,6 +246,23 @@ type Role struct {
 	PermissionNames []string `json:"permissionNames,omitempty"`
 }
 
+// Options for searching and filtering users
+//
+// The TenantIDs parameter is an optional array of tenant IDs to filter by.
+//
+// The roles parameter is an optional array of role names to filter by.
+//
+// The limit parameter limits the number of returned users. Leave at 0 to return the
+// default amount.
+//
+// The page parameter allow to paginate over the results. Pages start at 0 and must non-negative.
+type UserSearchOptions struct {
+	TenantIDs []string
+	Roles     []string
+	Limit     int32
+	Page      int32
+}
+
 type GroupMember struct {
 	LoginID string `json:"loginID,omitempty"`
 	UserID  string `json:"userId,omitempty"`

--- a/examples/managementcli/main.go
+++ b/examples/managementcli/main.go
@@ -73,7 +73,17 @@ func userLoad(args []string) error {
 }
 
 func userSearchAll(args []string) error {
-	res, err := descopeClient.Management.User().SearchAll(nil, nil, 0)
+	limit, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	page, err := strconv.ParseInt(args[1], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	res, err := descopeClient.Management.User().SearchAll(nil, nil, int32(limit), int32(page))
 	if err == nil {
 		for _, u := range res {
 			fmt.Println("Found:", u)
@@ -367,6 +377,7 @@ func main() {
 
 	addCommand(userSearchAll, "user-search-all", "Search existing users", func(cmd *cobra.Command) {
 		// Currently not accepting any filters
+		cmd.Args = cobra.ExactArgs(2)
 		cmd.DisableFlagsInUseLine = true
 	})
 

--- a/examples/managementcli/main.go
+++ b/examples/managementcli/main.go
@@ -83,7 +83,7 @@ func userSearchAll(args []string) error {
 		return err
 	}
 
-	res, err := descopeClient.Management.User().SearchAll(nil, nil, int32(limit), int32(page))
+	res, err := descopeClient.Management.User().SearchAll(&descope.UserSearchOptions{Limit: int32(limit), Page: int32(page)})
 	if err == nil {
 		for _, u := range res {
 			fmt.Println("Found:", u)


### PR DESCRIPTION
## Description
Add the ability to paginate the search user response. This change **breaks** the signature of the function but not behavior. Previous usages before this change were as if `page` was set to `0` (the first page).

## Must
- [X] Tests
- [X] Documentation (if applicable)
