### PR TITLE
Support custom attributes for user manamgenet SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,24 +527,36 @@ You can create, update, delete or load users, as well as search according to fil
 // A user must have a loginID, other fields are optional.
 // Roles should be set directly if no tenants exist, otherwise set
 // on a per-tenant basis.
-user, err := descopeClient.Management.User().Create("desmond@descope.com", "desmond@descope.com", "", "Desmond Copeland", nil, []*descope.AssociatedTenant{
-    {TenantID: "tenant-ID1", RoleNames: []string{"role-name1"}},
+userReq := &descope.UserRequest{}
+userReq.Email = "desmond@descope.com"
+userReq.Name = "Desmond Copeland"
+userReq.Tenants = []*descope.AssociatedTenant{
+    {TenantID: "tenant-ID1", Roles: []string{"role-name1"}},
     {TenantID: "tenant-ID2"},
-})
+}
+user, err := descopeClient.Management.User().Create("desmond@descope.com", userReq)
 
 // Alternatively, a user can be created and invited via an email message.
 // Make sure to configure the invite URL in the Descope console prior to using this function,
 // and that an email address is provided in the information.
-err := descopeClient.Management.User().Invite("desmond@descope.com", "desmond@descope.com", "", "Desmond Copeland", nil, []*descope.AssociatedTenant{
-    {TenantID: "tenant-ID1", RoleNames: []string{"role-name1"}},
+userReqInvite := &descope.UserRequest{}
+userReqInvite.Email = "desmond@descope.com"
+userReqInvite.Name = "Desmond Copeland"
+userReqInvite.Tenants = []*descope.AssociatedTenant{
+    {TenantID: "tenant-ID1", Roles: []string{"role-name1"}},
     {TenantID: "tenant-ID2"},
-})
+}
+err := descopeClient.Management.User().Invite("desmond@descope.com", userReqInvite)
 
 // Update will override all fields as is. Use carefully.
-err := descopeClient.Management.User().Update("desmond@descope.com", "desmond@descope.com", "", "Desmond Copeland", nil, []*descope.AssociatedTenant{
-    {TenantID: "tenant-ID1", RoleNames: []string{"role-name1", "role-name2"}},
+userReqUpdate := &descope.UserRequest{}
+userReqUpdate.Email = "desmond@descope.com"
+userReqUpdate.Name = "Desmond Copeland"
+userReqUpdate.Tenants = []*descope.AssociatedTenant{
+    {TenantID: "tenant-ID1", Roles: []string{"role-name1"}},
     {TenantID: "tenant-ID2"},
-})
+}
+err := descopeClient.Management.User().Update("desmond@descope.com", userReqUpdate)
 
 // User deletion cannot be undone. Use carefully.
 err := descopeClient.Management.User().Delete("desmond@descope.com")

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -76,6 +76,18 @@ func TestUserCreateError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUserCreateUpdateOrInviteWithNoUser(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := m.User().Create("abc", nil)
+	require.NoError(t, err)
+	_, err = m.User().CreateTestUser("abc", nil)
+	require.NoError(t, err)
+	_, err = m.User().Invite("abc", nil)
+	require.NoError(t, err)
+	_, err = m.User().Update("abc", nil)
+	require.NoError(t, err)
+}
+
 func TestUserUpdateSuccess(t *testing.T) {
 	response := map[string]any{
 		"user": map[string]any{

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -15,6 +15,7 @@ func TestUserCreateSuccess(t *testing.T) {
 		"user": map[string]any{
 			"email": "a@b.c",
 		}}
+	ca := map[string]any{"ak": "av"}
 	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		req := map[string]any{}
@@ -25,13 +26,18 @@ func TestUserCreateSuccess(t *testing.T) {
 		require.Len(t, roleNames, 1)
 		require.Equal(t, "foo", roleNames[0])
 		require.Nil(t, req["test"])
+		assert.EqualValues(t, ca, req["customAttributes"])
 	}, response))
-	res, err := m.User().Create("abc", "foo@bar.com", "", "", []string{"foo"}, nil)
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	user.Roles = []string{"foo"}
+	user.CustomAttributes = ca
+	res, err := m.User().Create("abc", user)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, "a@b.c", res.Email)
 
-	res, err = m.User().Invite("abc", "foo@bar.com", "", "", []string{"foo"}, nil)
+	res, err = m.User().Invite("abc", user)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, "a@b.c", res.Email)
@@ -53,7 +59,10 @@ func TestUserCreateTestUserSuccess(t *testing.T) {
 		require.Equal(t, "foo", roleNames[0])
 		require.EqualValues(t, true, req["test"])
 	}, response))
