### PR TITLE
Add the ability to specify invite type

### DIFF
--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -416,7 +416,15 @@ func makeCreateUserRequest(loginID, email, phone, displayName, picture string, r
 		req["test"] = true
 	}
 	if options != nil {
-		req["inviteUrl"] = options.InviteURL
+		if len(options.InviteURL) > 0 {
+			req["inviteUrl"] = options.InviteURL
+		}
+		if options.SendMail != nil {
+			req["sendMail"] = *options.SendMail
+		}
+		if options.SendSMS != nil {
+			req["sendSMS"] = *options.SendSMS
+		}
 	}
 	return req
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -262,6 +262,8 @@ func NewToken(JWT string, token jwt.Token) *Token {
 
 type InviteOptions struct {
 	InviteURL string `json:"inviteUrl,omitempty"`
+	SendMail  *bool  `json:"sendMail,omitempty"` // send invite via mail, default is according to project settings
+	SendSMS   *bool  `json:"sendSMS,omitempty"`  // send invite via text message, default is according to project settings
 }
 
 type User struct {


### PR DESCRIPTION
## Description
Add the ability to specify invite type - Email / SMS

Related to: https://github.com/descope/etc/issues/4542

## Must
- [x] Tests
- [x] Documentation (if applicable)
