### PR TITLE
Add user import API

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -83,6 +83,7 @@ var (
 			userUpdate:                       "mgmt/user/update",
 			userDelete:                       "mgmt/user/delete",
 			userDeleteAllTestUsers:           "mgmt/user/test/delete/all",
+			userImport:                       "mgmt/user/import",
 			userLoad:                         "mgmt/user",
 			userSearchAll:                    "mgmt/user/search",
 			userUpdateStatus:                 "mgmt/user/update/status",
@@ -225,6 +226,7 @@ type mgmtEndpoints struct {
 	userUpdate                string
 	userDelete                string
 	userDeleteAllTestUsers    string
+	userImport                string
 	userLoad                  string
 	userSearchAll             string
 	userUpdateStatus          string
@@ -484,6 +486,10 @@ func (e *endpoints) ManagementUserDelete() string {
 
 func (e *endpoints) ManagementUserDeleteAllTestUsers() string {
 	return path.Join(e.version, e.mgmt.userDeleteAllTestUsers)
+}
+
+func (e *endpoints) ManagementUserImport() string {
+	return path.Join(e.version, e.mgmt.userImport)
 }
 
 func (e *endpoints) ManagementUserLoad() string {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -110,6 +110,15 @@ type User interface {
 	// IMPORTANT: This action is irreversible. Use carefully.
 	DeleteAllTestUsers() error
 
+	// Imports a batch of users and/or password hashes.
+	//
+	// This API is intentionally loosely specified to support multiple types of sources,
+	// and the exact format of the data and the supported features differ depending on
+	// which source the data is from.
+	//
+	// Note that there's a limit on the number of users that can be imported in each batch.
+	Import(source string, users, hashes []byte, dryrun bool) (*descope.UserImportResponse, error)
+
 	// Load an existing user.
 	//
 	// The loginID is required and the user will be fetched according to it.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -167,6 +167,10 @@ type MockUser struct {
 	DeleteAllTestUsersAssert func()
 	DeleteAllTestUsersError  error
 
+	ImportAssert   func(source string, users, hashes []byte, dryrun bool)
+	ImportResponse *descope.UserImportResponse
+	ImportError    error
+
 	LoadAssert   func(loginID string)
 	LoadResponse *descope.UserResponse
 	LoadError    error
@@ -309,6 +313,13 @@ func (m *MockUser) DeleteAllTestUsers() error {
 		m.DeleteAllTestUsersAssert()
 	}
 	return m.DeleteAllTestUsersError
+}
+
+func (m *MockUser) Import(source string, users, hashes []byte, dryrun bool) (*descope.UserImportResponse, error) {
+	if m.ImportAssert != nil {
+		m.ImportAssert(source, users, hashes, dryrun)
+	}
+	return m.ImportResponse, m.ImportError
 }
 
 func (m *MockUser) Load(loginID string) (*descope.UserResponse, error) {

--- a/descope/types.go
+++ b/descope/types.go
@@ -439,6 +439,16 @@ const (
 	UserStatusInvited  UserStatus = "invited"
 )
 
+type UserImportResponse struct {
+	Users    []*UserResponse      `json:"users,omitempty"`
+	Failures []*UserImportFailure `json:"failures,omitempty"`
+}
+
+type UserImportFailure struct {
+	User   string `json:"user"`
+	Reason string `json:"reason"`
+}
+
 type GroupMember struct {
 	LoginID string `json:"loginID,omitempty"`
 	UserID  string `json:"userId,omitempty"`


### PR DESCRIPTION
## Description
- Expose user import API (`mgmt/user/import`) for direct use in manual imports or via the `migrate` command line tool

## Must
- [X] Tests
- [X] Documentation (if applicable)
