### PR TITLE
Multi SSO - allow to pass SSO ID for sso start method (breaks compilation)

### DIFF
--- a/descope/internal/auth/sso.go
+++ b/descope/internal/auth/sso.go
@@ -18,7 +18,7 @@ type ssoStartResponse struct {
 	URL string `json:"url"`
 }
 
-func (auth *sso) Start(ctx context.Context, tenant string, redirectURL string, prompt string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+func (auth *sso) Start(ctx context.Context, tenant string, redirectURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
 	if tenant == "" {
 		return "", utils.NewInvalidArgumentError("tenant")
 	}
@@ -31,6 +31,10 @@ func (auth *sso) Start(ctx context.Context, tenant string, redirectURL string, p
 	if len(prompt) > 0 {
 		m["prompt"] = prompt
 	}
+	if len(ssoID) > 0 {
+		m["ssoId"] = ssoID
+	}
+
 	var pswd string
 	if loginOptions.IsJWTRequired() {
 		pswd, err = getValidRefreshToken(r)

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -261,7 +261,8 @@ type SSOServiceProvider interface {
 	// return will be the redirect URL that needs to return to client
 	// and finalize with the ExchangeToken call
 	// prompt argument relevant only in case tenant configured with AuthType OIDC
-	Start(ctx context.Context, tenant string, returnURL string, prompt string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (redirectURL string, err error)
+	// ssoID can be used for providing the relevant SSO configuration (when having multiple SSO configurations per tenant)
+	Start(ctx context.Context, tenant string, returnURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (redirectURL string, err error)
 
 	// ExchangeToken - Finalize tenant login authentication
 	// code should be extracted from the redirect URL of SAML/OIDC authentication flow

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -509,7 +509,7 @@ func (m *MockSAML) ExchangeToken(_ context.Context, code string, w http.Response
 // Mock SSO
 
 type MockSSO struct {
-	StartAssert   func(tenant string, redirectURL string, prompt string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	StartAssert   func(tenant string, redirectURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	StartError    error
 	StartResponse string
 
@@ -518,9 +518,9 @@ type MockSSO struct {
 	ExchangeTokenResponse *descope.AuthenticationInfo
 }
 
-func (m *MockSSO) Start(_ context.Context, tenant string, redirectURL string, prompt string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockSSO) Start(_ context.Context, tenant string, redirectURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.StartAssert != nil {
-		m.StartAssert(tenant, redirectURL, prompt, r, loginOptions, w)
+		m.StartAssert(tenant, redirectURL, prompt, ssoID, r, loginOptions, w)
 	}
 	return m.StartResponse, m.StartError
 }


### PR DESCRIPTION
## Description
Multi SSO - allow to pass SSO ID for sso start method, only relevant when using Multi SSO.
This breaks complation.

Related to https://github.com/descope/etc/issues/2119

## Must
- [x] Tests
- [ ] Documentation (if applicable)
