### PR TITLE
Support domain and redirectURL field when updating SSO metadata URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ domain := "domain.com" // Users logging in from this domain will be logged in to
 err := descopeClient.Management.SSO().ConfigureSettings(tenantID, idpURL, entityID, idpCert, redirectURL, domain)
 
 // Alternatively, configure using an SSO metadata URL
-err := descopeClient.Management.SSO().ConfigureMetadata(tenantID, "https://idp.com/my-idp-metadata")
+err := descopeClient.Management.SSO().ConfigureMetadata(tenantID, "https://idp.com/my-idp-metadata", redirectURL, domain)
 
 // Map IDP groups to Descope roles, or map user attributes.
 // This function overrides any previous mapping (even when empty). Use carefully.

--- a/descope/internal/mgmt/sso.go
+++ b/descope/internal/mgmt/sso.go
@@ -63,7 +63,7 @@ func (s *sso) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL
 	return err
 }
 
-func (s *sso) ConfigureMetadata(tenantID, idpMetadataURL string) error {
+func (s *sso) ConfigureMetadata(tenantID, idpMetadataURL, redirectURL, domain string) error {
 	if tenantID == "" {
 		return utils.NewInvalidArgumentError("tenantID")
 	}
@@ -73,6 +73,8 @@ func (s *sso) ConfigureMetadata(tenantID, idpMetadataURL string) error {
 	req := map[string]any{
 		"tenantId":       tenantID,
 		"idpMetadataURL": idpMetadataURL,
+		"redirectURL":    redirectURL,
+		"domain":         domain,
 	}
 	_, err := s.client.DoPostRequest(api.Routes.ManagementSSOMetadata(), req, nil, s.conf.ManagementKey)
 	return err

--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -145,16 +145,18 @@ func TestSSOConfigureMetadataSuccess(t *testing.T) {
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "abc", req["tenantId"])
 		require.Equal(t, "http://idpURL", req["idpMetadataURL"])
+		require.Equal(t, "https://redirect", req["redirectURL"])
+		require.Equal(t, "domain.com", req["domain"])
 	}))
-	err := mgmt.SSO().ConfigureMetadata("abc", "http://idpURL")
+	err := mgmt.SSO().ConfigureMetadata("abc", "http://idpURL", "https://redirect", "domain.com")
 	require.NoError(t, err)
 }
 
 func TestSSOConfigureMetadataError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.SSO().ConfigureMetadata("", "http://idpURL")
+	err := mgmt.SSO().ConfigureMetadata("", "http://idpURL", "https://redirect", "domain.com")
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureMetadata("abc", "")
+	err = mgmt.SSO().ConfigureMetadata("abc", "", "https://redirect", "domain.com")
 	require.Error(t, err)
 }
 

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -270,7 +270,8 @@ type SSO interface {
 
 	// tenantID is required.
 	DeleteSettings(tenantID string) error
-	// Configure SSO setting for a tenant manually.
+
+	// Configure SSO settings for a tenant manually.
 	//
 	// tenantID, idpURL, idpCert, entityID, are required. The idpURL is the URL for the identity provider and idpCert
 	// is the certificated provided by the identity provider.
@@ -278,8 +279,11 @@ type SSO interface {
 	// domain is optional, it is used to map users to this tenant when authenticating via SSO.
 	ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL, domain string) error
 
-	// Configure SSO setting for a tenant by fetching SSO settings from an IDP metadata URL.
-	ConfigureMetadata(tenantID, idpMetadataURL string) error
+	// Configure SSO settings for a tenant by fetching them from an IDP metadata URL.
+	//
+	// redirectURL is optional, however if not given it has to be set when starting an SSO authentication via the request.
+	// domain is optional, it is used to map users to this tenant when authenticating via SSO.
+	ConfigureMetadata(tenantID, idpMetadataURL, redirectURL, domain string) error
 
 	// Configure SSO IDP mapping including groups to the Descope roles and user attributes.
 	ConfigureMapping(tenantID string, roleMappings []*descope.RoleMapping, attributeMapping *descope.AttributeMapping) error

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -278,14 +278,19 @@ type SSO interface {
 	//
 	// tenantID, idpURL, idpCert, entityID, are required. The idpURL is the URL for the identity provider and idpCert
 	// is the certificated provided by the identity provider.
+	//
 	// redirectURL is optional, however if not given it has to be set when starting an SSO authentication via the request.
 	// domain is optional, it is used to map users to this tenant when authenticating via SSO.
+	//
+	// Both optional values will override whatever is currently set even if left empty.
 	ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirectURL, domain string) error
 
 	// Configure SSO settings for a tenant by fetching them from an IDP metadata URL.
 	//
 	// redirectURL is optional, however if not given it has to be set when starting an SSO authentication via the request.
 	// domain is optional, it is used to map users to this tenant when authenticating via SSO.
+	//
+	// Both optional values will override whatever is currently set even if left empty.
 	ConfigureMetadata(tenantID, idpMetadataURL, redirectURL, domain string) error
 
 	// Configure SSO IDP mapping including groups to the Descope roles and user attributes.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -86,7 +86,7 @@ type MockSSO struct {
 	ConfigureSettingsAssert func(tenantID, idpURL, idpCert, entityID, redirectURL, domain string)
 	ConfigureSettingsError  error
 
-	ConfigureMetadataAssert func(tenantID, idpMetadataURL string)
+	ConfigureMetadataAssert func(tenantID, idpMetadataURL, redirectURL, domain string)
 	ConfigureMetadataError  error
 
 	ConfigureMappingAssert func(tenantID string, roleMappings []*descope.RoleMapping, attributeMapping *descope.AttributeMapping)
@@ -114,9 +114,9 @@ func (m *MockSSO) ConfigureSettings(tenantID, idpURL, idpCert, entityID, redirec
 	return m.ConfigureSettingsError
 }
 
-func (m *MockSSO) ConfigureMetadata(tenantID, idpMetadataURL string) error {
+func (m *MockSSO) ConfigureMetadata(tenantID, idpMetadataURL, redirectURL, domain string) error {
 	if m.ConfigureMetadataAssert != nil {
-		m.ConfigureMetadataAssert(tenantID, idpMetadataURL)
+		m.ConfigureMetadataAssert(tenantID, idpMetadataURL, redirectURL, domain)
 	}
 	return m.ConfigureMetadataError
 }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/go-sdk/issues/293

## Description
- Adds the two parameters from `ConfigureSettings` to also be available in `ConfigureMetadata`
- Requires backend support before this is usable in production
- This is a minor **_BREAKING CHANGE_** - existing code that calls `ConfigureMetadata` fail compilation until the values for the two new parameters are provided.

## Must
- [X] Tests
- [X] Documentation (if applicable)
