### PR TITLE
Add support for new WebAuthn and Password user auth method flags

### DIFF
--- a/descope/types.go
+++ b/descope/types.go
@@ -294,6 +294,8 @@ type UserResponse struct {
 	CustomAttributes map[string]any      `json:"customAttributes,omitempty"`
 	CreatedTime      int32               `json:"createdTime,omitempty"`
 	TOTP             bool                `json:"totp,omitempty"`
+	WebAuthn         bool                `json:"webauthn,omitempty"`
+	Password         bool                `json:"password,omitempty"`
 	SAML             bool                `json:"saml,omitempty"`
 	OAuth            map[string]bool     `json:"oauth,omitempty"`
 }


### PR DESCRIPTION
## Description
- Add `WebAuthn` and `Password` boolean flags to the `UserResponse` struct that mark if the user can authenticate with theses methods

## Must
- [X] Tests
- [X] Documentation (if applicable)
