### PR TITLE
Add support for custom templateID in sign up and sign in

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -29,7 +29,7 @@ runs:
           coverage.html
 
     - name: Convert coverage to lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.8
+      uses: jandelgado/gcov2lcov-action@v1.1.0
 
     - name: Enforce coverage
       uses: devmasx/coverage-check-action@v1.2.0

--- a/descope/internal/auth/enchantedlink.go
+++ b/descope/internal/auth/enchantedlink.go
@@ -59,6 +59,7 @@ func (auth *enchantedLink) SignUpOrIn(ctx context.Context, loginID, URI string, 
 	httpResponse, err := auth.client.DoPostRequest(ctx, composeEnchantedLinkSignUpOrInURL(), newMagicLinkAuthenticationRequestBody(loginID, URI, true, &descope.LoginOptions{
 		CustomClaims:    signUpOptions.CustomClaims,
 		TemplateOptions: signUpOptions.TemplateOptions,
+		TemplateID:      signUpOptions.TemplateID,
 	}), nil, "")
 	if err != nil {
 		return nil, err

--- a/descope/internal/auth/enchantedlink_test.go
+++ b/descope/internal/auth/enchantedlink_test.go
@@ -147,7 +147,7 @@ func TestSignUpEnchantedLinkWithSignUpOptions(t *testing.T) {
 		assert.EqualValues(t, uri, m["URI"])
 		assert.EqualValues(t, email, m["loginId"])
 		assert.EqualValues(t, "test", m["user"].(map[string]interface{})["name"])
-		assert.EqualValues(t, map[string]interface{}{"customClaims": map[string]interface{}{"aa": "bb"}, "templateOptions": map[string]interface{}{"cc": "dd"}}, m["loginOptions"])
+		assert.EqualValues(t, map[string]interface{}{"customClaims": map[string]interface{}{"aa": "bb"}, "templateOptions": map[string]interface{}{"cc": "dd"}, "templateId": "foo"}, m["loginOptions"])
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"pendingRef": "%s","linkId": "%s"}`, pendingRefResponse, loginID))),
@@ -157,6 +157,7 @@ func TestSignUpEnchantedLinkWithSignUpOptions(t *testing.T) {
 	response, err := a.EnchantedLink().SignUp(context.Background(), email, uri, &descope.User{Name: "test"}, &descope.SignUpOptions{
 		CustomClaims:    map[string]interface{}{"aa": "bb"},
 		TemplateOptions: map[string]string{"cc": "dd"},
+		TemplateID:      "foo",
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, pendingRefResponse, response.PendingRef)

--- a/descope/internal/auth/magiclink.go
+++ b/descope/internal/auth/magiclink.go
@@ -56,6 +56,7 @@ func (auth *magicLink) SignUpOrIn(ctx context.Context, method descope.DeliveryMe
 	_, err := auth.client.DoPostRequest(ctx, composeMagicLinkSignUpOrInURL(method), newMagicLinkAuthenticationRequestBody(loginID, URI, false, &descope.LoginOptions{
 		CustomClaims:    signUpOptions.CustomClaims,
 		TemplateOptions: signUpOptions.TemplateOptions,
+		TemplateID:      signUpOptions.TemplateID,
 	}), options, "")
 	return masked.GetMasked(), err
 }

--- a/descope/internal/auth/magiclink_test.go
+++ b/descope/internal/auth/magiclink_test.go
@@ -209,13 +209,14 @@ func TestSignUpMagicLinkEmailWithSignUpOptions(t *testing.T) {
 		resp := MaskedEmailRes{MaskedEmail: maskedEmail}
 		respBytes, err := utils.Marshal(resp)
 		require.NoError(t, err)
-		assert.EqualValues(t, map[string]interface{}{"customClaims": map[string]interface{}{"aa": "bb"}, "templateOptions": map[string]interface{}{"cc": "dd"}}, m["loginOptions"])
+		assert.EqualValues(t, map[string]interface{}{"customClaims": map[string]interface{}{"aa": "bb"}, "templateOptions": map[string]interface{}{"cc": "dd"}, "templateId": "foo"}, m["loginOptions"])
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
 	})
 	require.NoError(t, err)
 	me, err := a.MagicLink().SignUp(context.Background(), descope.MethodEmail, email, uri, &descope.User{Name: "test"}, &descope.SignUpOptions{
 		CustomClaims:    map[string]interface{}{"aa": "bb"},
 		TemplateOptions: map[string]string{"cc": "dd"},
+		TemplateID:      "foo",
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, maskedEmail, me)

--- a/descope/internal/auth/otp.go
+++ b/descope/internal/auth/otp.go
@@ -58,6 +58,7 @@ func (auth *otp) SignUpOrIn(ctx context.Context, method descope.DeliveryMethod, 
 	_, err := auth.client.DoPostRequest(ctx, composeSignUpOrInURL(method), newSignInRequestBody(loginID, &descope.LoginOptions{
 		CustomClaims:    signUpOptions.CustomClaims,
 		TemplateOptions: signUpOptions.TemplateOptions,
+		TemplateID:      signUpOptions.TemplateID,
 	}), options, "")
 	return masked.GetMasked(), err
 }

--- a/descope/internal/auth/otp_test.go
+++ b/descope/internal/auth/otp_test.go
@@ -86,13 +86,14 @@ func TestSignUpEmailWithSignUpOptions(t *testing.T) {
 		resp := MaskedEmailRes{MaskedEmail: maskedEmail}
 		respBytes, err := utils.Marshal(resp)
 		require.NoError(t, err)
-		assert.EqualValues(t, map[string]interface{}{"customClaims": map[string]interface{}{"aa": "bb"}, "templateOptions": map[string]interface{}{"cc": "dd"}}, m["loginOptions"])
+		assert.EqualValues(t, map[string]interface{}{"customClaims": map[string]interface{}{"aa": "bb"}, "templateOptions": map[string]interface{}{"cc": "dd"}, "templateId": "foo"}, m["loginOptions"])
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
 	})
 	require.NoError(t, err)
 	me, err := a.OTP().SignUp(context.Background(), descope.MethodEmail, email, &descope.User{Name: "test"}, &descope.SignUpOptions{
 		CustomClaims:    map[string]interface{}{"aa": "bb"},
 		TemplateOptions: map[string]string{"cc": "dd"},
+		TemplateID:      "foo",
 	})
 	require.NoError(t, err)
 	assert.EqualValues(t, maskedEmail, me)

--- a/descope/internal/auth/utils.go
+++ b/descope/internal/auth/utils.go
@@ -199,6 +199,7 @@ func newMagicLinkAuthenticationSignUpRequestBody(method descope.DeliveryMethod, 
 	b.LoginOptions = &descope.LoginOptions{
 		CustomClaims:    signUpOptions.CustomClaims,
 		TemplateOptions: signUpOptions.TemplateOptions,
+		TemplateID:      signUpOptions.TemplateID,
 	}
 	return &magicLinkAuthenticationSignUpRequestBody{authenticationSignUpRequestBody: b, CrossDevice: crossDevice, URI: URI}
 }
@@ -217,6 +218,7 @@ func newAuthenticationSignUpRequestBody(method descope.DeliveryMethod, loginID s
 	b.LoginOptions = &descope.LoginOptions{
 		CustomClaims:    signUpOptions.CustomClaims,
 		TemplateOptions: signUpOptions.TemplateOptions,
+		TemplateID:      signUpOptions.TemplateID,
 	}
 	return b
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -301,6 +301,7 @@ type LoginOptions struct {
 	Stepup          bool                   `json:"stepup,omitempty"`
 	MFA             bool                   `json:"mfa,omitempty"`
 	CustomClaims    map[string]interface{} `json:"customClaims,omitempty"`
+	TemplateID      string                 `json:"templateId,omitempty"`      // for overriding the default messaging template
 	TemplateOptions map[string]string      `json:"templateOptions,omitempty"` // for providing messaging template options (templates that are being sent via email / text message)
 }
 
@@ -314,6 +315,7 @@ type AccessKeyLoginOptions struct {
 
 type SignUpOptions struct {
 	CustomClaims    map[string]interface{} `json:"customClaims,omitempty"`
+	TemplateID      string                 `json:"templateId,omitempty"`      // for overriding the default messaging template
 	TemplateOptions map[string]string      `json:"templateOptions,omitempty"` // for providing messaging template options (templates that are being sent via email / text message)
 }
 


### PR DESCRIPTION
## Description
- Add support for custom `templateID` in sign up and sign in operations to choose a different messaging template other than the default one when a custom provider is configured.

## Must
- [X] Tests
- [X] Documentation (if applicable)
