### PR TITLE
Add Permitted IPs to Access Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,12 +930,14 @@ You can create, update, delete or load access keys, as well as search according 
 // on a per-tenant basis.
 // If userID is supplied, then authorization would be ignored, and access key would be bound to the users authorization
 // If customClaims is supplied, then those claims will be present in the JWT returned by calls to ExchangeAccessKey.
+// If permittedIps is supplied, then we will only allow using the access key from those IP addresses or CIDR ranges.
 res, err := descopeClient.Management.AccessKey().Create(context.Background(), "access-key-1", 0, nil, []*descope.AssociatedTenant{
 		{TenantID: "tenant-ID1", RoleNames: []string{"role-name1"}},
     	{TenantID: "tenant-ID2"},
     },
 	"",
-    map[string]any{"k1": "v1"})
+    map[string]any{"k1": "v1"},
+	nil)
 
 // Load specific access key
 res, err := descopeClient.Management.AccessKey().Load(context.Background(), "access-key-id")
@@ -1279,7 +1281,7 @@ if err == nil {
 You can also create audit event with data
 
 ```go
-err := descopeClient.Management.Audit().CreateEvent(context.Background(), &descope.AuditCreateOptions{ 
+err := descopeClient.Management.Audit().CreateEvent(context.Background(), &descope.AuditCreateOptions{
 	Action: "pencil.created",
 	Type: "info", // info/warn/error
 	ActorID: "UXXX",

--- a/descope/internal/mgmt/accesskey.go
+++ b/descope/internal/mgmt/accesskey.go
@@ -12,11 +12,11 @@ type accessKey struct {
 	managementBase
 }
 
-func (a *accessKey) Create(ctx context.Context, name string, expireTime int64, roleNames []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any) (string, *descope.AccessKeyResponse, error) {
+func (a *accessKey) Create(ctx context.Context, name string, expireTime int64, roleNames []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any, permittedIps []string) (string, *descope.AccessKeyResponse, error) {
 	if name == "" {
 		return "", nil, utils.NewInvalidArgumentError("name")
 	}
-	body := makeCreateAccessKeyBody(name, expireTime, roleNames, keyTenants, userID, customClaims)
+	body := makeCreateAccessKeyBody(name, expireTime, roleNames, keyTenants, userID, customClaims, permittedIps)
 	res, err := a.client.DoPostRequest(ctx, api.Routes.ManagementAccessKeyCreate(), body, nil, a.conf.ManagementKey)
 	if err != nil {
 		return "", nil, err
@@ -89,7 +89,7 @@ func (a *accessKey) Delete(ctx context.Context, id string) error {
 	return err
 }
 
-func makeCreateAccessKeyBody(name string, expireTime int64, roleNames []string, tenants []*descope.AssociatedTenant, userID string, customClaims map[string]any) map[string]any {
+func makeCreateAccessKeyBody(name string, expireTime int64, roleNames []string, tenants []*descope.AssociatedTenant, userID string, customClaims map[string]any, permittedIps []string) map[string]any {
 	return map[string]any{
 		"name":         name,
 		"expireTime":   expireTime,
@@ -97,6 +97,7 @@ func makeCreateAccessKeyBody(name string, expireTime int64, roleNames []string, 
 		"keyTenants":   makeAssociatedTenantList(tenants),
 		"userId":       userID,
 		"customClaims": customClaims,
+		"permittedIps": permittedIps,
 	}
 }
 

--- a/descope/internal/mgmt/accesskey_test.go
+++ b/descope/internal/mgmt/accesskey_test.go
@@ -15,6 +15,7 @@ func TestAccessKeyCreateSuccess(t *testing.T) {
 		"key": map[string]any{
 			"name":         "abc",
 			"customClaims": map[string]any{"k1": "v1"},
+			"permittedIps": []string{"10.0.0.1"},
 		}}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
@@ -27,9 +28,12 @@ func TestAccessKeyCreateSuccess(t *testing.T) {
 		require.Len(t, roleNames, 1)
 		require.Equal(t, "foo", roleNames[0])
 		require.Len(t, req["customClaims"], 1)
+		permittedIps := req["permittedIps"].([]any)
+		require.Len(t, permittedIps, 1)
+		require.Equal(t, "10.0.0.1", permittedIps[0])
 	}, response))
 	cc := map[string]any{"k1": "v1"}
-	cleartext, key, err := mgmt.AccessKey().Create(context.Background(), "abc", 0, []string{"foo"}, nil, "uid", cc)
+	cleartext, key, err := mgmt.AccessKey().Create(context.Background(), "abc", 0, []string{"foo"}, nil, "uid", cc, []string{"10.0.0.1"})
 	require.NoError(t, err)
 	require.Equal(t, "cleartext", cleartext)
 	require.Equal(t, "abc", key.Name)
@@ -39,7 +43,7 @@ func TestAccessKeyCreateSuccess(t *testing.T) {
 
 func TestAccessKeyCreateError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
-	_, _, err := mgmt.AccessKey().Create(context.Background(), "", 0, nil, nil, "", nil)
+	_, _, err := mgmt.AccessKey().Create(context.Background(), "", 0, nil, nil, "", nil, nil)
 	require.Error(t, err)
 }
 

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -410,7 +410,10 @@ type AccessKey interface {
 	// If userID is supplied, then authorization would be ignored, and access key would be bound to the users authorization
 	// The customClaims parameter is an optional map of claims and their values, and if it's provided then
 	// those claims will be present in the JWT returned by calls to ExchangeAccessKey.
-	Create(ctx context.Context, name string, expireTime int64, roles []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any) (string, *descope.AccessKeyResponse, error)
+	//
+	// The permittedIps parameter is an optional list of IP addresses or CIDR ranges that are allowed to use this access key.
+	// If not provided, all IPs are allowed.
+	Create(ctx context.Context, name string, expireTime int64, roles []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any, permittedIps []string) (string, *descope.AccessKeyResponse, error)
 
 	// Load an existing access key.
 	//

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -740,7 +740,7 @@ func (m *MockUser) History(_ context.Context, userIDs []string) ([]*descope.User
 // Mock Access Key
 
 type MockAccessKey struct {
-	CreateAssert     func(name string, expireTime int64, roles []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any)
+	CreateAssert     func(name string, expireTime int64, roles []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any, permittedIps []string)
 	CreateResponseFn func() (string, *descope.AccessKeyResponse)
 	CreateError      error
 
@@ -766,9 +766,9 @@ type MockAccessKey struct {
 	DeleteError  error
 }
 
-func (m *MockAccessKey) Create(_ context.Context, name string, expireTime int64, roles []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any) (string, *descope.AccessKeyResponse, error) {
+func (m *MockAccessKey) Create(_ context.Context, name string, expireTime int64, roles []string, keyTenants []*descope.AssociatedTenant, userID string, customClaims map[string]any, permittedIps []string) (string, *descope.AccessKeyResponse, error) {
 	if m.CreateAssert != nil {
-		m.CreateAssert(name, expireTime, roles, keyTenants, userID, customClaims)
+		m.CreateAssert(name, expireTime, roles, keyTenants, userID, customClaims, permittedIps)
 	}
 	var cleartext string
 	var key *descope.AccessKeyResponse

--- a/descope/types.go
+++ b/descope/types.go
@@ -536,6 +536,7 @@ type AccessKeyResponse struct {
 	ClientID     string              `json:"clientId,omitempty"`
 	UserID       string              `json:"boundUserId,omitempty"`
 	CustomClaims map[string]any      `json:"customClaims,omitempty"`
+	PermittedIps []string            `json:"permittedIps,omitempty"`
 }
 
 // Represents a tenant association for a User or an Access Key. The tenant ID is required


### PR DESCRIPTION
Related to https://github.com/descope/etc/issues/6798

## Description
Adds Permitted IPs to Access Keys

## Must
- [X] Tests
- [ ] Documentation (if applicable)
