### PR TITLE
Remove redundant redirectUrl param

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ ssoSettings, err := descopeClient.Management.SSO().GetSettings(context.Backgroun
 // Configure tenant SSO by OIDC settings
 
 oidcSettings := &descope.SSOOIDCSettings{..}
-err = cc.HC.DescopeClient().Management.SSO().ConfigureOIDCSettings("tenant-id", oidcSettings, "https://redirectlocation.com", "")
+err = cc.HC.DescopeClient().Management.SSO().ConfigureOIDCSettings("tenant-id", oidcSettings, "")
 // OR
 // Load all tenant SSO settings and use them for configure OIDC settings
 ssoSettings, err := cc.HC.DescopeClient().Management.SSO().LoadSettings("tenant-id")
@@ -894,7 +894,7 @@ ssoSettings.Oidc.Name = "my prOvider"
 ssoSettings.Oidc.AuthURL = authorizeEndpoint
 ...
 ssoSettings.Oidc.Scope = []string{"openid", "profile", "email"}
-err = cc.HC.DescopeClient().Management.SSO().ConfigureOIDCSettings("tenant-id", ssoSettings.Oidc, "https://redirectlocation.com", "")
+err = cc.HC.DescopeClient().Management.SSO().ConfigureOIDCSettings("tenant-id", ssoSettings.Oidc, "")
 
 // Configure tenant SSO by SAML settings
 tenantID := "tenant-id" // Which tenant this configuration is for

--- a/descope/internal/mgmt/sso.go
+++ b/descope/internal/mgmt/sso.go
@@ -106,7 +106,7 @@ func (s *sso) ConfigureSAMLSettingsByMetadata(ctx context.Context, tenantID stri
 	return err
 }
 
-func (s *sso) ConfigureOIDCSettings(ctx context.Context, tenantID string, settings *descope.SSOOIDCSettings, redirectURL string, domains []string) error {
+func (s *sso) ConfigureOIDCSettings(ctx context.Context, tenantID string, settings *descope.SSOOIDCSettings, domains []string) error {
 	if tenantID == "" {
 		return utils.NewInvalidArgumentError("tenantID")
 	}
@@ -116,10 +116,9 @@ func (s *sso) ConfigureOIDCSettings(ctx context.Context, tenantID string, settin
 	}
 
 	req := map[string]any{
-		"tenantId":    tenantID,
-		"settings":    settings,
-		"redirectUrl": redirectURL,
-		"domains":     domains,
+		"tenantId": tenantID,
+		"settings": settings,
+		"domains":  domains,
 	}
 
 	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOOIDCSettings(), req, nil, s.conf.ManagementKey)

--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -456,6 +456,7 @@ func TestSSOConfigureOIDCSettingsSuccess(t *testing.T) {
 		AuthURL:     "http://dummy.com",
 		TokenURL:    "http://dummy.com",
 		UserDataURL: "http://dummy.com",
+		RedirectURL: "https://redirect",
 		AttributeMapping: &descope.OIDCAttributeMapping{
 			GivenName: "myGivenName",
 		},
@@ -465,7 +466,6 @@ func TestSSOConfigureOIDCSettingsSuccess(t *testing.T) {
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "abc", req["tenantId"])
-		require.Equal(t, "https://redirect", req["redirectUrl"])
 
 		domains := req["domains"].([]any)
 		require.Len(t, domains, 1)
@@ -480,20 +480,21 @@ func TestSSOConfigureOIDCSettingsSuccess(t *testing.T) {
 		require.Equal(t, "http://dummy.com", sett["authUrl"])
 		require.Equal(t, "http://dummy.com", sett["tokenUrl"])
 		require.Equal(t, "http://dummy.com", sett["userDataUrl"])
+		require.Equal(t, "https://redirect", sett["redirectUrl"])
 
 		userAttrMappingInt, found := sett["userAttrMapping"]
 		require.True(t, found)
 		userAttrMapping, _ := userAttrMappingInt.(map[string]any)
 		require.Equal(t, "myGivenName", userAttrMapping["givenName"])
 	}))
-	err := mgmt.SSO().ConfigureOIDCSettings(context.Background(), "abc", oidcSettings, "https://redirect", []string{"domain.com"})
+	err := mgmt.SSO().ConfigureOIDCSettings(context.Background(), "abc", oidcSettings, []string{"domain.com"})
 	require.NoError(t, err)
 }
 
 func TestSSOConfigureOIDCSettingsError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	err := mgmt.SSO().ConfigureOIDCSettings(context.Background(), "", nil, "", []string{})
+	err := mgmt.SSO().ConfigureOIDCSettings(context.Background(), "", nil, []string{})
 	require.Error(t, err)
-	err = mgmt.SSO().ConfigureOIDCSettings(context.Background(), "abc", nil, "", []string{})
+	err = mgmt.SSO().ConfigureOIDCSettings(context.Background(), "abc", nil, []string{})
 	require.Error(t, err)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -451,11 +451,10 @@ type SSO interface {
 	//
 	// tenantID, settings are required.
 	//
-	// redirectURL is optional, however if not given it has to be set when starting an SSO authentication via the request.
 	// domains is optional, it is used to map users to this tenant when authenticating via SSO.
 	//
-	// Both optional values will override whatever is currently set even if left empty.
-	ConfigureOIDCSettings(_ context.Context, tenantID string, settings *descope.SSOOIDCSettings, redirectURL string, domains []string) error
+	// Optional value will override whatever is currently set even if left empty.
+	ConfigureOIDCSettings(_ context.Context, tenantID string, settings *descope.SSOOIDCSettings, domains []string) error
 
 	// tenantID is required.
 	DeleteSettings(ctx context.Context, tenantID string) error

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -109,7 +109,7 @@ type MockSSO struct {
 	ConfigureSAMLSettingsByMetadataAssert func(tenantID string, settings *descope.SSOSAMLSettingsByMetadata, redirectURL string, domains []string)
 	ConfigureSAMLSettingsByMetadataError  error
 
-	ConfigureOIDCSettingsAssert func(tenantID string, settings *descope.SSOOIDCSettings, redirectURL string, domains []string) error
+	ConfigureOIDCSettingsAssert func(tenantID string, settings *descope.SSOOIDCSettings, domains []string) error
 	ConfigureOIDCSettingsError  error
 
 	DeleteSettingsAssert func(tenantID string)
@@ -150,9 +150,9 @@ func (m *MockSSO) ConfigureSAMLSettingsByMetadata(_ context.Context, tenantID st
 	return m.ConfigureSAMLSettingsByMetadataError
 }
 
-func (m *MockSSO) ConfigureOIDCSettings(_ context.Context, tenantID string, settings *descope.SSOOIDCSettings, redirectURL string, domains []string) error {
+func (m *MockSSO) ConfigureOIDCSettings(_ context.Context, tenantID string, settings *descope.SSOOIDCSettings, domains []string) error {
 	if m.ConfigureOIDCSettingsAssert != nil {
-		m.ConfigureOIDCSettingsAssert(tenantID, settings, redirectURL, domains)
+		m.ConfigureOIDCSettingsAssert(tenantID, settings, domains)
 	}
 	return m.ConfigureOIDCSettingsError
 }


### PR DESCRIPTION
Remove redundant redirectUrl function parameter so it will not be confused with the same redirectUrl parameter inside the OIDCSettings parameter.