### PR TITLE
Check associated tenant before checking roles/permissions

### DIFF
--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -346,6 +346,9 @@ func (auth *authenticationService) ValidatePermissions(token *descope.Token, per
 }
 
 func (auth *authenticationService) ValidateTenantPermissions(token *descope.Token, tenant string, permissions []string) bool {
+	if tenant != "" && !isAssociatedWithTenant(token, tenant) {
+		return false
+	}
 	granted := getAuthorizationClaimItems(token, tenant, claimPermissions)
 	for i := range permissions {
 		if !slices.Contains(granted, permissions[i]) {
@@ -360,6 +363,9 @@ func (auth *authenticationService) ValidateRoles(token *descope.Token, roles []s
 }
 
 func (auth *authenticationService) ValidateTenantRoles(token *descope.Token, tenant string, roles []string) bool {
+	if tenant != "" && !isAssociatedWithTenant(token, tenant) {
+		return false
+	}
 	membership := getAuthorizationClaimItems(token, tenant, claimRoles)
 	for i := range roles {
 		if !slices.Contains(membership, roles[i]) {
@@ -684,6 +690,11 @@ func getAuthorizationClaimItems(token *descope.Token, tenant string, claim strin
 	}
 
 	return items
+}
+
+func isAssociatedWithTenant(token *descope.Token, tenant string) bool {
+	ts := token.GetTenants()
+	return slices.Contains(ts, tenant)
 }
 
 func getPendingRefFromResponse(httpResponse *api.HTTPResponse) (*descope.EnchantedLinkResponse, error) {

--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -693,8 +693,7 @@ func getAuthorizationClaimItems(token *descope.Token, tenant string, claim strin
 }
 
 func isAssociatedWithTenant(token *descope.Token, tenant string) bool {
-	ts := token.GetTenants()
-	return slices.Contains(ts, tenant)
+	return slices.Contains(token.GetTenants(), tenant)
 }
 
 func getPendingRefFromResponse(httpResponse *api.HTTPResponse) (*descope.EnchantedLinkResponse, error) {

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -56,7 +56,7 @@ var (
 	permissions                  = []interface{}{"foo", "bar"}
 	roles                        = []interface{}{"abc", "xyz"}
 	mockAuthorizationToken       = &descope.Token{Claims: map[string]any{claimPermissions: permissions, claimRoles: roles}}
-	mockAuthorizationTenantToken = &descope.Token{Claims: map[string]any{descope.ClaimAuthorizedTenants: map[string]any{"kuku": mockAuthorizationToken.Claims}}}
+	mockAuthorizationTenantToken = &descope.Token{Claims: map[string]any{descope.ClaimAuthorizedTenants: map[string]any{"kuku": mockAuthorizationToken.Claims, "t1": map[string]any{}}}}
 )
 
 func readBodyMap(r *http.Request) (m map[string]interface{}, err error) {
@@ -857,7 +857,7 @@ func TestValidatePermissions(t *testing.T) {
 	require.False(t, a.ValidatePermissions(mockAuthorizationTenantToken, []string{"foo", "bar"}))
 	require.False(t, a.ValidatePermissions(mockAuthorizationTenantToken, []string{"foo", "bar", "qux"}))
 
-	require.True(t, a.ValidateTenantPermissions(mockAuthorizationToken, "kuku", []string{}))
+	require.False(t, a.ValidateTenantPermissions(mockAuthorizationToken, "kuku", []string{}))
 	require.False(t, a.ValidateTenantPermissions(mockAuthorizationToken, "kuku", []string{"foo"}))
 	require.False(t, a.ValidateTenantPermissions(mockAuthorizationToken, "kuku", []string{"foo", "bar"}))
 	require.False(t, a.ValidateTenantPermissions(mockAuthorizationToken, "kuku", []string{"foo", "bar", "qux"}))
@@ -866,6 +866,9 @@ func TestValidatePermissions(t *testing.T) {
 	require.True(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "kuku", []string{"foo"}))
 	require.True(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "kuku", []string{"foo", "bar"}))
 	require.False(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "kuku", []string{"foo", "bar", "qux"}))
+
+	require.True(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "t1", []string{}))
+	require.False(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "t2", []string{}))
 }
 
 func TestValidateRoles(t *testing.T) {
@@ -885,7 +888,7 @@ func TestValidateRoles(t *testing.T) {
 	require.False(t, a.ValidateRoles(mockAuthorizationTenantToken, []string{"abc", "xyz"}))
 	require.False(t, a.ValidateRoles(mockAuthorizationTenantToken, []string{"abc", "xyz", "tuv"}))
 
-	require.True(t, a.ValidateTenantRoles(mockAuthorizationToken, "kuku", []string{}))
+	require.False(t, a.ValidateTenantRoles(mockAuthorizationToken, "kuku", []string{}))
 	require.False(t, a.ValidateTenantRoles(mockAuthorizationToken, "kuku", []string{"abc"}))
 	require.False(t, a.ValidateTenantRoles(mockAuthorizationToken, "kuku", []string{"abc", "xyz"}))
 	require.False(t, a.ValidateTenantRoles(mockAuthorizationToken, "kuku", []string{"abc", "xyz", "tuv"}))
@@ -894,6 +897,9 @@ func TestValidateRoles(t *testing.T) {
 	require.True(t, a.ValidateTenantRoles(mockAuthorizationTenantToken, "kuku", []string{"abc"}))
 	require.True(t, a.ValidateTenantRoles(mockAuthorizationTenantToken, "kuku", []string{"abc", "xyz"}))
 	require.False(t, a.ValidateTenantRoles(mockAuthorizationTenantToken, "kuku", []string{"abc", "xyz", "tuv"}))
+
+	require.True(t, a.ValidateTenantRoles(mockAuthorizationTenantToken, "t1", []string{}))
+	require.False(t, a.ValidateTenantRoles(mockAuthorizationTenantToken, "t2", []string{}))
 }
 
 func TestMe(t *testing.T) {

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -869,6 +869,15 @@ func TestValidatePermissions(t *testing.T) {
 
 	require.True(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "t1", []string{}))
 	require.False(t, a.ValidateTenantPermissions(mockAuthorizationTenantToken, "t2", []string{}))
+	// check when the value of the claim is not a map
+	require.False(t, a.ValidateTenantPermissions(
+		&descope.Token{Claims: map[string]any{
+			descope.ClaimAuthorizedTenants: map[string]interface{}{"t1": true},
+		}},
+		"t1",
+		[]string{"foo"},
+	))
+
 }
 
 func TestValidateRoles(t *testing.T) {


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/3104

## Description
Ensure that the user is associated to tenant before checking roles/permissions