-	res, err := m.User().CreateTestUser("abc", "foo@bar.com", "", "", []string{"foo"}, nil)
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	user.Roles = []string{"foo"}
+	res, err := m.User().CreateTestUser("abc", user)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, "a@b.c", res.Email)
@@ -61,7 +70,9 @@ func TestUserCreateTestUserSuccess(t *testing.T) {
 
 func TestUserCreateError(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoOk(nil))
-	_, err := m.User().Create("", "foo@bar.com", "", "", nil, nil)
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	_, err := m.User().Create("", user)
 	require.Error(t, err)
 }
 
@@ -91,7 +102,10 @@ func TestUserUpdateSuccess(t *testing.T) {
 			}
 		}
 	}, response))
-	res, err := m.User().Update("abc", "foo@bar.com", "", "", nil, []*descope.AssociatedTenant{{TenantID: "x", Roles: []string{"foo"}}, {TenantID: "y", Roles: []string{"bar"}}})
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	user.Tenants = []*descope.AssociatedTenant{{TenantID: "x", Roles: []string{"foo"}}, {TenantID: "y", Roles: []string{"bar"}}}
+	res, err := m.User().Update("abc", user)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, "a@b.c", res.Email)
@@ -99,7 +113,9 @@ func TestUserUpdateSuccess(t *testing.T) {
 
 func TestUserUpdateError(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoOk(nil))
-	_, err := m.User().Update("", "foo@bar.com", "", "", nil, nil)
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	_, err := m.User().Update("", user)
 	require.Error(t, err)
 }
 

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -47,7 +47,7 @@ type User interface {
 	// aren't associated with a tenant, while the tenants parameter can be used
 	// to specify which tenants to associate the user with and what roles the
 	// user has in each one.
-	Create(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error)
+	Create(loginID string, user *descope.UserRequest) (*descope.UserResponse, error)
 
 	// Create a new test user.
 	//
@@ -57,7 +57,7 @@ type User interface {
 	// You can later generate OTP, Magic link and enchanted link to use in the test without the need
 	// of 3rd party messaging services
 	// Those users are not counted as part of the monthly active users
-	CreateTestUser(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error)
+	CreateTestUser(loginID string, user *descope.UserRequest) (*descope.UserResponse, error)
 
 	// Create a new user and invite them via an email message.
 	//
@@ -68,7 +68,7 @@ type User interface {
 	// the email is explicitly set, or the loginID itself is an email address.
 	// You must configure the invitation URL in the Descope console prior to
 	// calling the method.
-	Invite(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error)
+	Invite(loginID string, user *descope.UserRequest) (*descope.UserResponse, error)
 
 	// Update an existing user.
 	//
@@ -76,7 +76,7 @@ type User interface {
 	//
 	// IMPORTANT: All parameters will override whatever values are currently set
 	// in the existing user. Use carefully.
-	Update(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error)
+	Update(loginID string, user *descope.UserRequest) (*descope.UserResponse, error)
 
 	// Delete an existing user.
 	//

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -41,7 +41,7 @@ type User interface {
 	// Create a new user.
 	//
 	// The loginID is required and will determine what the user will use to
-	// sign in. All other fields are optional.
+	// sign in. user is optional, and if provided, all attributes within it are optional
 	//
 	// The roles parameter is an optional list of the user's roles for users that
 	// aren't associated with a tenant, while the tenants parameter can be used
@@ -52,7 +52,8 @@ type User interface {
 	// Create a new test user.
 	//
 	// The loginID is required and will determine what the user will use to
-	// sign in, make sure the login id is unique for test. All other fields are optional.
+	// sign in, make sure the login id is unique for test. user is optional, and if provided,
+	// all attributes within it are optional
 	//
 	// You can later generate OTP, Magic link and enchanted link to use in the test without the need
 	// of 3rd party messaging services

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -105,19 +105,19 @@ func (m *MockSSO) ConfigureMapping(tenantID string, roleMappings []*descope.Role
 // Mock User
 
 type MockUser struct {
-	CreateAssert   func(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant)
+	CreateAssert   func(loginID string, user *descope.UserRequest)
 	CreateResponse *descope.UserResponse
 	CreateError    error
 
-	CreateTestUserAssert   func(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant)
+	CreateTestUserAssert   func(loginID string, user *descope.UserRequest)
 	CreateTestUserResponse *descope.UserResponse
 	CreateTestUserError    error
 
-	InviteAssert   func(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant)
+	InviteAssert   func(loginID string, user *descope.UserRequest)
 	InviteResponse *descope.UserResponse
 	InviteError    error
 
-	UpdateAssert   func(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant)
+	UpdateAssert   func(loginID string, user *descope.UserRequest)
 	UpdateResponse *descope.UserResponse
 	UpdateError    error
 
@@ -193,30 +193,30 @@ type MockUser struct {
 	GenerateEnchantedLinkForTestUserError              error
 }
 
-func (m *MockUser) Create(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error) {
+func (m *MockUser) Create(loginID string, user *descope.UserRequest) (*descope.UserResponse, error) {
 	if m.CreateAssert != nil {
-		m.CreateAssert(loginID, email, phone, displayName, roles, tenants)
+		m.CreateAssert(loginID, user)
 	}
 	return m.CreateResponse, m.CreateError
 }
 
-func (m *MockUser) CreateTestUser(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error) {
+func (m *MockUser) CreateTestUser(loginID string, user *descope.UserRequest) (*descope.UserResponse, error) {
 	if m.CreateTestUserAssert != nil {
-		m.CreateTestUserAssert(loginID, email, phone, displayName, roles, tenants)
+		m.CreateTestUserAssert(loginID, user)
 	}
 	return m.CreateTestUserResponse, m.CreateTestUserError
 }
 
-func (m *MockUser) Invite(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error) {
+func (m *MockUser) Invite(loginID string, user *descope.UserRequest) (*descope.UserResponse, error) {
 	if m.InviteAssert != nil {
-		m.InviteAssert(loginID, email, phone, displayName, roles, tenants)
+		m.InviteAssert(loginID, user)
 	}
 	return m.InviteResponse, m.InviteError
 }
 
-func (m *MockUser) Update(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) (*descope.UserResponse, error) {
+func (m *MockUser) Update(loginID string, user *descope.UserRequest) (*descope.UserResponse, error) {
 	if m.UpdateAssert != nil {
-		m.UpdateAssert(loginID, email, phone, displayName, roles, tenants)
+		m.UpdateAssert(loginID, user)
 	}
 	return m.UpdateResponse, m.UpdateError
 }

--- a/descope/tests/mocks/mgmt/managementmock_test.go
+++ b/descope/tests/mocks/mgmt/managementmock_test.go
@@ -16,7 +16,7 @@ func TestMockManagement(t *testing.T) {
 	descopeClient := client.DescopeClient{
 		Management: &MockManagement{
 			MockUser: &MockUser{
-				CreateAssert: func(loginID, email, phone, displayName string, roles []string, tenants []*descope.AssociatedTenant) {
+				CreateAssert: func(loginID string, user *descope.UserRequest) {
 					called = true
 					assert.EqualValues(t, expectedLoginID, loginID)
 				},
@@ -26,7 +26,7 @@ func TestMockManagement(t *testing.T) {
 		},
 	}
 	assert.NotNil(t, descopeClient.Management)
-	r, err := descopeClient.Management.User().Create(expectedLoginID, "", "", "", nil, nil)
+	r, err := descopeClient.Management.User().Create(expectedLoginID, &descope.UserRequest{})
 	require.NoError(t, err)
 	assert.EqualValues(t, expectedLoginID, r.UserID)
 	assert.True(t, called)

--- a/descope/types.go
+++ b/descope/types.go
@@ -2,6 +2,7 @@ package descope
 
 import (
 	"strings"
+	"time"
 
 	"github.com/descope/go-sdk/descope/logger"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -194,17 +195,30 @@ type User struct {
 	Email string `json:"email,omitempty"`
 }
 
+type UserRequest struct {
+	User             `json:",inline"`
+	Roles            []string            `json:"roles,omitempty"`
+	Tenants          []*AssociatedTenant `json:"tenants,omitempty"`
+	CustomAttributes map[string]any      `json:"customAttributes,omitempty"`
+}
+
 type UserResponse struct {
-	User          `json:",inline"`
-	UserID        string              `json:"userId,omitempty"`
-	LoginIDs      []string            `json:"loginIds,omitempty"`
-	VerifiedEmail bool                `json:"verifiedEmail,omitempty"`
-	VerifiedPhone bool                `json:"verifiedPhone,omitempty"`
-	RoleNames     []string            `json:"roleNames,omitempty"`
-	UserTenants   []*AssociatedTenant `json:"userTenants,omitempty"`
-	Status        string              `json:"status,omitempty"`
-	Picture       string              `json:"picture,omitempty"`
-	Test          bool                `json:"test,omitempty"`
+	User             `json:",inline"`
+	UserID           string              `json:"userId,omitempty"`
+	LoginIDs         []string            `json:"loginIds,omitempty"`
+	VerifiedEmail    bool                `json:"verifiedEmail,omitempty"`
+	VerifiedPhone    bool                `json:"verifiedPhone,omitempty"`
+	RoleNames        []string            `json:"roleNames,omitempty"`
+	UserTenants      []*AssociatedTenant `json:"userTenants,omitempty"`
+	Status           string              `json:"status,omitempty"`
+	Picture          string              `json:"picture,omitempty"`
+	Test             bool                `json:"test,omitempty"`
+	CustomAttributes map[string]any      `json:"customAttributes,omitempty"`
+	CreatedTime      int32               `json:"createdTime,omitempty"`
+}
+
+func (ur *UserResponse) GetCreatedTime() time.Time {
+	return time.Unix(int64(ur.CreatedTime), 0)
 }
 
 type AccessKeyResponse struct {
@@ -255,6 +269,11 @@ type Role struct {
 	Name            string   `json:"name"`
 	Description     string   `json:"description,omitempty"`
 	PermissionNames []string `json:"permissionNames,omitempty"`
+	CreatedTime     int32    `json:"createdTime,omitempty"`
+}
+
+func (r *Role) GetCreatedTime() time.Time {
+	return time.Unix(int64(r.CreatedTime), 0)
 }
 
 // Options for searching and filtering users

--- a/descope/types_test.go
+++ b/descope/types_test.go
@@ -81,3 +81,13 @@ func TestNewTokenWithProjectID(t *testing.T) {
 	assert.EqualValues(t, 0, resToken.RefreshExpiration)
 	assert.EqualValues(t, expiration.Unix(), resToken.Expiration)
 }
+
+func TestGetCreatedTime(t *testing.T) {
+	now := time.Now()
+	ct := now.Unix()
+	now = time.Unix(ct, 0)
+	u := UserResponse{CreatedTime: int32(ct)}
+	assert.True(t, u.GetCreatedTime().Equal(now))
+	r := Role{CreatedTime: int32(ct)}
+	assert.True(t, r.GetCreatedTime().Equal(now))
+}

--- a/examples/importusers/main.go
+++ b/examples/importusers/main.go
@@ -76,7 +76,9 @@ func main() {
 			tenants = append(tenants, &descope.AssociatedTenant{TenantID: curr.TenantID, Roles: curr.Roles})
 		}
 
-		res, err := descopeClient.Management.User().Create(user.LoginID, user.Email, user.Phone, user.DisplayName, user.Roles, tenants)
+		userReq := &descope.UserRequest{}
+		userReq.Email, userReq.Phone, userReq.Name, userReq.Roles, userReq.Tenants = user.Email, user.Phone, user.DisplayName, user.Roles, tenants
+		res, err := descopeClient.Management.User().Create(user.LoginID, userReq)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error adding user:", err)
 		} else {

--- a/examples/managementcli/main.go
+++ b/examples/managementcli/main.go
@@ -48,7 +48,12 @@ func userCreate(args []string) error {
 	for _, tenantID := range flags.Tenants {
 		tenants = append(tenants, &descope.AssociatedTenant{TenantID: tenantID})
 	}
-	_, err := descopeClient.Management.User().Create(args[0], flags.Email, flags.Phone, flags.Name, nil, tenants)
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	user.Phone = flags.Phone
+	user.Name = flags.Name
+	user.Tenants = tenants
+	_, err := descopeClient.Management.User().Create(args[0], user)
 	return err
 }
 
@@ -57,7 +62,13 @@ func userUpdate(args []string) error {
 	for _, tenantID := range flags.Tenants {
 		tenants = append(tenants, &descope.AssociatedTenant{TenantID: tenantID})
 	}
-	_, err := descopeClient.Management.User().Update(args[0], flags.Email, flags.Phone, flags.Name, nil, tenants)
+	user := &descope.UserRequest{}
+	user.Email = "foo@bar.com"
+	user.Phone = flags.Phone
+	user.Name = flags.Name
+	user.Tenants = tenants
+
+	_, err := descopeClient.Management.User().Update(args[0], user)
 	return err
 }
 


### PR DESCRIPTION
So one can now create/update/invite a user and have the custom attributes already in place
Assuming those were configured already in the Descope console 
Export the user and role createTime
related to https://github.com/descope/etc/issues/2450
related to https://github.com/descope/etc/issues/299


This PR will break compilation comparing to previous versions