### PR TITLE
Remove redundant Raw suffix from Import/Export function names

### DIFF
--- a/descope/internal/mgmt/project.go
+++ b/descope/internal/mgmt/project.go
@@ -25,7 +25,7 @@ type cloneProjectBody struct {
 	Tag  string `json:"tag"`
 }
 
-func (p *project) ExportRaw(ctx context.Context) (map[string]any, error) {
+func (p *project) Export(ctx context.Context) (map[string]any, error) {
 	body := map[string]any{}
 	res, err := p.client.DoPostRequest(ctx, api.Routes.ManagementProjectExport(), body, nil, p.conf.ManagementKey)
 	if err != nil {
@@ -38,7 +38,7 @@ func (p *project) ExportRaw(ctx context.Context) (map[string]any, error) {
 	return export.Files, nil
 }
 
-func (p *project) ImportRaw(ctx context.Context, files map[string]any) error {
+func (p *project) Import(ctx context.Context, files map[string]any) error {
 	body := projectBody{Files: files}
 	_, err := p.client.DoPostRequest(ctx, api.Routes.ManagementProjectImport(), body, nil, p.conf.ManagementKey)
 	return err

--- a/descope/internal/mgmt/project_test.go
+++ b/descope/internal/mgmt/project_test.go
@@ -9,19 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProjectExportRaw(t *testing.T) {
+func TestProjectExport(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 	}, map[string]any{"files": map[string]any{"foo": "bar"}}))
-	m, err := mgmt.Project().ExportRaw(context.Background())
+	m, err := mgmt.Project().Export(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	require.Equal(t, "bar", m["foo"])
 }
 
-func TestProjectImportRaw(t *testing.T) {
+func TestProjectImport(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		req := map[string]any{}
@@ -30,7 +30,7 @@ func TestProjectImportRaw(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "bar", files["foo"])
 	}))
-	err := mgmt.Project().ImportRaw(context.Background(), map[string]any{"foo": "bar"})
+	err := mgmt.Project().Import(context.Background(), map[string]any{"foo": "bar"})
 	require.NoError(t, err)
 }
 

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -613,21 +613,21 @@ type Flow interface {
 // Provides functions for exporting and importing project settings, flows, styles, etc.
 type Project interface {
 	// Exports all settings and configurations for a project and returns the raw JSON
-	// result as a map.
+	// files response as a map.
 	//
 	// This API is meant to be used via the 'environment' command line tool that can be
 	// found in the '/tools' directory.
-	ExportRaw(ctx context.Context) (map[string]any, error)
+	Export(ctx context.Context) (map[string]any, error)
 
 	// Imports all settings and configurations for a project overriding any current
 	// configuration.
 	//
-	// The input is expected to be a raw JSON map in the same format as the one returned
-	// by calls to ExportRaw.
+	// The input is expected to be a raw JSON map of files in the same format as the one
+	// returned by calls to Export.
 	//
 	// This API is meant to be used via the 'environment' command line tool that can be
 	// found in the '/tools' directory.
-	ImportRaw(ctx context.Context, files map[string]any) error
+	Import(ctx context.Context, files map[string]any) error
 
 	// Update the current project name.
 	UpdateName(ctx context.Context, name string) error

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1112,11 +1112,11 @@ func (m *MockFlow) ImportTheme(_ context.Context, theme *descope.Theme) (*descop
 // Mock Project
 
 type MockProject struct {
-	ExportRawResponse map[string]any
-	ExportRawError    error
+	ExportResponse map[string]any
+	ExportError    error
 
-	ImportRawAssert func(files map[string]any)
-	ImportRawError  error
+	ImportAssert func(files map[string]any)
+	ImportError  error
 
 	UpdateNameAssert func(name string)
 	UpdateNameError  error
@@ -1129,15 +1129,15 @@ type MockProject struct {
 	DeleteError  error
 }
 
-func (m *MockProject) ExportRaw(_ context.Context) (map[string]any, error) {
-	return m.ExportRawResponse, m.ExportRawError
+func (m *MockProject) Export(_ context.Context) (map[string]any, error) {
+	return m.ExportResponse, m.ExportError
 }
 
-func (m *MockProject) ImportRaw(_ context.Context, files map[string]any) error {
-	if m.ImportRawAssert != nil {
-		m.ImportRawAssert(files)
+func (m *MockProject) Import(_ context.Context, files map[string]any) error {
+	if m.ImportAssert != nil {
+		m.ImportAssert(files)
 	}
-	return m.ExportRawError
+	return m.ExportError
 }
 
 func (m *MockProject) UpdateName(_ context.Context, name string) error {

--- a/tools/environment/export.go
+++ b/tools/environment/export.go
@@ -19,7 +19,7 @@ type exporter struct {
 
 func (ex *exporter) Export() error {
 	fmt.Println("* Exporting project...")
-	files, err := descopeClient.Management.Project().ExportRaw()
+	files, err := descopeClient.Management.Project().Export()
 	if err != nil {
 		return fmt.Errorf("failed to export project: %w", err)
 	}

--- a/tools/environment/import.go
+++ b/tools/environment/import.go
@@ -27,7 +27,7 @@ func (im *importer) Import() error {
 	}
 
 	fmt.Println("* Importing project...")
-	if err := descopeClient.Management.Project().ImportRaw(im.files); err != nil {
+	if err := descopeClient.Management.Project().Import(im.files); err != nil {
 		return fmt.Errorf("failed to import project: %w", err)
 	}
 


### PR DESCRIPTION
## Description
- Remove redundant `...Raw` suffix from project `ImportRaw`/`ExportRaw` function names

## Must
- [X] Tests
- [X] Documentation (if applicable)
