### PR TITLE
Return the masked email or address to caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ user := &descope.User{
     Phone: "212-555-1234",
     Email: loginID,
 }
-err := descopeClient.Auth.OTP().SignUp(descope.MethodEmail, loginID, user)
+maskedAddress, err := descopeClient.Auth.OTP().SignUp(descope.MethodEmail, loginID, user)
 if err != nil {
     if errors.Is(err, descope.ErrUserAlreadyExists) {
         // user already exists with this loginID
@@ -89,7 +89,7 @@ The user can either `sign up`, `sign in` or `sign up or in`
 ```go
 // If configured globally, the redirect URI is optional. If provided however, it will be used
 // instead of any global configuration
-err := descopeClient.Auth.MagicLink().SignUpOrIn(descope.MethodEmail, "desmond@descope.com", "http://myapp.com/verify-magic-link")
+maskedAddress, err := descopeClient.Auth.MagicLink().SignUpOrIn(descope.MethodEmail, "desmond@descope.com", "http://myapp.com/verify-magic-link")
 if err {
     // handle error
 }

--- a/descope/client/client_test.go
+++ b/descope/client/client_test.go
@@ -55,7 +55,7 @@ func TestConcurrentClients(t *testing.T) {
 
 	// SignUpOrIn is called to trigger logging, to ensure it is safe
 	// during a concurrent creation of another client
-	_ = c.Auth.OTP().SignUpOrIn(descope.MethodEmail, "test@test.com")
+	_, _ = c.Auth.OTP().SignUpOrIn(descope.MethodEmail, "test@test.com")
 }
 
 func TestEmptyProjectID(t *testing.T) {

--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -808,3 +808,36 @@ func setCookies(cookies []*http.Cookie, w http.ResponseWriter) {
 		http.SetCookie(w, cookies[i])
 	}
 }
+
+type Masked interface {
+	GetMasked() string
+}
+
+type MaskedEmailRes struct {
+	MaskedEmail string `json:"maskedEmail,omitempty"` // Masked email to which the message was sent
+}
+
+func (mer *MaskedEmailRes) GetMasked() string {
+	return mer.MaskedEmail
+}
+
+type MaskedPhoneRes struct {
+	MaskedPhone string `json:"maskedPhone,omitempty"` // Masked phone to which the message was sent
+}
+
+func (mer *MaskedPhoneRes) GetMasked() string {
+	return mer.MaskedPhone
+}
+
+func getMaskedValue(method descope.DeliveryMethod) Masked {
+	var m Masked
+	switch method {
+	case descope.MethodSMS:
+		fallthrough
+	case descope.MethodWhatsApp:
+		m = &MaskedPhoneRes{}
+	case descope.MethodEmail:
+		m = &MaskedEmailRes{}
+	}
+	return m
+}

--- a/descope/internal/auth/enchantedlink_test.go
+++ b/descope/internal/auth/enchantedlink_test.go
@@ -38,6 +38,7 @@ func TestSignInEnchantedLink(t *testing.T) {
 	uri := "http://test.me"
 	pendingRefResponse := "pending_ref"
 	loginID := "loginID"
+	maskedEmail := "t**@email.com"
 	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
 		assert.EqualValues(t, composeEnchantedLinkSignInURL(), r.URL.RequestURI())
 
@@ -47,14 +48,15 @@ func TestSignInEnchantedLink(t *testing.T) {
 		assert.EqualValues(t, uri, m["URI"])
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"pendingRef": "%s","linkId": "%s"}`, pendingRefResponse, loginID))),
+			Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"pendingRef": "%s","linkId": "%s", "maskedEmail":"%s"}`, pendingRefResponse, loginID, maskedEmail))),
 		}, nil
 	})
 	require.NoError(t, err)
 	response, err := a.EnchantedLink().SignIn(email, uri, nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, pendingRefResponse, response.PendingRef)
-	require.Equal(t, loginID, response.LinkID)
+	require.EqualValues(t, pendingRefResponse, response.PendingRef)
+	require.EqualValues(t, loginID, response.LinkID)
+	require.EqualValues(t, maskedEmail, response.MaskedEmail)
 }
 
 func TestSignInEnchantedLinkStepup(t *testing.T) {
@@ -85,8 +87,8 @@ func TestSignInEnchantedLinkStepup(t *testing.T) {
 	require.NoError(t, err)
 	response, err := a.EnchantedLink().SignIn(email, uri, &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}})
 	require.NoError(t, err)
-	require.Equal(t, pendingRefResponse, response.PendingRef)
-	require.Equal(t, loginID, response.LinkID)
+	require.EqualValues(t, pendingRefResponse, response.PendingRef)
+	require.EqualValues(t, loginID, response.LinkID)
 }
 
 func TestSignInEnchantedLinkInvalidResponse(t *testing.T) {
@@ -126,8 +128,8 @@ func TestSignUpEnchantedLink(t *testing.T) {
 	require.NoError(t, err)
 	response, err := a.EnchantedLink().SignUp(email, uri, &descope.User{Name: "test"})
 	require.NoError(t, err)
-	require.Equal(t, pendingRefResponse, response.PendingRef)
-	require.Equal(t, loginID, response.LinkID)
+	require.EqualValues(t, pendingRefResponse, response.PendingRef)
+	require.EqualValues(t, loginID, response.LinkID)
 }
 
 func TestSignUpOrInEnchantedLink(t *testing.T) {
@@ -150,8 +152,8 @@ func TestSignUpOrInEnchantedLink(t *testing.T) {
 	require.NoError(t, err)
 	response, err := a.EnchantedLink().SignUpOrIn(email, uri)
 	require.NoError(t, err)
-	require.Equal(t, pendingRefResponse, response.PendingRef)
-	require.Equal(t, loginID, response.LinkID)
+	require.EqualValues(t, pendingRefResponse, response.PendingRef)
+	require.EqualValues(t, loginID, response.LinkID)
 }
 
 func TestSignUpEnchantedLinkEmptyLoginID(t *testing.T) {

--- a/descope/internal/auth/utils.go
+++ b/descope/internal/auth/utils.go
@@ -31,11 +31,6 @@ type authenticationWebAuthnSignInRequestBody struct {
 	LoginOptions *descope.LoginOptions `json:"loginOptions,omitempty"`
 }
 
-type authenticationWebAuthnSignUpOrInRequestBody struct {
-	LoginID string `json:"loginId,omitempty"`
-	Origin  string `json:"origin"`
-}
-
 type authenticationWebAuthnAddDeviceRequestBody struct {
 	LoginID string `json:"loginId,omitempty"`
 	Origin  string `json:"origin"`

--- a/descope/internal/auth/webauthn_test.go
+++ b/descope/internal/auth/webauthn_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type authenticationWebAuthnSignUpOrInRequestBody struct {
+	LoginID string `json:"loginId,omitempty"`
+	Origin  string `json:"origin"`
+}
+
 func TestSignUpStart(t *testing.T) {
 	expectedResponse := descope.WebAuthnTransactionResponse{TransactionID: "a"}
 	a, err := newTestAuth(nil, DoOkWithBody(func(r *http.Request) {

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -9,20 +9,20 @@ import (
 type MagicLink interface {
 	// SignIn - Use to login a user based on a magic link that will be sent either email or a phone
 	// and choose the selected delivery method for verification (see auth/DeliveryMethod).
-	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	// returns the masked address where the link was sent (email or phone) or an error upon failure.
 	SignIn(method descope.DeliveryMethod, loginID, URI string, r *http.Request, loginOptions *descope.LoginOptions) (maskedAddress string, err error)
 
 	// SignUp - Use to create a new user based on the given loginID either email or a phone.
 	// choose the selected delivery method for verification (see auth/DeliveryMethod).
 	// optional to add user metadata for farther user details such as name and more.
-	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	// returns the masked address where the link was sent (email or phone) or an error upon failure.
 	SignUp(method descope.DeliveryMethod, loginID, URI string, user *descope.User) (maskedAddress string, err error)
 
 	// SignUpOrIn - Use to login in using loginID, if user does not exist, a new user will be created
 	// with the given loginID.
 	// choose the selected delivery method for verification (see auth/DeliveryMethod).
 	// optional to add user metadata for farther user details such as name and more.
-	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	// returns the masked address where the link was sent (email or phone) or an error upon failure.
 	SignUpOrIn(method descope.DeliveryMethod, loginID string, URI string) (maskedAddress string, err error)
 
 	// Verify - Use to verify a SignIn/SignUp request, based on the magic link token generated.
@@ -32,14 +32,14 @@ type MagicLink interface {
 	// UpdateUserEmail - Use to update email and validate via magiclink
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	// returns the masked email where the link was sent or an error upon failure.
 	UpdateUserEmail(loginID, email, URI string, request *http.Request) (maskedAddress string, err error)
 
 	// UpdateUserPhone - Use to update phone and validate via magiclink
 	// allowed methods are phone based methods - whatsapp and SMS
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	// returns the masked phone where the link was sent or an error upon failure.
 	UpdateUserPhone(method descope.DeliveryMethod, loginID, phone, URI string, request *http.Request) (maskedAddress string, err error)
 }
 
@@ -76,18 +76,18 @@ type EnchantedLink interface {
 type OTP interface {
 	// SignIn - Use to login a user based on the given loginID either email or a phone
 	// and choose the selected delivery method for verification. (see auth/DeliveryMethod)
-	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	// returns the masked address where the code was sent (email or phone) or an error upon failure.
 	SignIn(method descope.DeliveryMethod, loginID string, r *http.Request, loginOptions *descope.LoginOptions) (maskedAddress string, err error)
 
 	// SignUp - Use to create a new user based on the given loginID either email or a phone.
 	// choose the selected delivery method for verification. (see auth/DeliveryMethod)
 	// optional to add user metadata for farther user details such as name and more.
-	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	// returns the masked address where the code was sent (email or phone) or an error upon failure.
 	SignUp(method descope.DeliveryMethod, loginID string, user *descope.User) (maskedAddress string, err error)
 
 	// SignUpOrIn - Use to login in using loginID, if user does not exist, a new user will be created
 	// with the given loginID.
-	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	// returns the masked address where the code was sent (email or phone) or an error upon failure.
 	SignUpOrIn(method descope.DeliveryMethod, loginID string) (maskedAddress string, err error)
 
 	// VerifyCode - Use to verify a SignIn/SignUp based on the given loginID either an email or a phone
@@ -100,14 +100,14 @@ type OTP interface {
 	// UpdateUserEmail - Use to a update email, and verify via OTP
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	// returns the masked email where the code was sent or an error upon failure.
 	UpdateUserEmail(loginID, email string, request *http.Request) (maskedAddress string, err error)
 
 	// UpdateUserPhone - Use to update phone and validate via OTP
 	// allowed methods are phone based methods - whatsapp and SMS
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	// returns the masked phone where the code was sent or an error upon failure.
 	UpdateUserPhone(method descope.DeliveryMethod, loginID, phone string, request *http.Request) (maskedAddress string, err error)
 }
 

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -9,21 +9,21 @@ import (
 type MagicLink interface {
 	// SignIn - Use to login a user based on a magic link that will be sent either email or a phone
 	// and choose the selected delivery method for verification (see auth/DeliveryMethod).
-	// returns an error upon failure.
-	SignIn(method descope.DeliveryMethod, loginID, URI string, r *http.Request, loginOptions *descope.LoginOptions) error
+	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	SignIn(method descope.DeliveryMethod, loginID, URI string, r *http.Request, loginOptions *descope.LoginOptions) (maskedAddress string, err error)
 
 	// SignUp - Use to create a new user based on the given loginID either email or a phone.
 	// choose the selected delivery method for verification (see auth/DeliveryMethod).
 	// optional to add user metadata for farther user details such as name and more.
-	// returns an error upon failure.
-	SignUp(method descope.DeliveryMethod, loginID, URI string, user *descope.User) error
+	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	SignUp(method descope.DeliveryMethod, loginID, URI string, user *descope.User) (maskedAddress string, err error)
 
 	// SignUpOrIn - Use to login in using loginID, if user does not exist, a new user will be created
 	// with the given loginID.
 	// choose the selected delivery method for verification (see auth/DeliveryMethod).
 	// optional to add user metadata for farther user details such as name and more.
-	// returns an error upon failure.
-	SignUpOrIn(method descope.DeliveryMethod, loginID string, URI string) error
+	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	SignUpOrIn(method descope.DeliveryMethod, loginID string, URI string) (maskedAddress string, err error)
 
 	// Verify - Use to verify a SignIn/SignUp request, based on the magic link token generated.
 	// if the link was generated with crossDevice, the authentication info will be nil, and should returned with GetSession.
@@ -32,13 +32,15 @@ type MagicLink interface {
 	// UpdateUserEmail - Use to update email and validate via magiclink
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	UpdateUserEmail(loginID, email, URI string, request *http.Request) error
+	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	UpdateUserEmail(loginID, email, URI string, request *http.Request) (maskedAddress string, err error)
 
 	// UpdateUserPhone - Use to update phone and validate via magiclink
 	// allowed methods are phone based methods - whatsapp and SMS
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	UpdateUserPhone(method descope.DeliveryMethod, loginID, phone, URI string, request *http.Request) error
+	// returns the masked address where the link was sent (email or phone) to and an error upon failure.
+	UpdateUserPhone(method descope.DeliveryMethod, loginID, phone, URI string, request *http.Request) (maskedAddress string, err error)
 }
 
 type EnchantedLink interface {
@@ -74,18 +76,19 @@ type EnchantedLink interface {
 type OTP interface {
 	// SignIn - Use to login a user based on the given loginID either email or a phone
 	// and choose the selected delivery method for verification. (see auth/DeliveryMethod)
-	// returns an error upon failure.
-	SignIn(method descope.DeliveryMethod, loginID string, r *http.Request, loginOptions *descope.LoginOptions) error
+	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	SignIn(method descope.DeliveryMethod, loginID string, r *http.Request, loginOptions *descope.LoginOptions) (maskedAddress string, err error)
 
 	// SignUp - Use to create a new user based on the given loginID either email or a phone.
 	// choose the selected delivery method for verification. (see auth/DeliveryMethod)
 	// optional to add user metadata for farther user details such as name and more.
-	// returns an error upon failure.
-	SignUp(method descope.DeliveryMethod, loginID string, user *descope.User) error
+	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	SignUp(method descope.DeliveryMethod, loginID string, user *descope.User) (maskedAddress string, err error)
 
 	// SignUpOrIn - Use to login in using loginID, if user does not exist, a new user will be created
 	// with the given loginID.
-	SignUpOrIn(method descope.DeliveryMethod, loginID string) error
+	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	SignUpOrIn(method descope.DeliveryMethod, loginID string) (maskedAddress string, err error)
 
 	// VerifyCode - Use to verify a SignIn/SignUp based on the given loginID either an email or a phone
 	// followed by the code used to verify and authenticate the user.
@@ -97,13 +100,15 @@ type OTP interface {
 	// UpdateUserEmail - Use to a update email, and verify via OTP
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	UpdateUserEmail(loginID, email string, request *http.Request) error
+	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	UpdateUserEmail(loginID, email string, request *http.Request) (maskedAddress string, err error)
 
 	// UpdateUserPhone - Use to update phone and validate via OTP
 	// allowed methods are phone based methods - whatsapp and SMS
 	// LoginID of user whom we want to update
 	// Request is needed to obtain JWT and send it to Descope, for verification
-	UpdateUserPhone(method descope.DeliveryMethod, loginID, phone string, request *http.Request) error
+	// returns the masked address where the code was sent (email or phone) to and an error upon failure.
+	UpdateUserPhone(method descope.DeliveryMethod, loginID, phone string, request *http.Request) (maskedAddress string, err error)
 }
 
 type TOTP interface {

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -74,25 +74,25 @@ type MockMagicLink struct {
 	UpdateUserPhoneError  error
 }
 
-func (m *MockMagicLink) SignIn(method descope.DeliveryMethod, loginID, URI string, r *http.Request, loginOptions *descope.LoginOptions) error {
+func (m *MockMagicLink) SignIn(method descope.DeliveryMethod, loginID, URI string, r *http.Request, loginOptions *descope.LoginOptions) (string, error) {
 	if m.SignInAssert != nil {
 		m.SignInAssert(method, loginID, URI, r, loginOptions)
 	}
-	return m.SignInError
+	return "", m.SignInError
 }
 
-func (m *MockMagicLink) SignUp(method descope.DeliveryMethod, loginID, URI string, user *descope.User) error {
+func (m *MockMagicLink) SignUp(method descope.DeliveryMethod, loginID, URI string, user *descope.User) (string, error) {
 	if m.SignUpAssert != nil {
 		m.SignUpAssert(method, loginID, URI, user)
 	}
-	return m.SignUpError
+	return "", m.SignUpError
 }
 
-func (m *MockMagicLink) SignUpOrIn(method descope.DeliveryMethod, loginID string, URI string) error {
+func (m *MockMagicLink) SignUpOrIn(method descope.DeliveryMethod, loginID string, URI string) (string, error) {
 	if m.SignUpOrInAssert != nil {
 		m.SignUpOrInAssert(method, loginID, URI)
 	}
-	return m.SignUpOrInError
+	return "", m.SignUpOrInError
 }
 
 func (m *MockMagicLink) Verify(token string, w http.ResponseWriter) (*descope.AuthenticationInfo, error) {
@@ -102,18 +102,18 @@ func (m *MockMagicLink) Verify(token string, w http.ResponseWriter) (*descope.Au
 	return m.VerifyResponse, m.VerifyError
 }
 
-func (m *MockMagicLink) UpdateUserEmail(loginID, email, URI string, r *http.Request) error {
+func (m *MockMagicLink) UpdateUserEmail(loginID, email, URI string, r *http.Request) (string, error) {
 	if m.UpdateUserEmailAssert != nil {
 		m.UpdateUserEmailAssert(loginID, email, URI, r)
 	}
-	return m.UpdateUserEmailError
+	return "", m.UpdateUserEmailError
 }
 
-func (m *MockMagicLink) UpdateUserPhone(method descope.DeliveryMethod, loginID, phone, URI string, r *http.Request) error {
+func (m *MockMagicLink) UpdateUserPhone(method descope.DeliveryMethod, loginID, phone, URI string, r *http.Request) (string, error) {
 	if m.UpdateUserPhoneAssert != nil {
 		m.UpdateUserPhoneAssert(method, loginID, phone, URI, r)
 	}
-	return m.UpdateUserPhoneError
+	return "", m.UpdateUserPhoneError
 }
 
 // Mock EnchantedLink
@@ -211,25 +211,25 @@ type MockOTP struct {
 	UpdateUserPhoneError  error
 }
 
-func (m *MockOTP) SignIn(method descope.DeliveryMethod, loginID string, r *http.Request, loginOptions *descope.LoginOptions) error {
+func (m *MockOTP) SignIn(method descope.DeliveryMethod, loginID string, r *http.Request, loginOptions *descope.LoginOptions) (string, error) {
 	if m.SignInAssert != nil {
 		m.SignInAssert(method, loginID, r, loginOptions)
 	}
-	return m.SignInError
+	return "", m.SignInError
 }
 
-func (m *MockOTP) SignUp(method descope.DeliveryMethod, loginID string, user *descope.User) error {
+func (m *MockOTP) SignUp(method descope.DeliveryMethod, loginID string, user *descope.User) (string, error) {
 	if m.SignUpAssert != nil {
 		m.SignUpAssert(method, loginID, user)
 	}
-	return m.SignUpError
+	return "", m.SignUpError
 }
 
-func (m *MockOTP) SignUpOrIn(method descope.DeliveryMethod, loginID string) error {
+func (m *MockOTP) SignUpOrIn(method descope.DeliveryMethod, loginID string) (string, error) {
 	if m.SignUpOrInAssert != nil {
 		m.SignUpOrInAssert(method, loginID)
 	}
-	return m.SignUpOrInError
+	return "", m.SignUpOrInError
 }
 
 func (m *MockOTP) VerifyCode(method descope.DeliveryMethod, loginID string, code string, w http.ResponseWriter) (*descope.AuthenticationInfo, error) {
@@ -239,18 +239,18 @@ func (m *MockOTP) VerifyCode(method descope.DeliveryMethod, loginID string, code
 	return m.VerifyCodeResponse, m.VerifyCodeError
 }
 
-func (m *MockOTP) UpdateUserEmail(loginID, email string, r *http.Request) error {
+func (m *MockOTP) UpdateUserEmail(loginID, email string, r *http.Request) (string, error) {
 	if m.UpdateUserEmailAssert != nil {
 		m.UpdateUserEmailAssert(loginID, email, r)
 	}
-	return m.UpdateUserEmailError
+	return "", m.UpdateUserEmailError
 }
 
-func (m *MockOTP) UpdateUserPhone(method descope.DeliveryMethod, loginID, phone string, r *http.Request) error {
+func (m *MockOTP) UpdateUserPhone(method descope.DeliveryMethod, loginID, phone string, r *http.Request) (string, error) {
 	if m.UpdateUserPhoneAssert != nil {
 		m.UpdateUserPhoneAssert(method, loginID, phone, r)
 	}
-	return m.UpdateUserPhoneError
+	return "", m.UpdateUserPhoneError
 }
 
 // Mock TOTP

--- a/descope/types.go
+++ b/descope/types.go
@@ -137,8 +137,9 @@ type JWTResponse struct {
 }
 
 type EnchantedLinkResponse struct {
-	PendingRef string `json:"pendingRef,omitempty"` // Pending referral code used to poll enchanted link authentication status
-	LinkID     string `json:"linkId,omitempty"`     // Link id, on which link the user should click
+	PendingRef  string `json:"pendingRef,omitempty"`  // Pending referral code used to poll enchanted link authentication status
+	LinkID      string `json:"linkId,omitempty"`      // Link id, on which link the user should click
+	MaskedEmail string `json:"maskedEmail,omitempty"` // Masked email to which the email was sent
 }
 
 func NewAuthenticationInfo(jRes *JWTResponse, sessionToken, refreshToken *Token) *AuthenticationInfo {

--- a/examples/ginwebapp/main.go
+++ b/examples/ginwebapp/main.go
@@ -73,11 +73,11 @@ func handleIsHealthy(c *gin.Context) {
 
 func handleSignUpOrIn(c *gin.Context) {
 	method, loginID := getMethodAndLoginID(c)
-	err := descopeClient.Auth.OTP().SignUpOrIn(method, loginID)
+	masked, err := descopeClient.Auth.OTP().SignUpOrIn(method, loginID)
 	if err != nil {
 		setErrorWithSignUpIn(c, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /otp/verify?" + string(method) + "=" + loginID + "&code=<code>"
+		helpTxt := fmt.Sprintf("to verify code received to %s go to /otp/verify?%s=%s&code=<code>", masked, string(method), loginID)
 		setResponse(c, http.StatusOK, helpTxt)
 	}
 }

--- a/examples/webapp/main.go
+++ b/examples/webapp/main.go
@@ -155,22 +155,22 @@ func help(w http.ResponseWriter, r *http.Request) {
 
 func handleSignUp(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
-	err := descopeClient.Auth.OTP().SignUp(method, loginID, &descope.User{Name: "test"})
+	masked, err := descopeClient.Auth.OTP().SignUp(method, loginID, &descope.User{Name: "test"})
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /otp/verify?" + string(method) + "=" + loginID + "&code=<code>"
+		helpTxt := fmt.Sprintf("Code was sent to %s, to verify code received go to /otp/verify?%s=%s&code=<code>", masked, string(method), loginID)
 		setResponse(w, http.StatusOK, helpTxt)
 	}
 }
 
 func handleSignIn(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
-	err := descopeClient.Auth.OTP().SignIn(method, loginID, nil, nil)
+	masked, err := descopeClient.Auth.OTP().SignIn(method, loginID, nil, nil)
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /otp/verify?" + string(method) + "=" + loginID + "&code=<code>"
+		helpTxt := fmt.Sprintf("Code was sent to %s to verify code received go to /otp/verify?%s=%s&code=<code>", masked, string(method), loginID)
 		setResponse(w, http.StatusOK, helpTxt)
 	}
 }
@@ -230,26 +230,24 @@ func sendSuccessAuthResponse(w http.ResponseWriter, authInfo *descope.Authentica
 
 func handleMagicLinkSignIn(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
-	err := descopeClient.Auth.MagicLink().SignIn(method, loginID, verifyMagicLinkURI, nil, nil)
+	masked, err := descopeClient.Auth.MagicLink().SignIn(method, loginID, verifyMagicLinkURI, nil, nil)
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 		return
 	}
-	helpTxt := "You should have received a magiclink by " + string(method) + "\n"
-	helpTxt += "Copy it to this browser in order to complete the signin"
+	helpTxt := fmt.Sprintf("You should have received a magiclink by %s here: %s.\nCopy it to this browser in order to complete the signin", string(method), masked)
 	setResponse(w, http.StatusOK, helpTxt)
 }
 
 func handleMagicLinkSignUp(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
 	user := &descope.User{Name: "test"}
-	err := descopeClient.Auth.MagicLink().SignUp(method, loginID, verifyMagicLinkURI, user)
+	masked, err := descopeClient.Auth.MagicLink().SignUp(method, loginID, verifyMagicLinkURI, user)
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 		return
 	}
-	helpTxt := "You should have received a magiclink by " + string(method) + "\n"
-	helpTxt += "Copy it to this browser in order to complete the sign up"
+	helpTxt := fmt.Sprintf("You should have received a magiclink by %s here: %s.\nCopy it to this browser in order to complete the sign up", string(method), masked)
 	setResponse(w, http.StatusOK, helpTxt)
 }
 
@@ -428,11 +426,11 @@ func handleStepup(w http.ResponseWriter, r *http.Request) {
 
 func handleStepupSignUpInEmail(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
-	err := descopeClient.Auth.OTP().SignUpOrIn(method, loginID)
+	masked, err := descopeClient.Auth.OTP().SignUpOrIn(method, loginID)
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /stepup/conf/verify?" + string(method) + "=" + loginID + "&code=<code>"
+		helpTxt := fmt.Sprintf("Code was sent to %s, to verify code received go to /stepup/conf/verify?%s=%s&code=<code>", masked, string(method), loginID)
 		setResponse(w, http.StatusOK, helpTxt)
 	}
 }
@@ -463,11 +461,11 @@ func handleStepupConfUpdate(w http.ResponseWriter, r *http.Request) {
 	if codes, ok := r.URL.Query()["loginId"]; ok {
 		exID = codes[0]
 	}
-	err := descopeClient.Auth.OTP().UpdateUserPhone(method, exID, loginID, r)
+	masked, err := descopeClient.Auth.OTP().UpdateUserPhone(method, exID, loginID, r)
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /stepup/conf/update/verify?" + string(method) + "=" + exID + "&code=<code>"
+		helpTxt := fmt.Sprintf("Code was sent to %s, to verify code received go to /stepup/conf/update/verify?%s=%s&code=<code>", masked, string(method), exID)
 		setResponse(w, http.StatusOK, helpTxt)
 	}
 }
@@ -494,11 +492,11 @@ func handleStepupConfUpdateVerify(w http.ResponseWriter, r *http.Request) {
 
 func handleStepupLogin(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
-	err := descopeClient.Auth.OTP().SignUpOrIn(method, loginID)
+	masked, err := descopeClient.Auth.OTP().SignUpOrIn(method, loginID)
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /stepup/login/verify?" + string(method) + "=" + loginID + "&code=<code>"
+		helpTxt := fmt.Sprintf("Code was sent to %s, to verify code received go to /stepup/login/verify?%s=%s&code=<code>", masked, string(method), loginID)
 		setResponse(w, http.StatusOK, helpTxt)
 	}
 }
@@ -527,11 +525,11 @@ func handleStepupLoginVerify(w http.ResponseWriter, r *http.Request) {
 
 func handleStepupStepup(w http.ResponseWriter, r *http.Request) {
 	method, loginID := getMethodAndLoginID(r)
-	err := descopeClient.Auth.OTP().SignIn(method, loginID, r, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"demoKey": "demoValue"}})
+	masked, err := descopeClient.Auth.OTP().SignIn(method, loginID, r, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"demoKey": "demoValue"}})
 	if err != nil {
 		setErrorWithSignUpIn(w, err.Error(), method, loginID)
 	} else {
-		helpTxt := "to verify code received go to /stepup/stepup/verify?" + string(method) + "=" + loginID + "&code=<code>"
+		helpTxt := fmt.Sprintf("Code was sent to %s, to verify code received go to /stepup/stepup/verify?%s=%s&code=<code>", masked, string(method), loginID)
 		setResponse(w, http.StatusOK, helpTxt)
 	}
 }


### PR DESCRIPTION
This applies to otp magic link and enchanted link
Use of magix link and otp will break compilation upon upgrading to this version The value is returned upon initiation of the signup/in method and returned in masked format

