### PR TITLE
Fixed syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ u2.Email = "two@two.com"
 u2.Roles = []string{"two"}
 
 batchUsers = append(batchUsers, u1, u2)
-err := descopeClient.Management.User().InviteBatch(batchUsers, options)
+users, err := descopeClient.Management.User().InviteBatch(batchUsers, options)
 
 // Update will override all fields as is. Use carefully.
 userReqUpdate := &descope.UserRequest{}


### PR DESCRIPTION
## Description
Fixed syntax error in readme

![image](https://github.com/descope/go-sdk/assets/42780533/fa7290d7-1be7-49a4-956f-d59d0ea857bb)


## Must
- [ ] Tests
- [ ] Documentation (if applicable)
