### PR TITLE
feat: added support for paging audit search results 

### DIFF
--- a/descope/internal/mgmt/audit.go
+++ b/descope/internal/mgmt/audit.go
@@ -32,6 +32,8 @@ func (a *audit) Search(ctx context.Context, options *descope.AuditSearchOptions)
 		"tenants":         options.Tenants,
 		"noTenants":       options.NoTenants,
 		"text":            options.Text,
+		"size":            options.Size,
+		"page":            options.Page,
 	}
 	res, err := a.client.DoPostRequest(ctx, api.Routes.ManagementAuditSearch(), body, nil, a.conf.ManagementKey)
 	if err != nil {

--- a/descope/internal/mgmt/audit_test.go
+++ b/descope/internal/mgmt/audit_test.go
@@ -56,6 +56,8 @@ func TestAuditSearch(t *testing.T) {
 		Tenants:         []string{"t1"},
 		NoTenants:       true,
 		Text:            "kuku",
+		Size:            10,
+		Page:            1,
 	}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		called = true
@@ -75,6 +77,8 @@ func TestAuditSearch(t *testing.T) {
 		require.EqualValues(t, []interface{}{searchOptions.Tenants[0]}, req["tenants"])
 		require.EqualValues(t, searchOptions.NoTenants, req["noTenants"])
 		require.EqualValues(t, searchOptions.Text, req["text"])
+		require.EqualValues(t, searchOptions.Size, req["size"])
+		require.EqualValues(t, searchOptions.Page, req["page"])
 	}, response))
 	res, err := mgmt.Audit().Search(context.Background(), searchOptions)
 	require.NoError(t, err)

--- a/descope/types.go
+++ b/descope/types.go
@@ -870,6 +870,8 @@ type AuditSearchOptions struct {
 	Tenants         []string  `json:"tenants"`                   // List of tenants to filter by
 	NoTenants       bool      `json:"noTenants"`                 // Should audits without any tenants always be included
 	Text            string    `json:"text"`                      // Free text search across all fields
+	Size            int32     `json:"size,omitempty"`            // Number of results to include per retrived page. Current default, and max value, is 1000.
+	Page            int32     `json:"page,omitempty"`            // Page number of results to retrieve, zero-based. Default is 0.
 }
 
 type AuditCreateOptions struct {

--- a/examples/webapp/go.sum
+++ b/examples/webapp/go.sum
@@ -25,7 +25,7 @@ github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e h1:Ctm9yurWsg7aWwIpH9Bnap/IdSVxixymIb3MhiMEQQA=

--- a/examples/webapp/main.go
+++ b/examples/webapp/main.go
@@ -95,6 +95,8 @@ func main() {
 	router.HandleFunc("/stepup/stepup", handleStepupStepup).Methods(http.MethodGet)
 	router.HandleFunc("/stepup/stepup/verify", handleStepupStepupVerify).Methods(http.MethodGet)
 
+	router.HandleFunc("/mgmt/audit/search", handleAuditSearch).Methods(http.MethodGet)
+
 	authRouter := router.Methods(http.MethodGet).Subrouter()
 	authRouter.Use(sdk.AuthenticationMiddleware(descopeClient.Auth, func(w http.ResponseWriter, r *http.Request, err error) {
 		setResponse(w, http.StatusUnauthorized, "Unauthorized")
@@ -154,6 +156,8 @@ func help(w http.ResponseWriter, r *http.Request) {
 	helpTxt += "Start a stepup flow go to: /stepup\n\n"
 	helpTxt += "---------------------------------------------------------\n\n"
 	helpTxt += "See that you are actually logged in go to: /private \n\n"
+	helpTxt += "---------------------------------------------------------\n\n"
+	helpTxt += "Run a management audit search go to: /mgmt/audit/search \n\n"
 	setResponse(w, http.StatusOK, helpTxt)
 }
 
@@ -557,6 +561,19 @@ func handleStepupStepupVerify(w http.ResponseWriter, r *http.Request) {
 	mr, _ := json.MarshalIndent(authInfo, "", "")
 	helpTxt += string(mr)
 	setResponse(w, http.StatusOK, helpTxt)
+}
+
+func handleAuditSearch(w http.ResponseWriter, r *http.Request) {
+	searchOptions := &descope.AuditSearchOptions{}
+	auditSearchRes, err := descopeClient.Management.Audit().Search(r.Context(), searchOptions)
+	if err != nil {
+		setError(w, err.Error())
+	} else {
+		helpTxt := fmt.Sprintf("Audit Search Results (%d Results Returned):\n", len(auditSearchRes))
+		mr, _ := json.MarshalIndent(auditSearchRes, "", "\t")
+		helpTxt += string(mr) + "\n"
+		setResponse(w, http.StatusOK, helpTxt)
+	}
 }
 
 func queryBool(r *http.Request, key string) bool {


### PR DESCRIPTION
Added support for paging audit search results and updated example webapp accordingly

## Description
Added support for the setting the "size" and "page" parameters for the `/mgmt/audit/search` API call via the SDK
Fixes: https://github.com/descope/etc/issues/8822

## Must
- [x] Tests
- [ ] Documentation (if applicable)
