### PR TITLE
Fix history param name to be userIDs and not loginIDs

### DIFF
--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -551,11 +551,11 @@ func (u *user) GenerateEmbeddedLink(ctx context.Context, loginID string, customC
 	return tRes.Token, nil
 }
 
-func (u *user) History(ctx context.Context, loginIDs []string) ([]*descope.UserHistoryResponse, error) {
-	if loginIDs == nil {
-		return nil, utils.NewInvalidArgumentError("loginIDs")
+func (u *user) History(ctx context.Context, userIDs []string) ([]*descope.UserHistoryResponse, error) {
+	if userIDs == nil {
+		return nil, utils.NewInvalidArgumentError("userIDs")
 	}
-	res, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserHistory(), loginIDs, nil, u.conf.ManagementKey)
+	res, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserHistory(), userIDs, nil, u.conf.ManagementKey)
 	if err != nil {
 		return nil, err
 	}

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -1619,7 +1619,7 @@ func TestUserHistorySuccess(t *testing.T) {
 	assert.Equal(t, int32(23), userHistory[1].LoginTime)
 }
 
-func TestHistoryNoLoginIDs(t *testing.T) {
+func TestHistoryNoUserIDs(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoOk(nil))
 	userHistory, err := m.User().History(context.TODO(), nil)
 	assert.ErrorIs(t, err, descope.ErrInvalidArguments)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -360,9 +360,9 @@ type User interface {
 	// or via flow verify step
 	GenerateEmbeddedLink(ctx context.Context, loginID string, customClaims map[string]any) (string, error)
 
-	// Use to retrieve users' authentication history, by user's ids.
+	// Use to retrieve users' authentication history, by the given user's ids.
 	// returns slice of users' authentication history.
-	History(ctx context.Context, loginIDs []string) ([]*descope.UserHistoryResponse, error)
+	History(ctx context.Context, userIDs []string) ([]*descope.UserHistoryResponse, error)
 }
 
 // Provides functions for managing access keys in a project.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -375,7 +375,7 @@ type MockUser struct {
 	LogoutAssert func(id string)
 	LogoutError  error
 
-	HistoryAssert   func(loginIDs []string)
+	HistoryAssert   func(userIDs []string)
 	HistoryResponse []*descope.UserHistoryResponse
 	HistoryError    error
 }
@@ -681,9 +681,9 @@ func (m *MockUser) GenerateEmbeddedLink(_ context.Context, loginID string, custo
 	return m.GenerateEmbeddedLinkResponse, m.GenerateEmbeddedLinkError
 }
 
-func (m *MockUser) History(_ context.Context, loginIDs []string) ([]*descope.UserHistoryResponse, error) {
+func (m *MockUser) History(_ context.Context, userIDs []string) ([]*descope.UserHistoryResponse, error) {
 	if m.HistoryAssert != nil {
-		m.HistoryAssert(loginIDs)
+		m.HistoryAssert(userIDs)
 	}
 	return m.HistoryResponse, m.HistoryError
 }


### PR DESCRIPTION
## Description
Related to: https://github.com/descope/etc/issues/4713

Fix history param name to be userIDs and not loginIDs

## Must
- [x] Tests
- [x] Documentation (if applicable)
