### PR TITLE
Expose additional errors on invite batch

### DIFF
--- a/descope/types.go
+++ b/descope/types.go
@@ -525,8 +525,9 @@ type UsersFailedResponse struct {
 }
 
 type UsersBatchResponse struct {
-	CreatedUsers []*UserResponse        `json:"createdUsers,omitempty"`
-	FailedUsers  []*UsersFailedResponse `json:"failedUsers,omitempty"`
+	CreatedUsers     []*UserResponse        `json:"createdUsers,omitempty"`
+	FailedUsers      []*UsersFailedResponse `json:"failedUsers,omitempty"`
+	AdditionalErrors map[string]string      `json:"additionalErrors,omitempty"`
 }
 
 func (ur *UserResponse) GetCreatedTime() time.Time {


### PR DESCRIPTION
So we can see which users failed on the invite sent and which not
