### PR TITLE
Replace password session

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Alternatively, it is also possible to replace an existing active password with a
 
 ```go
 // Replaces the user's current password with a new one
-err := descopeClient.Auth.Password().ReplaceUserPassword(loginID, oldPassword, newPassword)
+authInfo, err := descopeClient.Auth.Password().ReplaceUserPassword(loginID, oldPassword, newPassword. w)
 ```
 
 ### Session Validation
@@ -637,7 +637,7 @@ authInfo, err := descopeClient.Auth.Password().SignIn("<login-id>", "<some-passw
 if err != nil {
      if errors.Is(err, descope.ErrPasswordExpired) {
         // Handle a case when the error is expired, the user should replace/reset the password
-        // Use descopeClient.Auth.Password().ReplaceUserPassword("<login-id>", "<some-password>", "<new-password>")
+        // Use descopeClient.Auth.Password().ReplaceUserPassword("<login-id>", "<some-password>", "<new-password>", w)
      }
      // Handle other errors
 }

--- a/descope/internal/auth/password.go
+++ b/descope/internal/auth/password.go
@@ -66,16 +66,16 @@ func (auth *password) UpdateUserPassword(loginID, newPassword string, r *http.Re
 	return nil
 }
 
-func (auth *password) ReplaceUserPassword(loginID, oldPassword, newPassword string) error {
+func (auth *password) ReplaceUserPassword(loginID, oldPassword, newPassword string, w http.ResponseWriter) (*descope.AuthenticationInfo, error) {
 	if loginID == "" {
-		return utils.NewInvalidArgumentError("loginID")
+		return nil, utils.NewInvalidArgumentError("loginID")
 	}
 
-	_, err := auth.client.DoPostRequest(api.Routes.ReplaceUserPassword(), authenticationPasswordReplaceRequestBody{LoginID: loginID, OldPassword: oldPassword, NewPassword: newPassword}, nil, "")
+	res, err := auth.client.DoPostRequest(api.Routes.ReplaceUserPassword(), authenticationPasswordReplaceRequestBody{LoginID: loginID, OldPassword: oldPassword, NewPassword: newPassword}, nil, "")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return auth.generateAuthenticationInfo(res, w)
 }
 
 func (auth *password) GetPasswordPolicy() (*descope.PasswordPolicy, error) {

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -166,7 +166,7 @@ type Password interface {
 	// password will be updated to newPassword.
 	// NewPassword must conform to the password policy defined in the password settings
 	// in the Descope console.
-	ReplaceUserPassword(loginID, oldPassword, newPassword string) error
+	ReplaceUserPassword(loginID, oldPassword, newPassword string, w http.ResponseWriter) (*descope.AuthenticationInfo, error)
 
 	// GetPasswordPolicy - fetch the rules for valid passwords configured in the policy
 	// in the Descope console. This can be used to implement client-side validation of new

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -181,7 +181,7 @@ type User interface {
 
 	// Expire the password for the given login ID.
 	// Note: user sign-in with an expired password, the user will get `errors.ErrPasswordExpired` error.
-	// Use the `ResetPassword` or `ReplacePassword` methods to reset/replace the password.
+	// Use the `SendPasswordReset` or `ReplaceUserPassword` methods to reset/replace the password.
 	ExpirePassword(loginID string) error
 
 	// Get the provider token for the given login ID.

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -304,8 +304,9 @@ type MockPassword struct {
 	UpdateAssert func(loginID, newPassword string, r *http.Request)
 	UpdateError  error
 
-	ReplaceAssert func(loginID, oldPassword, newPassword string)
-	ReplaceError  error
+	ReplaceAssert   func(loginID, oldPassword, newPassword string, w http.ResponseWriter)
+	ReplaceError    error
+	ReplaceResponse *descope.AuthenticationInfo
 
 	PolicyResponse *descope.PasswordPolicy
 	PolicyError    error
@@ -339,11 +340,11 @@ func (m *MockPassword) UpdateUserPassword(loginID, newPassword string, r *http.R
 	return m.ResetError
 }
 
-func (m *MockPassword) ReplaceUserPassword(loginID, oldPassword, newPassword string) error {
+func (m *MockPassword) ReplaceUserPassword(loginID, oldPassword, newPassword string, w http.ResponseWriter) (*descope.AuthenticationInfo, error) {
 	if m.ReplaceAssert != nil {
-		m.ReplaceAssert(loginID, oldPassword, newPassword)
+		m.ReplaceAssert(loginID, oldPassword, newPassword, w)
 	}
-	return m.ResetError
+	return m.ReplaceResponse, m.ReplaceError
 }
 
 func (m *MockPassword) GetPasswordPolicy() (*descope.PasswordPolicy, error) {


### PR DESCRIPTION
## Description
related to https://github.com/descope/etc/issues/3800
Change `ReplaceUserPassword` func signature to support the returned authentication info
 - receive a response writer argument (`w`)
 - return an authentication info (`*descope.AuthenticationInfo`)
 
 
 noting that this breaks usage compilation, based on some discussions we conclude to:
  - communicate that in next release note
  - should not consider this as a major version
  
if we agree on that, I will communicate this forward to relevant ppl in team