### PR TITLE
Add option to logout all previous JWTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,14 @@ invalidate all user's refresh tokens. After calling this function, you must inva
 descopeClient.Auth.LogoutAll(request, w)
 ```
 
+It is also possible to sign the user out of previous session. Calling `logoutPrevious` will
+invalidate all user's refresh tokens that were generated prior to the given session.
+
+```go
+// Refresh token will be taken from the request header or cookies automatically
+descopeClient.Auth.LogoutPrevious(request)
+```
+
 ### History
 
 You can get the current session user history.

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -203,30 +203,32 @@ var (
 			fgaDeleteRelations:                 "mgmt/fga/relations/delete",
 			fgaCheck:                           "mgmt/fga/check",
 		},
-		logout:       "auth/logout",
-		logoutAll:    "auth/logoutall",
-		keys:         "/keys/",
-		refresh:      "auth/refresh",
-		selectTenant: "auth/tenant/select",
-		me:           "auth/me",
-		meTenants:    "auth/me/tenants",
-		history:      "auth/me/history",
+		logout:         "auth/logout",
+		logoutAll:      "auth/logoutall",
+		logoutPrevious: "auth/logoutprevious",
+		keys:           "/keys/",
+		refresh:        "auth/refresh",
+		selectTenant:   "auth/tenant/select",
+		me:             "auth/me",
+		meTenants:      "auth/me/tenants",
+		history:        "auth/me/history",
 	}
 )
 
 type endpoints struct {
-	version      string
-	versionV2    string
-	auth         authEndpoints
-	mgmt         mgmtEndpoints
-	logout       string
-	logoutAll    string
-	keys         string
-	refresh      string
-	selectTenant string
-	me           string
-	meTenants    string
-	history      string
+	version        string
+	versionV2      string
+	auth           authEndpoints
+	mgmt           mgmtEndpoints
+	logout         string
+	logoutAll      string
+	logoutPrevious string
+	keys           string
+	refresh        string
+	selectTenant   string
+	me             string
+	meTenants      string
+	history        string
 }
 
 type authEndpoints struct {
@@ -599,6 +601,10 @@ func (e *endpoints) Logout() string {
 
 func (e *endpoints) LogoutAll() string {
 	return path.Join(e.version, e.logoutAll)
+}
+
+func (e *endpoints) LogoutPrevious() string {
+	return path.Join(e.version, e.logoutPrevious)
 }
 
 func (e *endpoints) Me() string {

--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -231,6 +231,37 @@ func (auth *authenticationService) logoutAll(request *http.Request, w http.Respo
 	return nil
 }
 
+func (auth *authenticationService) LogoutPrevious(request *http.Request) error {
+	return auth.logoutPrevious(request)
+}
+
+func (auth *authenticationService) LogoutPreviousWithToken(refreshToken string) error {
+	request := &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: refreshToken})
+	return auth.logoutPrevious(request)
+}
+
+func (auth *authenticationService) logoutPrevious(request *http.Request) error {
+	if request == nil {
+		return utils.NewInvalidArgumentError("request")
+	}
+
+	_, refreshToken := provideTokens(request)
+	if refreshToken == "" {
+		logger.LogDebug("Unable to find tokens from cookies")
+		return descope.ErrRefreshToken.WithMessage("Unable to find tokens from cookies")
+	}
+
+	_, err := auth.validateJWT(refreshToken)
+	if err != nil {
+		logger.LogDebug("Invalid refresh token")
+		return descope.ErrRefreshToken.WithMessage("Invalid refresh token")
+	}
+
+	_, err = auth.client.DoPostRequest(request.Context(), api.Routes.LogoutPrevious(), nil, &api.HTTPRequest{}, refreshToken)
+	return err
+}
+
 func (auth *authenticationService) Me(request *http.Request) (*descope.UserResponse, error) {
 	if request == nil {
 		return nil, utils.NewInvalidArgumentError("request")

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -762,6 +762,28 @@ func TestLogoutAllWithToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLogoutPrevious(t *testing.T) {
+	a, err := newTestAuth(nil, func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(mockAuthSessionBody))}, nil
+	})
+	require.NoError(t, err)
+	request := &http.Request{Header: http.Header{}}
+	request.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtRTokenValid})
+
+	err = a.LogoutPrevious(request)
+	require.NoError(t, err)
+}
+
+func TestLogoutPreviousWithToken(t *testing.T) {
+	a, err := newTestAuth(nil, func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(mockAuthSessionBody))}, nil
+	})
+	require.NoError(t, err)
+
+	err = a.LogoutPreviousWithToken(jwtRTokenValid)
+	require.NoError(t, err)
+}
+
 func TestLogoutNoClaims(t *testing.T) {
 	a, err := newTestAuth(nil, func(_ *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK}, nil

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -424,6 +424,12 @@ type Authentication interface {
 	// Use the ResponseWriter (optional) to apply the cookies to the response automatically.
 	LogoutAllWithToken(refreshToken string, w http.ResponseWriter) error
 
+	// LogoutPrevious - Use to perform logout from all active sessions that were created prior to the given token.
+	LogoutPrevious(request *http.Request) error
+
+	// LogoutPreviousWithToken - Use to perform logout from all active sessions that were created prior to the given token.
+	LogoutPreviousWithToken(refreshToken string) error
+
 	// Me - Use to retrieve current session user details. The request requires a valid refresh token.
 	// returns the user details or error if the refresh token is not valid.
 	Me(request *http.Request) (*descope.UserResponse, error)

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -692,6 +692,12 @@ type MockSession struct {
 	LogoutAllWithTokenAssert func(refreshToken string, w http.ResponseWriter)
 	LogoutAllWithTokenError  error
 
+	LogoutPreviousAssert func(r *http.Request)
+	LogoutPreviousError  error
+
+	LogoutPreviousWithTokenAssert func(refreshToken string)
+	LogoutPreviousWithTokenError  error
+
 	MeAssert   func(r *http.Request)
 	MeError    error
 	MeResponse *descope.UserResponse
@@ -883,6 +889,20 @@ func (m *MockSession) LogoutAllWithToken(refreshToken string, w http.ResponseWri
 		m.LogoutAllWithTokenAssert(refreshToken, w)
 	}
 	return m.LogoutAllWithTokenError
+}
+
+func (m *MockSession) LogoutPrevious(r *http.Request) error {
+	if m.LogoutPreviousAssert != nil {
+		m.LogoutPreviousAssert(r)
+	}
+	return m.LogoutPreviousError
+}
+
+func (m *MockSession) LogoutPreviousWithToken(refreshToken string) error {
+	if m.LogoutPreviousWithTokenAssert != nil {
+		m.LogoutPreviousWithTokenAssert(refreshToken)
+	}
+	return m.LogoutPreviousWithTokenError
 }
 
 func (m *MockSession) Me(r *http.Request) (*descope.UserResponse, error) {


### PR DESCRIPTION
This new function call, will expire all jwts created prior to the one in the request related to https://github.com/descope/etc/issues/8242
+ tests
