### PR TITLE
Skip certificate validation for non-domain hostnames by default

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -1085,7 +1085,7 @@ func (mode CertificateVerifyMode) SkipVerifyValue(baseURL string) bool {
 		return true
 	}
 	if url, err := urlpkg.Parse(baseURL); err == nil {
-		if url.Hostname() == "localhost" || url.Port() != "" {
+		if !strings.Contains(url.Hostname(), ".") || url.Port() != "" {
 			return true
 		}
 		if ip := net.ParseIP(url.Hostname()); ip != nil {

--- a/descope/api/client_test.go
+++ b/descope/api/client_test.go
@@ -255,10 +255,14 @@ func TestRoutesSignInOTP(t *testing.T) {
 func TestSkipVerifyValue(t *testing.T) {
 	require.True(t, CertificateVerifyNever.SkipVerifyValue("foo"))
 	require.False(t, CertificateVerifyAlways.SkipVerifyValue("foo"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue("https://.com"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue("https://example.com"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue("http://example.com"))
 	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(defaultURL))
 	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(defaultURL+"/v1/auth"))
-	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(" http"))
+	require.False(t, CertificateVerifyAutomatic.SkipVerifyValue(" http://example.com"))
 	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://localhost"))
+	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://apache/foo"))
 	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://127.0.0.1"))
 	require.True(t, CertificateVerifyAutomatic.SkipVerifyValue("https://example.com:8443"))
 }


### PR DESCRIPTION
## Description
Skip certificate validation for non-domain hostnames by default

## Must
- [X] Tests
- [X] Documentation (if applicable)
