### PR TITLE
Add support for TOTP seed in invite users

### DIFF
--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -710,6 +710,9 @@ func makeCreateUsersBatchRequest(users []*descope.BatchUser, options *descope.In
 				user["hashedPassword"] = m
 			}
 		}
+		if u.Seed != nil {
+			user["seed"] = u.Seed
+		}
 		usersReq = append(usersReq, user)
 	}
 	req := map[string]any{

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -121,12 +121,14 @@ func TestUsersInviteBatchSuccess(t *testing.T) {
 
 	users := []*descope.BatchUser{}
 
+	u1Seed := "aaa"
 	u1 := &descope.BatchUser{}
 	u1.LoginID = "one"
 	u1.Email = "one@one.com"
 	u1.Roles = []string{"one"}
 	u1.CustomAttributes = ca
 	u1.Password = &descope.BatchUserPassword{Cleartext: "foo"}
+	u1.Seed = &u1Seed
 
 	u2 := &descope.BatchUser{}
 	u2.LoginID = "two"
@@ -170,6 +172,7 @@ func TestUsersInviteBatchSuccess(t *testing.T) {
 		roleNames := userRes1["roleNames"].([]any)
 		require.Len(t, roleNames, 1)
 		require.Equal(t, u1.Roles[0], roleNames[0])
+		require.EqualValues(t, &u1Seed, u1.Seed)
 
 		require.Equal(t, u2.LoginID, userRes2["loginId"])
 		require.Equal(t, u2.Email, userRes2["email"])
@@ -185,6 +188,7 @@ func TestUsersInviteBatchSuccess(t *testing.T) {
 		roleNames = userRes2["roleNames"].([]any)
 		require.Len(t, roleNames, 1)
 		require.Equal(t, u2.Roles[0], roleNames[0])
+		require.Nil(t, u2.Seed)
 	}, response))
 
 	res, err := m.User().InviteBatch(context.Background(), users, &descope.InviteOptions{

--- a/descope/types.go
+++ b/descope/types.go
@@ -389,6 +389,7 @@ type UserRequest struct {
 type BatchUser struct {
 	LoginID     string             `json:"loginId,omitempty"`
 	Password    *BatchUserPassword `json:"password,omitempty"`
+	Seed        *string            `json:"seed,omitempty"`
 	UserRequest `json:",inline"`
 }
 


### PR DESCRIPTION
## Related Issues
Related to: https://github.com/descope/etc/issues/6651


## Description
Add support for TOTP seed in invite users.

## Must
- [x] Tests
- [ ] Documentation (if applicable)

