### PR TITLE
Management User Add Tenant Roles API upgrade

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -794,7 +794,7 @@ func (e *endpoints) ManagementUserSetRole() string {
 }
 
 func (e *endpoints) ManagementUserAddRole() string {
-	return path.Join(e.version, e.mgmt.userAddRole)
+	return path.Join(e.versionV2, e.mgmt.userAddRole)
 }
 
 func (e *endpoints) ManagementUserRemoveRole() string {

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -3,6 +3,7 @@ package mgmt
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/descope/go-sdk/descope"
@@ -1147,6 +1148,7 @@ func TestUserAddRoleSuccess(t *testing.T) {
 			"roleNames": []string{"foo"},
 		}}
 	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.True(t, strings.HasPrefix(r.URL.RequestURI(), "/v2/"))
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
@@ -1457,6 +1459,7 @@ func TestUserAddTenantRoleSuccess(t *testing.T) {
 		}}
 	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		assert.True(t, strings.HasPrefix(r.URL.RequestURI(), "/v2/"))
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "abc", req["loginId"])


### PR DESCRIPTION
## Description
Updates the version for the Management User Add Tenant Roles API. 
With this new version, roles will be added to the tenant even if the user does not have access to the tenant. Access to the tenant will be added.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)
