### PR TITLE
Handle GetTeanats and IsPermittedPerTenant with descope tenants claim

### DIFF
--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -821,13 +821,13 @@ func getAuthorizationClaimItems(token *descope.Token, tenant string, claim strin
 		}
 	} else {
 		var claimValue []interface{}
-		if token.Claims[claimDescopeCurrentTenant] == tenant && len(token.GetTenants()) == 0 {
+		if v, ok := token.GetTenantValue(tenant, claim).([]interface{}); ok {
+			claimValue = v
+		} else if token.Claims[descope.ClaimDescopeCurrentTenant] == tenant {
 			// The token may have the current tenant in the "dct" claim and without the "tenants" claim
 			if v, ok := token.Claims[claim].([]interface{}); ok {
 				claimValue = v
 			}
-		} else if v, ok := token.GetTenantValue(tenant, claim).([]interface{}); ok {
-			claimValue = v
 		}
 
 		for i := range claimValue {
@@ -846,7 +846,7 @@ func getAuthorizationClaimItems(token *descope.Token, tenant string, claim strin
 }
 
 func isAssociatedWithTenant(token *descope.Token, tenant string) bool {
-	return slices.Contains(token.GetTenants(), tenant) || (token.Claims != nil && token.Claims[claimDescopeCurrentTenant] == tenant)
+	return slices.Contains(token.GetTenants(), tenant) || (token.Claims != nil && token.Claims[descope.ClaimDescopeCurrentTenant] == tenant)
 }
 
 func getPendingRefFromResponse(httpResponse *api.HTTPResponse) (*descope.EnchantedLinkResponse, error) {

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -79,9 +79,9 @@ var (
 	}
 	mockAuthorizationCurrentTenantToken = &descope.Token{
 		Claims: map[string]any{
-			claimPermissions:          permissions,
-			claimRoles:                roles,
-			claimDescopeCurrentTenant: "t1",
+			claimPermissions:                  permissions,
+			claimRoles:                        roles,
+			descope.ClaimDescopeCurrentTenant: "t1",
 		},
 	}
 )
@@ -1043,6 +1043,12 @@ func TestValidatePermissions(t *testing.T) {
 		"t1",
 		[]string{"foo"},
 	))
+}
+
+func TestGetTenants(t *testing.T) {
+	require.Equal(t, []string{}, mockAuthorizationToken.GetTenants())
+	require.Equal(t, []string{"t1"}, mockAuthorizationCurrentTenantToken.GetTenants())
+	require.ElementsMatch(t, []string{"kuku", "t1"}, mockAuthorizationTenantToken.GetTenants())
 }
 
 func TestGetMatchedPermissions(t *testing.T) {

--- a/descope/internal/auth/utils.go
+++ b/descope/internal/auth/utils.go
@@ -231,10 +231,9 @@ func newExchangeAccessKeyBody(loginOptions *descope.AccessKeyLoginOptions) *exch
 }
 
 const (
-	claimAttributeName        = "drn"
-	claimPermissions          = "permissions"
-	claimRoles                = "roles"
-	claimDescopeCurrentTenant = "dct"
+	claimAttributeName = "drn"
+	claimPermissions   = "permissions"
+	claimRoles         = "roles"
 )
 
 var (

--- a/descope/types.go
+++ b/descope/types.go
@@ -187,6 +187,9 @@ type Token struct {
 
 func (to *Token) GetTenants() []string {
 	tenants := to.getTenants()
+	if len(tenants) == 0 && to.Claims != nil && to.Claims[ClaimDescopeCurrentTenant] != nil {
+		return []string{to.Claims[ClaimDescopeCurrentTenant].(string)}
+	}
 	return maps.Keys(tenants)
 }
 
@@ -218,6 +221,9 @@ func (to *Token) IsPermitted(permission string) bool {
 func (to *Token) IsPermittedPerTenant(tenant string, permission string) bool {
 	permitted := false
 	tenants := to.getTenants()
+	if to.Claims[ClaimDescopeCurrentTenant] == tenant && len(tenants) == 0 {
+		return to.IsPermitted(permission)
+	}
 	tPermissions, ok := tenants[tenant]
 	if ok {
 		if tPermissionsMap, ok := tPermissions.(map[string]any); ok {
@@ -917,6 +923,7 @@ const (
 	ContextUserIDPropertyKey         ContextKey = ContextUserIDProperty
 	ClaimAuthorizedTenants                      = "tenants"
 	ClaimAuthorizedGlobalPermissions            = "permissions"
+	ClaimDescopeCurrentTenant                   = "dct"
 
 	EnvironmentVariableProjectID     = "DESCOPE_PROJECT_ID"
 	EnvironmentVariablePublicKey     = "DESCOPE_PUBLIC_KEY"

--- a/descope/types_test.go
+++ b/descope/types_test.go
@@ -92,7 +92,7 @@ func TestGetCreatedTime(t *testing.T) {
 	assert.True(t, r.GetCreatedTime().Equal(now))
 }
 
-func TestIsPermittedPerTenant(t *testing.T) {
+func TestIsPermittedPerTenantFromTenantsClaim(t *testing.T) {
 	tenantID := "somestring"
 	dt := &Token{
 		Claims: map[string]any{
@@ -107,6 +107,20 @@ func TestIsPermittedPerTenant(t *testing.T) {
 	assert.True(t, p)
 	p = dt.IsPermittedPerTenant(tenantID+"a", "a")
 	assert.False(t, p)
+	p = dt.IsPermittedPerTenant(tenantID, "d")
+	assert.False(t, p)
+}
+
+func TestIsPermittedPerTenantWithCurrentTenant(t *testing.T) {
+	tenantID := "t1"
+	dt := &Token{
+		Claims: map[string]any{
+			ClaimDescopeCurrentTenant:        tenantID,
+			ClaimAuthorizedGlobalPermissions: []any{"a", "b", "c"},
+		},
+	}
+	p := dt.IsPermittedPerTenant(tenantID, "a")
+	assert.True(t, p)
 	p = dt.IsPermittedPerTenant(tenantID, "d")
 	assert.False(t, p)
 }


### PR DESCRIPTION
## Description
leftover from https://github.com/descope/go-sdk/pull/437

handle IsPermittedPerTenant and GetTeanats when descope current tenant exists