### PR TITLE
Skip certificate validation only for development server baseURLs

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -1078,15 +1078,13 @@ func (mode CertificateVerifyMode) SkipVerifyValue(baseURL string) bool {
 	if mode == CertificateVerifyNever {
 		return true
 	}
-	url, err := urlpkg.Parse(baseURL)
-	if err != nil {
-		return false
-	}
-	if url.Hostname() == "localhost" || url.Port() != "" {
-		return true
-	}
-	if ip := net.ParseIP(url.Hostname()); ip != nil {
-		return true
+	if url, err := urlpkg.Parse(baseURL); err == nil {
+		if url.Hostname() == "localhost" || url.Port() != "" {
+			return true
+		}
+		if ip := net.ParseIP(url.Hostname()); ip != nil {
+			return true
+		}
 	}
 	return false
 }

--- a/descope/api/client_test.go
+++ b/descope/api/client_test.go
@@ -255,7 +255,8 @@ func TestRoutesSignInOTP(t *testing.T) {
 func TestSkipVerifyValue(t *testing.T) {
 	require.True(t, CertificateVerifyNever.SkipVerifyValue("foo"))
 	require.False(t, CertificateVerifyAlways.SkipVerifyValue("foo"))
-	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue("https://api.descope.com"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(defaultURL))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(defaultURL+"/v1/auth"))
 	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(" http"))
 	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://localhost"))
 	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://127.0.0.1"))

--- a/descope/api/client_test.go
+++ b/descope/api/client_test.go
@@ -251,3 +251,13 @@ func TestRoutesSignInOTP(t *testing.T) {
 	r := Routes.SignInOTP()
 	assert.EqualValues(t, "/v1/auth/otp/signin", r)
 }
+
+func TestSkipVerifyValue(t *testing.T) {
+	require.True(t, CertificateVerifyNever.SkipVerifyValue("foo"))
+	require.False(t, CertificateVerifyAlways.SkipVerifyValue("foo"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue("https://api.descope.com"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(" http"))
+	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://localhost"))
+	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://127.0.0.1"))
+	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://example.com:8443"))
+}

--- a/descope/client/client.go
+++ b/descope/client/client.go
@@ -49,7 +49,13 @@ func NewWithConfig(config *Config) (*DescopeClient, error) {
 	}
 	config.setManagementKey()
 
-	c := api.NewClient(api.ClientParams{BaseURL: config.DescopeBaseURL, CustomDefaultHeaders: config.CustomDefaultHeaders, DefaultClient: config.DefaultClient, ProjectID: config.ProjectID, VerifyServerCertificate: config.VerifyServerCertificate})
+	c := api.NewClient(api.ClientParams{
+		ProjectID:            config.ProjectID,
+		BaseURL:              config.DescopeBaseURL,
+		DefaultClient:        config.DefaultClient,
+		CustomDefaultHeaders: config.CustomDefaultHeaders,
+		CertificateVerify:    config.CertificateVerify,
+	})
 
 	authService, err := auth.NewAuth(auth.AuthParams{
 		ProjectID:           config.ProjectID,

--- a/descope/client/config.go
+++ b/descope/client/config.go
@@ -24,8 +24,8 @@ type Config struct {
 	DescopeBaseURL string
 	// DefaultClient (optional, http.DefaultClient) - override the default client used to Do the actual http request.
 	DefaultClient api.IHttpClient
-	// VerifyServerCertificate (optional) - verify the server certificate
-	VerifyServerCertificate bool
+	// CertificateVerifyMode (optional, CertificateVerifyAutomatic) - override the default server certificate verification behavior
+	CertificateVerify api.CertificateVerifyMode
 	// CustomDefaultHeaders (optional, nil) - add custom headers to all requests used to communicate with descope services.
 	CustomDefaultHeaders map[string]string
 	// LogLevel (optional, LogNone) - set a log level (Debug/Info/None) for the sdk to use when logging.


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/descope/etc/issues/4996

## Description
- Change default behavior to only skip certificate validation when overriding the server baseURL with the address of a development environment
- Allow clients to decide to override behavior to always or never validate server certificate

## Must
- [X] Tests
- [X] Documentation (if applicable)
