### PR TITLE
Allow updating jwt expiry via SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,7 +1273,7 @@ You can add custom claims to a valid JWT.
 updatedJWT, err := descopeClient.Management.JWT().UpdateJWTWithCustomClaims(context.Background(), "original-jwt", map[string]any{
     "custom-key1": "custom-value1",
     "custom-key2": "custom-value2",
-})
+}, 60*9)
 if err != nil {
     // handle error
 }

--- a/descope/client/client_test.go
+++ b/descope/client/client_test.go
@@ -101,7 +101,7 @@ func TestDescopeSDKMock(t *testing.T) {
 		Management: &mocksmgmt.MockManagement{
 			MockJWT: &mocksmgmt.MockJWT{
 				UpdateJWTWithCustomClaimsResponse: updateJWTWithCustomClaimsResponse,
-				UpdateJWTWithCustomClaimsAssert: func(jwt string, _ map[string]any) {
+				UpdateJWTWithCustomClaimsAssert: func(jwt string, _ map[string]any, _ int32) {
 					updateJWTWithCustomClaimsCalled = true
 					assert.EqualValues(t, "some jwt", jwt)
 				},
@@ -115,7 +115,7 @@ func TestDescopeSDKMock(t *testing.T) {
 	assert.EqualValues(t, validateSessionResponse, info.JWT)
 	assert.ErrorIs(t, err, descope.ErrPublicKey)
 
-	res, err := api.Management.JWT().UpdateJWTWithCustomClaims(ctx, "some jwt", nil)
+	res, err := api.Management.JWT().UpdateJWTWithCustomClaims(ctx, "some jwt", nil, 0)
 	require.NoError(t, err)
 	assert.True(t, updateJWTWithCustomClaimsCalled)
 	assert.EqualValues(t, updateJWTWithCustomClaimsResponse, res)

--- a/descope/internal/mgmt/jwt.go
+++ b/descope/internal/mgmt/jwt.go
@@ -18,14 +18,15 @@ type jwtRes struct {
 	JWT string `json:"jwt,omitempty"`
 }
 
-func (j *jwt) UpdateJWTWithCustomClaims(ctx context.Context, jwt string, customClaims map[string]any) (string, error) {
+func (j *jwt) UpdateJWTWithCustomClaims(ctx context.Context, jwt string, customClaims map[string]any, refreshDuration int32) (string, error) {
 	if jwt == "" {
 		return "", utils.NewInvalidArgumentError("jwt")
 	}
 	// customClaims can be nil, it will mean that this JWT will be validated, and updated authz data will be set
 	req := map[string]any{
-		"jwt":          jwt,
-		"customClaims": customClaims,
+		"jwt":             jwt,
+		"customClaims":    customClaims,
+		"refreshDuration": refreshDuration,
 	}
 	res, err := j.client.DoPostRequest(ctx, api.Routes.ManagementUpdateJWT(), req, nil, j.conf.ManagementKey)
 	if err != nil {

--- a/descope/internal/mgmt/jwt_test.go
+++ b/descope/internal/mgmt/jwt_test.go
@@ -13,15 +13,17 @@ func TestUpdateJwt(t *testing.T) {
 	orgJwt := "orgjwt"
 	customClaims := map[string]any{"k1": "v1"}
 	expectedJWT := "res"
+	refreshDuration := 3
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.EqualValues(t, orgJwt, req["jwt"])
 		require.EqualValues(t, customClaims, req["customClaims"])
+		require.EqualValues(t, refreshDuration, req["refreshDuration"])
 
 	}, map[string]interface{}{"jwt": expectedJWT}))
-	jwtRes, err := mgmt.JWT().UpdateJWTWithCustomClaims(context.Background(), orgJwt, customClaims)
+	jwtRes, err := mgmt.JWT().UpdateJWTWithCustomClaims(context.Background(), orgJwt, customClaims, int32(refreshDuration))
 	require.NoError(t, err)
 	require.EqualValues(t, expectedJWT, jwtRes)
 }
@@ -31,7 +33,7 @@ func TestUpdateJwtMissingJWT(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
 		called = true
 	}))
-	jwtRes, err := mgmt.JWT().UpdateJWTWithCustomClaims(context.Background(), "", nil)
+	jwtRes, err := mgmt.JWT().UpdateJWTWithCustomClaims(context.Background(), "", nil, 0)
 	require.Error(t, err)
 	require.False(t, called)
 	require.Empty(t, jwtRes)
@@ -42,7 +44,7 @@ func TestUpdateJwtHTTPError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoBadRequest(func(_ *http.Request) {
 		called = true
 	}))
-	jwtRes, err := mgmt.JWT().UpdateJWTWithCustomClaims(context.Background(), "test", nil)
+	jwtRes, err := mgmt.JWT().UpdateJWTWithCustomClaims(context.Background(), "test", nil, 0)
 	require.Error(t, err)
 	require.True(t, called)
 	require.Empty(t, jwtRes)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -554,8 +554,10 @@ type PasswordManagement interface {
 // Provide functions for manipulating valid JWT
 type JWT interface {
 	// Update a valid JWT with the custom claims provided
+	// Also the expiration of the jwt can be set by providing a duration in seconds
+	// providing 0, will leave the expiration as is
 	// The new JWT will be returned
-	UpdateJWTWithCustomClaims(ctx context.Context, jwt string, customClaims map[string]any) (string, error)
+	UpdateJWTWithCustomClaims(ctx context.Context, jwt string, customClaims map[string]any, refreshDuration int32) (string, error)
 
 	// Impersonate another user
 	// The impersonator user must have `impersonation` permission in order for this request to work

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -94,7 +94,7 @@ func (m *MockManagement) ThirdPartyApplication() sdk.ThirdPartyApplication {
 // Mock JWT
 
 type MockJWT struct {
-	UpdateJWTWithCustomClaimsAssert   func(jwt string, customClaims map[string]any)
+	UpdateJWTWithCustomClaimsAssert   func(jwt string, customClaims map[string]any, refreshDuration int32)
 	UpdateJWTWithCustomClaimsResponse string
 	UpdateJWTWithCustomClaimsError    error
 
@@ -103,9 +103,9 @@ type MockJWT struct {
 	ImpersonateError    error
 }
 
-func (m *MockJWT) UpdateJWTWithCustomClaims(_ context.Context, jwt string, customClaims map[string]any) (string, error) {
+func (m *MockJWT) UpdateJWTWithCustomClaims(_ context.Context, jwt string, customClaims map[string]any, refreshDuration int32) (string, error) {
 	if m.UpdateJWTWithCustomClaimsAssert != nil {
-		m.UpdateJWTWithCustomClaimsAssert(jwt, customClaims)
+		m.UpdateJWTWithCustomClaimsAssert(jwt, customClaims, refreshDuration)
 	}
 	return m.UpdateJWTWithCustomClaimsResponse, m.UpdateJWTWithCustomClaimsError
 }


### PR DESCRIPTION
Supported as part of jwt update flow
+test
fixes https://github.com/descope/etc/issues/8900
