### PR TITLE
fix: github token

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,9 +1,9 @@
 name: Lint and more checks
-description: 'Lint and more checks'
+description: "Lint and more checks"
 inputs:
   go_version:
-    description: 'Go version to use'
-    required: truexR
+    description: "Go version to use"
+    required: true
 runs:
   using: "composite"
   steps:

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -7,6 +7,9 @@ inputs:
   go_version:
     description: "Go version to use"
     required: true
+  token:
+    description: "Github token"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -37,4 +40,4 @@ runs:
         type: lcov
         result_path: coverage.lcov
         min_coverage: ${{ inputs.min_coverage }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ inputs.token }}

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -1,11 +1,11 @@
 name: Run Tests
-description: 'Run Tests'
+description: "Run Tests"
 inputs:
   min_coverage:
-    description: 'Minimum coverage'
+    description: "Minimum coverage"
     required: true
   go_version:
-    description: 'Go version to use'
+    description: "Go version to use"
     required: true
 runs:
   using: "composite"
@@ -37,4 +37,4 @@ runs:
         type: lcov
         result_path: coverage.lcov
         min_coverage: ${{ inputs.min_coverage }}
-        token: ${{ github.token }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           go_version: ${{ env.GO_VERSION }}
           min_coverage: 100
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request]
 
 env:
   GO_VERSION: 1.18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 env:
   GO_VERSION: 1.18


### PR DESCRIPTION
`{{ github.token }}` is only available in job `steps` and not available in action `with:` so this action fails when running with a non-privileged user.

This fix replaces the use of `github` context with `secrets.GITHUB_TOKEN` which is always available

also fixed other action linting issues 

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context:~:text=token%20authentication.%22-,Note%3A%20This%20context%20property%20is%20set%20by%20the%20Actions%20runner%2C%20and%20is%20only%20available%20within%20the%20execution%20steps%20of%20a%20job.%20Otherwise%2C%20the%20value%20of%20this%20property%20will%20be%20null.,-github.triggering_actor