### PR TITLE
Add user history support for auth and mgmt apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,21 @@ invalidate all user's refresh tokens. After calling this function, you must inva
 descopeClient.Auth.LogoutAll(request, w)
 ```
 
+Get the current session user history. The request requires a valid refresh token.
+
+```go
+loginHistoryRes, err := descopeClient.Auth.History(request, r)
+if err == nil {
+    for i := range loginHistoryRes {
+        fmt.Println(loginHistoryRes[i].UserID)
+        fmt.Println(loginHistoryRes[i].City)
+        fmt.Println(loginHistoryRes[i].Country)
+        fmt.Println(loginHistoryRes[i].IP)
+        fmt.Println(loginHistoryRes[i].LoginTime)
+    }
+}
+```
+
 ## Management Functions
 
 It is very common for some form of management or automation to be required. These can be performed
@@ -667,7 +682,7 @@ err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(),
 
 ### Manage Users
 
-You can create, update, delete or load users, as well as search according to filters:
+You can create, update, delete, logout, get user history and load users, as well as search according to filters:
 
 ```go
 // A user must have a loginID, other fields are optional.
@@ -776,6 +791,18 @@ err := descopeClient.Management.User().LogoutUser(context.Background(), "<login 
 
 // Logout given user from all its devices, by user ID
 err := descopeClient.Management.User().LogoutUserByUserID(context.Background(), "<user id>")
+
+// Get users' authentication history
+loginHistoryRes, err := descopeClient.Management.User().History(context.Background(), []string{"<user id 1>", "<user id 2>"})
+if err == nil {
+    for i := range loginHistoryRes {
+        fmt.Println(loginHistoryRes[i].UserID)
+        fmt.Println(loginHistoryRes[i].City)
+        fmt.Println(loginHistoryRes[i].Country)
+        fmt.Println(loginHistoryRes[i].IP)
+        fmt.Println(loginHistoryRes[i].LoginTime)
+    }
+}
 ```
 
 #### Set or Expire User Password

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -744,7 +744,7 @@ func (e *endpoints) ManagementUserGenerateEnchantedLinkForTest() string {
 }
 
 func (e *endpoints) ManagementUserHistory() string {
-	return path.Join(e.version, e.mgmt.userGenerateEnchantedLinkForTest)
+	return path.Join(e.version, e.mgmt.userHistory)
 }
 
 func (e *endpoints) ManagementAccessKeyCreate() string {

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -122,6 +122,7 @@ var (
 			userGenerateMagicLinkForTest:     "mgmt/tests/generate/magiclink",
 			userGenerateEnchantedLinkForTest: "mgmt/tests/generate/enchantedlink",
 			userCreateEmbeddedLink:           "mgmt/user/signin/embeddedlink",
+			userHistory:                      "mgmt/user/history",
 			accessKeyCreate:                  "mgmt/accesskey/create",
 			accessKeyLoad:                    "mgmt/accesskey",
 			accessKeySearchAll:               "mgmt/accesskey/search",
@@ -184,6 +185,7 @@ var (
 		refresh:      "auth/refresh",
 		selectTenant: "auth/tenant/select",
 		me:           "auth/me",
+		history:      "auth/me/history",
 	}
 )
 
@@ -198,6 +200,7 @@ type endpoints struct {
 	refresh      string
 	selectTenant string
 	me           string
+	history      string
 }
 
 type authEndpoints struct {
@@ -295,6 +298,8 @@ type mgmtEndpoints struct {
 	userGenerateEnchantedLinkForTest string
 	userCreateEmbeddedLink           string
 
+	userHistory string
+
 	accessKeyCreate     string
 	accessKeyLoad       string
 	accessKeySearchAll  string
@@ -367,51 +372,67 @@ type mgmtEndpoints struct {
 func (e *endpoints) SignInOTP() string {
 	return path.Join(e.version, e.auth.signInOTP)
 }
+
 func (e *endpoints) SignUpOTP() string {
 	return path.Join(e.version, e.auth.signUpOTP)
 }
+
 func (e *endpoints) SignUpOrInOTP() string {
 	return path.Join(e.version, e.auth.signUpOrInOTP)
 }
+
 func (e *endpoints) SignUpTOTP() string {
 	return path.Join(e.version, e.auth.signUpTOTP)
 }
+
 func (e *endpoints) UpdateTOTP() string {
 	return path.Join(e.version, e.auth.updateTOTP)
 }
+
 func (e *endpoints) VerifyCode() string {
 	return path.Join(e.version, e.auth.verifyCode)
 }
+
 func (e *endpoints) VerifyTOTPCode() string {
 	return path.Join(e.version, e.auth.verifyTOTPCode)
 }
+
 func (e *endpoints) SignUpPassword() string {
 	return path.Join(e.version, e.auth.signUpPassword)
 }
+
 func (e *endpoints) SignInPassword() string {
 	return path.Join(e.version, e.auth.signInPassword)
 }
+
 func (e *endpoints) SendResetPassword() string {
 	return path.Join(e.version, e.auth.sendResetPassword)
 }
+
 func (e *endpoints) UpdateUserPassword() string {
 	return path.Join(e.version, e.auth.updateUserPassword)
 }
+
 func (e *endpoints) ReplaceUserPassword() string {
 	return path.Join(e.version, e.auth.replaceUserPassword)
 }
+
 func (e *endpoints) PasswordPolicy() string {
 	return path.Join(e.version, e.auth.passwordPolicy)
 }
+
 func (e *endpoints) SignInMagicLink() string {
 	return path.Join(e.version, e.auth.signInMagicLink)
 }
+
 func (e *endpoints) SignUpMagicLink() string {
 	return path.Join(e.version, e.auth.signUpMagicLink)
 }
+
 func (e *endpoints) SignUpOrInMagicLink() string {
 	return path.Join(e.version, e.auth.signUpOrInMagicLink)
 }
+
 func (e *endpoints) VerifyMagicLink() string {
 	return path.Join(e.version, e.auth.verifyMagicLink)
 }
@@ -419,24 +440,31 @@ func (e *endpoints) VerifyMagicLink() string {
 func (e *endpoints) SignInEnchantedLink() string {
 	return path.Join(e.version, e.auth.signInEnchantedLink)
 }
+
 func (e *endpoints) SignUpEnchantedLink() string {
 	return path.Join(e.version, e.auth.signUpEnchantedLink)
 }
+
 func (e *endpoints) SignUpOrInEnchantedLink() string {
 	return path.Join(e.version, e.auth.signUpOrInEnchantedLink)
 }
+
 func (e *endpoints) UpdateUserEmailEnchantedlink() string {
 	return path.Join(e.version, e.auth.updateUserEmailEnchantedLink)
 }
+
 func (e *endpoints) VerifyEnchantedLink() string {
 	return path.Join(e.version, e.auth.verifyEnchantedLink)
 }
+
 func (e *endpoints) GetEnchantedLinkSession() string {
 	return path.Join(e.version, e.auth.getEnchantedLinkSession)
 }
+
 func (e *endpoints) OAuthStart() string {
 	return path.Join(e.version, e.auth.oauthStart)
 }
+
 func (e *endpoints) ExchangeTokenOAuth() string {
 	return path.Join(e.version, e.auth.exchangeTokenOAuth)
 }
@@ -454,45 +482,63 @@ func (e *endpoints) ExchangeTokenSAML() string {
 func (e *endpoints) SSOStart() string {
 	return path.Join(e.version, e.auth.ssoStart)
 }
+
 func (e *endpoints) ExchangeTokenSSO() string {
 	return path.Join(e.version, e.auth.exchangeTokenSSO)
 }
+
 func (e *endpoints) WebAuthnSignUpStart() string {
 	return path.Join(e.version, e.auth.webauthnSignUpStart)
 }
+
 func (e *endpoints) WebAuthnSignUpFinish() string {
 	return path.Join(e.version, e.auth.webauthnSignUpFinish)
 }
+
 func (e *endpoints) WebAuthnSignInStart() string {
 	return path.Join(e.version, e.auth.webauthnSignInStart)
 }
+
 func (e *endpoints) WebAuthnSignInFinish() string {
 	return path.Join(e.version, e.auth.webauthnSignInFinish)
 }
+
 func (e *endpoints) WebAuthnSignUpOrInStart() string {
 	return path.Join(e.version, e.auth.webauthnSignUpOrInStart)
 }
+
 func (e *endpoints) WebAuthnUpdateUserDeviceStart() string {
 	return path.Join(e.version, e.auth.webauthnUpdateStart)
 }
+
 func (e *endpoints) WebAuthnUpdateUserDeviceFinish() string {
 	return path.Join(e.version, e.auth.webauthnUpdateFinish)
 }
+
 func (e *endpoints) Logout() string {
 	return path.Join(e.version, e.logout)
 }
+
 func (e *endpoints) LogoutAll() string {
 	return path.Join(e.version, e.logoutAll)
 }
+
 func (e *endpoints) Me() string {
 	return path.Join(e.version, e.me)
 }
+
+func (e *endpoints) History() string {
+	return path.Join(e.version, e.history)
+}
+
 func (e *endpoints) GetKeys() string {
 	return path.Join(e.versionV2, e.keys)
 }
+
 func (e *endpoints) RefreshToken() string {
 	return path.Join(e.version, e.refresh)
 }
+
 func (e *endpoints) SelectTenant() string {
 	return path.Join(e.version, e.selectTenant)
 }
@@ -694,6 +740,10 @@ func (e *endpoints) ManagementUserGenerateMagicLinkForTest() string {
 }
 
 func (e *endpoints) ManagementUserGenerateEnchantedLinkForTest() string {
+	return path.Join(e.version, e.mgmt.userGenerateEnchantedLinkForTest)
+}
+
+func (e *endpoints) ManagementUserHistory() string {
 	return path.Join(e.version, e.mgmt.userGenerateEnchantedLinkForTest)
 }
 

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -52,7 +52,13 @@ var (
 	mockAuthSessionBody             = fmt.Sprintf(`{"sessionJwt": "%s", "refreshJwt": "%s", "cookiePath": "%s", "cookieDomain": "%s" }`, jwtTokenValid, jwtRTokenValid, "/my-path", "my-domain")
 	mockAuthSessionBodyNoRefreshJwt = fmt.Sprintf(`{"sessionJwt": "%s", "cookiePath": "%s", "cookieDomain": "%s" }`, jwtTokenValid, "/my-path", "my-domain")
 
-	mockUserResponseBody = fmt.Sprintf(`{"name": "%s", "email": "%s", "userId": "%s", "picture": "%s"}`, "kuku name", "kuku@test.com", "kuku", "@(^_^)@")
+	mockUserResponseBody        = fmt.Sprintf(`{"name": "%s", "email": "%s", "userId": "%s", "picture": "%s"}`, "kuku name", "kuku@test.com", "kuku", "@(^_^)@")
+	mockUserHistoryResponseBody = fmt.Sprintf(`[
+		{"city": "%s", "country": "%s", "userId": "%s", "ip": "%s", "loginTime": %d},
+		{"city": "%s", "country": "%s", "userId": "%s", "ip": "%s", "loginTime": %d}
+	]`,
+		"kefar saba", "Israel", "kuku", "1.1.1.1", 32,
+		"eilat", "Israele", "nunu", "1.1.1.2", 23)
 
 	permissions                  = []interface{}{"foo", "bar"}
 	roles                        = []interface{}{"abc", "xyz"}
@@ -1050,6 +1056,74 @@ func TestMeEmptyResponse(t *testing.T) {
 	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
 
 	user, err := a.Me(request)
+	assert.ErrorContains(t, err, "JSON input")
+	assert.Nil(t, user)
+}
+
+func TestHistory(t *testing.T) {
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(mockUserHistoryResponseBody))}, nil
+	})
+	require.NoError(t, err)
+	request := &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
+
+	userHistory, err := a.History(request)
+	require.NoError(t, err)
+	require.Len(t, userHistory, 2)
+
+	assert.Equal(t, "kuku", userHistory[0].UserID)
+	assert.Equal(t, "kefar saba", userHistory[0].City)
+	assert.Equal(t, "Israel", userHistory[0].Country)
+	assert.Equal(t, "1.1.1.1", userHistory[0].IP)
+	assert.Equal(t, int32(32), userHistory[0].LoginTime)
+
+	assert.Equal(t, "nunu", userHistory[1].UserID)
+	assert.Equal(t, "eilat", userHistory[1].City)
+	assert.Equal(t, "Israele", userHistory[1].Country)
+	assert.Equal(t, "1.1.1.2", userHistory[1].IP)
+	assert.Equal(t, int32(23), userHistory[1].LoginTime)
+}
+
+func TestHistoryNoRequest(t *testing.T) {
+	a, err := newTestAuth(nil, DoOk(nil))
+	require.NoError(t, err)
+	user, err := a.History(nil)
+	assert.ErrorIs(t, err, descope.ErrInvalidArguments)
+	assert.Nil(t, user)
+}
+
+func TestHistoryNoToken(t *testing.T) {
+	a, err := newTestAuth(nil, DoOk(nil))
+	require.NoError(t, err)
+	request := &http.Request{Header: http.Header{}}
+	user, err := a.History(request)
+	assert.ErrorIs(t, err, descope.ErrRefreshToken)
+	assert.ErrorContains(t, err, "Unable to find tokens")
+	assert.Nil(t, user)
+}
+
+func TestHistoryInvalidToken(t *testing.T) {
+	a, err := newTestAuth(nil, DoOk(nil))
+	require.NoError(t, err)
+	request := &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtTokenExpired})
+
+	user, err := a.History(request)
+	assert.ErrorIs(t, err, descope.ErrRefreshToken)
+	assert.ErrorContains(t, err, "Invalid refresh token")
+	assert.Nil(t, user)
+}
+
+func TestHistoryEmptyResponse(t *testing.T) {
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(""))}, nil
+	})
+	require.NoError(t, err)
+	request := &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
+
+	user, err := a.History(request)
 	assert.ErrorContains(t, err, "JSON input")
 	assert.Nil(t, user)
 }

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -551,6 +551,24 @@ func (u *user) GenerateEmbeddedLink(ctx context.Context, loginID string, customC
 	return tRes.Token, nil
 }
 
+func (u *user) History(ctx context.Context, loginIDs []string) ([]*descope.UserHistoryResponse, error) {
+	if loginIDs == nil {
+		return nil, utils.NewInvalidArgumentError("loginIDs")
+	}
+	res, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserHistory(), map[string]any{
+		"loginIds": loginIDs,
+	}, nil, u.conf.ManagementKey)
+	if err != nil {
+		return nil, err
+	}
+	tRes := []*descope.UserHistoryResponse{}
+	err = utils.Unmarshal([]byte(res.BodyStr), &tRes)
+	if err != nil {
+		return nil, err //notest
+	}
+	return tRes, nil
+}
+
 func makeCreateUserRequest(loginID, email, phone, displayName, givenName, middleName, familyName, picture string, roles []string, tenants []*descope.AssociatedTenant, invite, test bool, customAttributes map[string]any, verifiedEmail *bool, verifiedPhone *bool, additionalLoginIDs []string, options *descope.InviteOptions, ssoAppIDs []string) map[string]any {
 	req := makeUpdateUserRequest(loginID, email, phone, displayName, givenName, middleName, familyName, picture, roles, tenants, customAttributes, verifiedEmail, verifiedPhone, additionalLoginIDs, ssoAppIDs)
 	req["invite"] = invite

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -555,9 +555,7 @@ func (u *user) History(ctx context.Context, loginIDs []string) ([]*descope.UserH
 	if loginIDs == nil {
 		return nil, utils.NewInvalidArgumentError("loginIDs")
 	}
-	res, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserHistory(), map[string]any{
-		"loginIds": loginIDs,
-	}, nil, u.conf.ManagementKey)
+	res, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserHistory(), loginIDs, nil, u.conf.ManagementKey)
 	if err != nil {
 		return nil, err
 	}

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -1596,9 +1596,9 @@ func TestUserHistorySuccess(t *testing.T) {
 
 	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
-		req := map[string]any{}
+		req := []string{}
 		require.NoError(t, helpers.ReadBody(r, &req))
-		require.Equal(t, []interface{}{"one", "two"}, req["loginIds"])
+		require.Equal(t, []string{"one", "two"}, req)
 	}, response))
 
 	userHistory, err := m.User().History(context.Background(), []string{"one", "two"})
@@ -1629,9 +1629,9 @@ func TestHistoryNoLoginIDs(t *testing.T) {
 func TestHistoryFailure(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoBadRequest(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
-		req := map[string]any{}
+		req := []string{}
 		require.NoError(t, helpers.ReadBody(r, &req))
-		require.Equal(t, []interface{}{"one", "two"}, req["loginIds"])
+		require.Equal(t, []string{"one", "two"}, req)
 	}))
 	userHistory, err := m.User().History(context.TODO(), []string{"one", "two"})
 	assert.ErrorIs(t, err, descope.ErrInvalidResponse)

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -1575,3 +1575,65 @@ func TestUserCreateWithVerifiedPhoneUserSuccess(t *testing.T) {
 	require.NotNil(t, res)
 	require.Equal(t, "a@b.c", res.Email)
 }
+
+func TestUserHistorySuccess(t *testing.T) {
+	response := []map[string]any{
+		{
+			"userId":    "kuku",
+			"city":      "kefar saba",
+			"country":   "Israel",
+			"ip":        "1.1.1.1",
+			"loginTime": 32,
+		},
+		{
+			"userId":    "nunu",
+			"city":      "eilat",
+			"country":   "Israele",
+			"ip":        "1.1.1.2",
+			"loginTime": 23,
+		},
+	}
+
+	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, []interface{}{"one", "two"}, req["loginIds"])
+	}, response))
+
+	userHistory, err := m.User().History(context.Background(), []string{"one", "two"})
+	require.NoError(t, err)
+	require.NotNil(t, userHistory)
+	require.Len(t, userHistory, 2)
+
+	assert.Equal(t, "kuku", userHistory[0].UserID)
+	assert.Equal(t, "kefar saba", userHistory[0].City)
+	assert.Equal(t, "Israel", userHistory[0].Country)
+	assert.Equal(t, "1.1.1.1", userHistory[0].IP)
+	assert.Equal(t, int32(32), userHistory[0].LoginTime)
+
+	assert.Equal(t, "nunu", userHistory[1].UserID)
+	assert.Equal(t, "eilat", userHistory[1].City)
+	assert.Equal(t, "Israele", userHistory[1].Country)
+	assert.Equal(t, "1.1.1.2", userHistory[1].IP)
+	assert.Equal(t, int32(23), userHistory[1].LoginTime)
+}
+
+func TestHistoryNoLoginIDs(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoOk(nil))
+	userHistory, err := m.User().History(context.TODO(), nil)
+	assert.ErrorIs(t, err, descope.ErrInvalidArguments)
+	assert.Nil(t, userHistory)
+}
+
+func TestHistoryFailure(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoBadRequest(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, []interface{}{"one", "two"}, req["loginIds"])
+	}))
+	userHistory, err := m.User().History(context.TODO(), []string{"one", "two"})
+	assert.ErrorIs(t, err, descope.ErrInvalidResponse)
+	assert.Nil(t, userHistory)
+}

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -362,4 +362,8 @@ type Authentication interface {
 	// Me - Use to retrieve current session user details. The request requires a valid refresh token.
 	// returns the user details or error if the refresh token is not valid.
 	Me(request *http.Request) (*descope.UserResponse, error)
+
+	// History - Use to retrieve current session user history. The request requires a valid refresh token.
+	// returns the user authentication history or error if the refresh token is not valid.
+	History(request *http.Request) ([]*descope.UserHistoryResponse, error)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -359,6 +359,10 @@ type User interface {
 	// Generate an embedded link token, later can be used to authenticate via magiclink verify method
 	// or via flow verify step
 	GenerateEmbeddedLink(ctx context.Context, loginID string, customClaims map[string]any) (string, error)
+
+	// Use to retrieve users' authentication history, by user's ids.
+	// returns slice of users' authentication history.
+	History(ctx context.Context, loginIDs []string) ([]*descope.UserHistoryResponse, error)
 }
 
 // Provides functions for managing access keys in a project.

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -592,6 +592,10 @@ type MockSession struct {
 	MeAssert   func(r *http.Request)
 	MeError    error
 	MeResponse *descope.UserResponse
+
+	HistoryAssert   func(r *http.Request)
+	HistoryError    error
+	HistoryResponse []*descope.UserHistoryResponse
 }
 
 func (m *MockSession) ValidateSessionWithRequest(r *http.Request) (bool, *descope.Token, error) {
@@ -765,4 +769,11 @@ func (m *MockSession) Me(r *http.Request) (*descope.UserResponse, error) {
 		m.MeAssert(r)
 	}
 	return m.MeResponse, m.MeError
+}
+
+func (m *MockSession) History(r *http.Request) ([]*descope.UserHistoryResponse, error) {
+	if m.HistoryAssert != nil {
+		m.HistoryAssert(r)
+	}
+	return m.HistoryResponse, m.HistoryError
 }

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -374,6 +374,10 @@ type MockUser struct {
 
 	LogoutAssert func(id string)
 	LogoutError  error
+
+	HistoryAssert   func(loginIDs []string)
+	HistoryResponse []*descope.UserHistoryResponse
+	HistoryError    error
 }
 
 func (m *MockUser) Create(_ context.Context, loginID string, user *descope.UserRequest) (*descope.UserResponse, error) {
@@ -675,6 +679,13 @@ func (m *MockUser) GenerateEmbeddedLink(_ context.Context, loginID string, custo
 		m.GenerateEmbeddedLinkAssert(loginID, customClaims)
 	}
 	return m.GenerateEmbeddedLinkResponse, m.GenerateEmbeddedLinkError
+}
+
+func (m *MockUser) History(_ context.Context, loginIDs []string) ([]*descope.UserHistoryResponse, error) {
+	if m.HistoryAssert != nil {
+		m.HistoryAssert(loginIDs)
+	}
+	return m.HistoryResponse, m.HistoryError
 }
 
 // Mock Access Key

--- a/descope/types.go
+++ b/descope/types.go
@@ -440,6 +440,14 @@ type UserResponse struct {
 	SSOAppIDs        []string            `json:"ssoAppIds,omitempty"`
 }
 
+type UserHistoryResponse struct {
+	UserID    string `json:"userId,omitempty"`
+	LoginTime int32  `json:"loginTime,omitempty"`
+	City      string `json:"city,omitempty"`
+	Country   string `json:"country,omitempty"`
+	IP        string `json:"ip,omitempty"`
+}
+
 type UsersFailedResponse struct {
 	Failure string        `json:"failure,omitempty"`
 	User    *UserResponse `json:"user,omitempty"`


### PR DESCRIPTION
## Description
Related to: https://github.com/descope/etc/issues/4713

Add user history support for auth and mgmt apis.

## Must
- [x] Tests
