### PR TITLE
Add total users to search all users method (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ userRes, err := descopeClient.Management.User().LoadByUserID(context.Background(
 
 // Search all users, optionally according to tenant and/or role filter
 // Results can be paginated using the limit and page parameters
-usersResp, err := descopeClient.Management.User().SearchAll(context.Background(), &descope.UserSearchOptions{TenantIDs: []string{"my-tenant-id"}})
+usersResp, total, err := descopeClient.Management.User().SearchAll(context.Background(), &descope.UserSearchOptions{TenantIDs: []string{"my-tenant-id"}})
 if err == nil {
     for _, user := range usersResp {
         // Do something

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -532,6 +532,7 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 		"users": []map[string]any{{
 			"email": "a@b.c",
 		}},
+		"total": 85,
 	}
 	tenantIDs := []string{"t1"}
 	roleNames := []string{"role1"}
@@ -550,7 +551,7 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 		require.EqualValues(t, "blue", req["text"])
 		require.EqualValues(t, []interface{}([]interface{}{map[string]interface{}{"Desc": true, "Field": "nono"}, map[string]interface{}{"Desc": false, "Field": "lolo"}}), req["sort"])
 	}, response))
-	res, err := m.User().SearchAll(context.Background(), &descope.UserSearchOptions{
+	res, total, err := m.User().SearchAll(context.Background(), &descope.UserSearchOptions{
 		Statuses:         []descope.UserStatus{descope.UserStatusDisabled},
 		TenantIDs:        tenantIDs,
 		Roles:            roleNames,
@@ -568,26 +569,30 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 	require.NotNil(t, res)
 	require.Len(t, res, 1)
 	require.Equal(t, "a@b.c", res[0].Email)
+	require.Equal(t, 85, total)
 }
 
 func TestSearchAllUsersError(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
-	res, err := m.User().SearchAll(context.Background(), nil)
+	res, total, err := m.User().SearchAll(context.Background(), nil)
 	require.Error(t, err)
 	require.Nil(t, res)
+	require.Zero(t, total)
 }
 
 func TestSearchAllUsersBadRequest(t *testing.T) {
 	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
-	res, err := m.User().SearchAll(context.Background(), &descope.UserSearchOptions{Limit: -1})
+	res, total, err := m.User().SearchAll(context.Background(), &descope.UserSearchOptions{Limit: -1})
 	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.Contains(t, err.Error(), "limit")
 	require.Nil(t, res)
+	require.Zero(t, total)
 
-	res, err = m.User().SearchAll(context.Background(), &descope.UserSearchOptions{Page: -1})
+	res, total, err = m.User().SearchAll(context.Background(), &descope.UserSearchOptions{Page: -1})
 	require.ErrorIs(t, err, descope.ErrInvalidArguments)
 	require.Contains(t, err.Error(), "page")
 	require.Nil(t, res)
+	require.Zero(t, total)
 }
 
 func TestUserActivateSuccess(t *testing.T) {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -223,7 +223,8 @@ type User interface {
 	// The options optional parameter allows to fine-tune the search filters
 	// and results. Using nil will result in a filter-less query with a set amount of
 	// results.
-	SearchAll(ctx context.Context, options *descope.UserSearchOptions) ([]*descope.UserResponse, error)
+	// Returns slice of users and total number of users for the query
+	SearchAll(ctx context.Context, options *descope.UserSearchOptions) ([]*descope.UserResponse, int, error)
 
 	// Activate an existing user.
 	Activate(ctx context.Context, loginID string) (*descope.UserResponse, error)

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -269,9 +269,10 @@ type MockUser struct {
 	LoadResponse *descope.UserResponse
 	LoadError    error
 
-	SearchAllAssert   func(options *descope.UserSearchOptions)
-	SearchAllResponse []*descope.UserResponse
-	SearchAllError    error
+	SearchAllAssert        func(options *descope.UserSearchOptions)
+	SearchAllResponse      []*descope.UserResponse
+	SearchAllTotalResponse int
+	SearchAllError         error
 
 	ActivateAssert   func(loginID string)
 	ActivateResponse *descope.UserResponse
@@ -489,11 +490,11 @@ func (m *MockUser) LogoutUserByUserID(_ context.Context, userID string) error {
 	return m.LogoutError
 }
 
-func (m *MockUser) SearchAll(_ context.Context, options *descope.UserSearchOptions) ([]*descope.UserResponse, error) {
+func (m *MockUser) SearchAll(_ context.Context, options *descope.UserSearchOptions) ([]*descope.UserResponse, int, error) {
 	if m.SearchAllAssert != nil {
 		m.SearchAllAssert(options)
 	}
-	return m.SearchAllResponse, m.SearchAllError
+	return m.SearchAllResponse, m.SearchAllTotalResponse, m.SearchAllError
 }
 
 func (m *MockUser) Activate(_ context.Context, loginID string) (*descope.UserResponse, error) {


### PR DESCRIPTION
## Description
Add total users to search all users method.
This breaks compatibility - compilation only.

## Must
- [x] Tests
- [x] Documentation (if applicable)
