### PR TITLE
Signup or in via mgmt

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -155,6 +155,9 @@ var (
 			passwordSettings:                    "mgmt/password/settings",
 			updateJWT:                           "mgmt/jwt/update",
 			impersonate:                         "mgmt/impersonate",
+			mgmtSignIn:                          "mgmt/auth/signin",
+			mgmtSignUp:                          "mgmt/auth/signup",
+			mgmtSignUpOrIn:                      "mgmt/auth/signup-in",
 			permissionCreate:                    "mgmt/permission/create",
 			permissionUpdate:                    "mgmt/permission/update",
 			permissionDelete:                    "mgmt/permission/delete",
@@ -372,6 +375,9 @@ type mgmtEndpoints struct {
 	ssoOIDCSettings           string
 	updateJWT                 string
 	impersonate               string
+	mgmtSignIn                string
+	mgmtSignUp                string
+	mgmtSignUpOrIn            string
 
 	passwordSettings string
 
@@ -946,6 +952,18 @@ func (e *endpoints) ManagementUpdateJWT() string {
 
 func (e *endpoints) ManagementImpersonate() string {
 	return path.Join(e.version, e.mgmt.impersonate)
+}
+
+func (e *endpoints) ManagementSignIn() string {
+	return path.Join(e.version, e.mgmt.mgmtSignIn)
+}
+
+func (e *endpoints) ManagementSignUp() string {
+	return path.Join(e.version, e.mgmt.mgmtSignUp)
+}
+
+func (e *endpoints) ManagementSignUpOrIn() string {
+	return path.Join(e.version, e.mgmt.mgmtSignUpOrIn)
 }
 
 func (e *endpoints) ManagementGenerateEmbeddedLink() string {

--- a/descope/client/client.go
+++ b/descope/client/client.go
@@ -59,19 +59,20 @@ func NewWithConfig(config *Config) (*DescopeClient, error) {
 		CertificateVerify:    config.CertificateVerify,
 		RequestTimeout:       config.RequestTimeout,
 	})
-
-	authService, err := auth.NewAuth(auth.AuthParams{
+	conf := &auth.AuthParams{
 		ProjectID:           config.ProjectID,
 		PublicKey:           config.PublicKey,
 		SessionJWTViaCookie: config.SessionJWTViaCookie,
 		CookieDomain:        config.SessionJWTCookieDomain,
 		CookieSameSite:      config.SessionJWTCookieSameSite,
-	}, c)
+	}
+	provider := auth.NewProvider(c, conf)
+	authService, err := auth.NewAuthWithProvider(*conf, provider, c)
 	if err != nil {
 		return nil, err
 	}
 
-	managementService := mgmt.NewManagement(mgmt.ManagementParams{ProjectID: config.ProjectID, ManagementKey: config.ManagementKey}, c)
+	managementService := mgmt.NewManagement(mgmt.ManagementParams{ProjectID: config.ProjectID, ManagementKey: config.ManagementKey}, provider, c)
 
 	return &DescopeClient{Auth: authService, Management: managementService, config: config}, nil
 }

--- a/descope/internal/mgmt/jwt.go
+++ b/descope/internal/mgmt/jwt.go
@@ -3,13 +3,17 @@ package mgmt
 import (
 	"context"
 
+	"github.com/descope/go-sdk/descope"
 	"github.com/descope/go-sdk/descope/api"
+	"github.com/descope/go-sdk/descope/internal/auth"
 	"github.com/descope/go-sdk/descope/internal/utils"
+	"github.com/descope/go-sdk/descope/logger"
 	"github.com/descope/go-sdk/descope/sdk"
 )
 
 type jwt struct {
 	managementBase
+	provider *auth.Provider
 }
 
 var _ sdk.JWT = &jwt{}
@@ -64,4 +68,107 @@ func (j *jwt) Impersonate(ctx context.Context, impersonatorID string, loginID st
 		return "", err //notest
 	}
 	return jRes.JWT, nil
+}
+
+func (j *jwt) parseJWT(jwtResponse *descope.JWTResponse) (*descope.AuthenticationInfo, error) {
+	dsr, err := auth.ValidateJWT(jwtResponse.RefreshJwt, j.provider)
+	if err != nil {
+		return nil, err
+	}
+	ds, err := auth.ValidateJWT(jwtResponse.SessionJwt, j.provider)
+	if err != nil {
+		return nil, err
+	}
+	ds.RefreshExpiration = dsr.Expiration
+	return descope.NewAuthenticationInfo(jwtResponse, ds, dsr), nil
+}
+
+type authenticationRequestBody struct {
+	LoginID             string                 `json:"loginId,omitempty"`
+	Stepup              bool                   `json:"stepup,omitempty"`
+	MFA                 bool                   `json:"mfa,omitempty"`
+	RevokeOtherSessions bool                   `json:"revokeOtherSessions,omitempty"`
+	CustomClaims        map[string]interface{} `json:"customClaims,omitempty"`
+	JWT                 string                 `json:"jwt,omitempty"`
+}
+
+type authenticationSignUpRequestBody struct {
+	LoginID       string                 `json:"loginId,omitempty"`
+	User          *descope.User          `json:"user,omitempty"`
+	EmailVerified bool                   `json:"emailVerified,omitempty"`
+	PhoneVerified bool                   `json:"phoneVerified,omitempty"`
+	SsoAppID      string                 `json:"ssoAppId,omitempty"`
+	CustomClaims  map[string]interface{} `json:"customClaims,omitempty"`
+}
+
+func (j *jwt) SignIn(ctx context.Context, loginID string, loginOptions *descope.MgmLoginOptions) (*descope.AuthenticationInfo, error) {
+	if loginID == "" {
+		return nil, utils.NewInvalidArgumentError("loginID")
+	}
+	if loginOptions == nil {
+		loginOptions = &descope.MgmLoginOptions{}
+	}
+	if loginOptions.IsJWTRequired() && len(loginOptions.JWT) == 0 {
+		return nil, descope.ErrInvalidStepUpJWT
+	}
+
+	arb := &authenticationRequestBody{
+		LoginID:             loginID,
+		Stepup:              loginOptions.Stepup,
+		MFA:                 loginOptions.MFA,
+		RevokeOtherSessions: loginOptions.RevokeOtherSessions,
+		CustomClaims:        loginOptions.CustomClaims,
+		JWT:                 loginOptions.JWT,
+	}
+	httpResponse, err := j.client.DoPostRequest(ctx, api.Routes.ManagementSignIn(), arb, nil, j.conf.ManagementKey)
+	if err != nil {
+		return nil, err
+	}
+	jRes := &descope.JWTResponse{}
+	err = utils.Unmarshal([]byte(httpResponse.BodyStr), jRes)
+	if err != nil {
+		logger.LogError("Unable to parse jwt response", err)
+		return nil, err
+	}
+	return j.parseJWT(jRes)
+}
+
+func (j *jwt) SignUp(ctx context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error) {
+	return j.signUp(ctx, api.Routes.ManagementSignUp(), loginID, user, signUpOptions)
+}
+
+func (j *jwt) signUp(ctx context.Context, endpoint string, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error) {
+	if user == nil {
+		user = &descope.MgmtUserRequest{}
+	}
+	if loginID == "" {
+		return nil, utils.NewInvalidArgumentError("loginID")
+	}
+	if signUpOptions == nil {
+		signUpOptions = &descope.MgmSignUpOptions{}
+	}
+
+	arb := &authenticationSignUpRequestBody{
+		LoginID:       loginID,
+		User:          &user.User,
+		EmailVerified: user.EmailVerified,
+		PhoneVerified: user.PhoneVerified,
+		SsoAppID:      user.SsoAppID,
+		CustomClaims:  signUpOptions.CustomClaims,
+	}
+	httpResponse, err := j.client.DoPostRequest(ctx, endpoint, arb, nil, j.conf.ManagementKey)
+	if err != nil {
+		return nil, err
+	}
+	jRes := &descope.JWTResponse{}
+	err = utils.Unmarshal([]byte(httpResponse.BodyStr), jRes)
+	if err != nil {
+		logger.LogError("Unable to parse jwt response", err)
+		return nil, err
+	}
+	return j.parseJWT(jRes)
+}
+
+func (j *jwt) SignUpOrIn(ctx context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error) {
+	return j.signUp(ctx, api.Routes.ManagementSignUpOrIn(), loginID, user, signUpOptions)
 }

--- a/descope/internal/mgmt/jwt_test.go
+++ b/descope/internal/mgmt/jwt_test.go
@@ -3,8 +3,10 @@ package mgmt
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/descope/go-sdk/descope"
 	"github.com/descope/go-sdk/descope/tests/helpers"
 	"github.com/stretchr/testify/require"
 )
@@ -90,4 +92,169 @@ func TestImpersonateMissingImpersonator(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, called)
 	require.Empty(t, jwtRes)
+}
+
+const jwtTokenValid = `eyJhbGciOiJFUzM4NCIsImtpZCI6InRlc3RrZXkiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsidGVzdCJdLCJkcm4iOiJEUyIsImV4cCI6MzY1OTU2MTQzMCwiaWF0IjoxNjU5NTYxNDMwLCJpc3MiOiJ0ZXN0Iiwic3ViIjoic29tZXVzZXIiLCJ0ZXN0IjoidGVzdCJ9.tE6hXIuH74drymm6DSAs4FkaQSzf3MQ0D7pjC-9SaBRnqHoRuDOIJd3mIRsxzfb2nS6NX_tk6H1na6kFEKsJdMsUG-LbCqqib98z9tHtq-Jh6Axl5Qe9RITfIOwzOssw`
+const jwtRTokenValid = `eyJhbGciOiJFUzM4NCIsImtpZCI6InRlc3RrZXkiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsidGVzdCJdLCJkcm4iOiJEU1IiLCJleHAiOjM2NTk1NjE0MzAsImlhdCI6MTY1OTU2MTQzMCwiaXNzIjoidGVzdCIsInN1YiI6InNvbWV1c2VyIiwidGVzdCI6InRlc3QifQ.zKbJKuGo9Q9NsvI_SdrH1pDH8uuTRnTcT4eMJe237Lr6ZrtRGbw2a0U0aEwgNrox2RXupkmD3vfQtZiD3AiU9xHY8X3xwTGsDwA497eT6RrA13zNufrhSMNjF6V5-xVl`
+
+func TestSignIn(t *testing.T) {
+	loginID := "id2"
+	checked := false
+	options := true
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1/mgmt/auth/signin") {
+			checked = true
+			require.Equal(t, "Bearer a:key", r.Header.Get("Authorization"))
+			req := map[string]any{}
+			require.NoError(t, helpers.ReadBody(r, &req))
+			require.EqualValues(t, loginID, req["loginId"])
+			if options {
+				require.EqualValues(t, "test", req["jwt"])
+				require.EqualValues(t, true, req["mfa"])
+				require.EqualValues(t, true, req["stepup"])
+				require.EqualValues(t, true, req["revokeOtherSessions"])
+				require.EqualValues(t, map[string]any{"k1": "v1"}, req["customClaims"])
+			} else {
+				require.Nil(t, req["jwt"])
+				require.Nil(t, req["mfa"])
+				require.Nil(t, req["stepup"])
+				require.Nil(t, req["revokeOtherSessions"])
+				require.Nil(t, req["customClaims"])
+			}
+		}
+	}, &descope.JWTResponse{
+		RefreshJwt: jwtRTokenValid,
+		SessionJwt: jwtTokenValid,
+		User: &descope.UserResponse{
+			User: descope.User{
+				Name:  "name",
+				Phone: "phone",
+			},
+		},
+		FirstSeen: true,
+	}))
+	jwtRes, err := mgmt.JWT().SignIn(context.Background(), loginID, &descope.MgmLoginOptions{Stepup: true, MFA: true, RevokeOtherSessions: true, CustomClaims: map[string]any{"k1": "v1"}, JWT: "test"})
+	require.NoError(t, err)
+	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
+	require.True(t, checked)
+
+	checked = false
+	options = false
+	jwtRes, err = mgmt.JWT().SignIn(context.Background(), loginID, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
+	require.True(t, checked)
+
+	checked = false
+	jwtRes, err = mgmt.JWT().SignIn(context.Background(), "", &descope.MgmLoginOptions{Stepup: true, MFA: true, RevokeOtherSessions: true, CustomClaims: map[string]any{"k1": "v1"}, JWT: "test"})
+	require.Error(t, err)
+	require.Nil(t, jwtRes)
+	require.False(t, checked)
+
+	jwtRes, err = mgmt.JWT().SignIn(context.Background(), loginID, &descope.MgmLoginOptions{Stepup: true, MFA: true, RevokeOtherSessions: true, CustomClaims: map[string]any{"k1": "v1"}})
+	require.Error(t, err)
+	require.Nil(t, jwtRes)
+	require.False(t, checked)
+}
+
+func TestSignUp(t *testing.T) {
+	loginID := "id2"
+	checked := false
+	options := true
+	user := true
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1/mgmt/auth/signup") {
+			checked = true
+			require.Equal(t, "Bearer a:key", r.Header.Get("Authorization"))
+			req := map[string]any{}
+			require.NoError(t, helpers.ReadBody(r, &req))
+			require.EqualValues(t, loginID, req["loginId"])
+			if user {
+				require.EqualValues(t, "name", req["user"].(map[string]any)["name"])
+				require.EqualValues(t, "phone", req["user"].(map[string]any)["phone"])
+				require.EqualValues(t, true, req["emailVerified"])
+				require.EqualValues(t, true, req["phoneVerified"])
+				require.EqualValues(t, "sso", req["ssoAppId"])
+			} else {
+				require.Nil(t, req["user"].(map[string]any)["name"])
+				require.Nil(t, req["user"].(map[string]any)["phone"])
+				require.Nil(t, req["emailVerified"])
+				require.Nil(t, req["phoneVerified"])
+				require.Nil(t, req["ssoAppId"])
+			}
+			if options {
+				require.EqualValues(t, map[string]any{"k1": "v1"}, req["customClaims"])
+			} else {
+				require.Nil(t, req["customClaims"])
+			}
+		}
+	}, &descope.JWTResponse{
+		RefreshJwt: jwtRTokenValid,
+		SessionJwt: jwtTokenValid,
+		User: &descope.UserResponse{
+			User: descope.User{
+				Name:  "name",
+				Phone: "phone",
+			},
+		},
+		FirstSeen: true,
+	}))
+	jwtRes, err := mgmt.JWT().SignUp(context.Background(), loginID, &descope.MgmtUserRequest{User: descope.User{Name: "name", Phone: "phone"}, EmailVerified: true, PhoneVerified: true, SsoAppID: "sso"}, &descope.MgmSignUpOptions{CustomClaims: map[string]any{"k1": "v1"}})
+	require.NoError(t, err)
+	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
+	require.True(t, checked)
+
+	checked = false
+	options = false
+	jwtRes, err = mgmt.JWT().SignUp(context.Background(), loginID, &descope.MgmtUserRequest{User: descope.User{Name: "name", Phone: "phone"}, EmailVerified: true, PhoneVerified: true, SsoAppID: "sso"}, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
+	require.True(t, checked)
+
+	checked = false
+	options = true
+	user = false
+	jwtRes, err = mgmt.JWT().SignUp(context.Background(), loginID, nil, &descope.MgmSignUpOptions{CustomClaims: map[string]any{"k1": "v1"}})
+	require.NoError(t, err)
+	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
+	require.True(t, checked)
+
+	checked = false
+	_, err = mgmt.JWT().SignUp(context.Background(), "", nil, &descope.MgmSignUpOptions{CustomClaims: map[string]any{"k1": "v1"}})
+	require.Error(t, err)
+	require.False(t, checked)
+}
+
+func TestSignUpOrIn(t *testing.T) {
+	loginID := "id2"
+	checked := false
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1/mgmt/auth/signup-in") {
+			checked = true
+			require.Equal(t, "Bearer a:key", r.Header.Get("Authorization"))
+			req := map[string]any{}
+			require.NoError(t, helpers.ReadBody(r, &req))
+			require.EqualValues(t, loginID, req["loginId"])
+			require.EqualValues(t, "name", req["user"].(map[string]any)["name"])
+			require.EqualValues(t, "phone", req["user"].(map[string]any)["phone"])
+			require.EqualValues(t, true, req["emailVerified"])
+			require.EqualValues(t, true, req["phoneVerified"])
+			require.EqualValues(t, "sso", req["ssoAppId"])
+			require.EqualValues(t, map[string]any{"k1": "v1"}, req["customClaims"])
+		}
+	}, &descope.JWTResponse{
+		RefreshJwt: jwtRTokenValid,
+		SessionJwt: jwtTokenValid,
+		User: &descope.UserResponse{
+			User: descope.User{
+				Name:  "name",
+				Phone: "phone",
+			},
+		},
+		FirstSeen: true,
+	}))
+	jwtRes, err := mgmt.JWT().SignUpOrIn(context.Background(), loginID, &descope.MgmtUserRequest{User: descope.User{Name: "name", Phone: "phone"}, EmailVerified: true, PhoneVerified: true, SsoAppID: "sso"}, &descope.MgmSignUpOptions{CustomClaims: map[string]any{"k1": "v1"}})
+	require.NoError(t, err)
+	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
+	require.True(t, checked)
 }

--- a/descope/internal/mgmt/mgmt.go
+++ b/descope/internal/mgmt/mgmt.go
@@ -3,6 +3,7 @@ package mgmt
 import (
 	"github.com/descope/go-sdk/descope"
 	"github.com/descope/go-sdk/descope/api"
+	"github.com/descope/go-sdk/descope/internal/auth"
 	"github.com/descope/go-sdk/descope/logger"
 	"github.com/descope/go-sdk/descope/sdk"
 )
@@ -38,7 +39,7 @@ type managementService struct {
 	thirdPartyApplication sdk.ThirdPartyApplication
 }
 
-func NewManagement(conf ManagementParams, c *api.Client) *managementService {
+func NewManagement(conf ManagementParams, provider *auth.Provider, c *api.Client) *managementService {
 	base := managementBase{conf: &conf, client: c}
 	service := &managementService{managementBase: base}
 	service.tenant = &tenant{managementBase: base}
@@ -47,7 +48,7 @@ func NewManagement(conf ManagementParams, c *api.Client) *managementService {
 	service.user = &user{managementBase: base}
 	service.accessKey = &accessKey{managementBase: base}
 	service.sso = &sso{managementBase: base}
-	service.jwt = &jwt{managementBase: base}
+	service.jwt = &jwt{managementBase: base, provider: provider}
 	service.permission = &permission{managementBase: base}
 	service.role = &role{managementBase: base}
 	service.group = &group{managementBase: base}

--- a/descope/internal/mgmt/mgmt_test.go
+++ b/descope/internal/mgmt/mgmt_test.go
@@ -2,8 +2,11 @@ package mgmt
 
 import (
 	"github.com/descope/go-sdk/descope/api"
+	"github.com/descope/go-sdk/descope/internal/auth"
 	"github.com/descope/go-sdk/descope/tests/mocks"
 )
+
+const publicKey = `{"alg":"ES384","crv":"P-384","kid":"testkey","kty":"EC","use":"sig","x":"fcK-QcFhZooWoMPU2qIfkwBXfLIKkGm2plbS35jEQ53JqgnCaHDzLpyGaWWaIKfg","y":"IJS9pIQl3ZHh3GXi166DZgDieWGEypG9zaE3mEQrjgU-9F4qJWYDo4Fk0XS-ZJXr"}`
 
 func newTestMgmt(clientParams *api.ClientParams, callback mocks.Do) *managementService {
 	return newTestMgmtConf(nil, clientParams, callback)
@@ -17,5 +20,6 @@ func newTestMgmtConf(mgmtParams *ManagementParams, clientParams *api.ClientParam
 		mgmtParams = &ManagementParams{ProjectID: "a", ManagementKey: "key"}
 	}
 	clientParams.DefaultClient = mocks.NewTestClient(callback)
-	return NewManagement(*mgmtParams, api.NewClient(*clientParams))
+	client := api.NewClient(*clientParams)
+	return NewManagement(*mgmtParams, auth.NewProvider(client, &auth.AuthParams{ProjectID: clientParams.ProjectID, PublicKey: publicKey}), client)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -563,6 +563,13 @@ type JWT interface {
 	// The impersonator user must have `impersonation` permission in order for this request to work
 	// The response would be a refresh JWT of the impersonated user
 	Impersonate(ctx context.Context, impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string) (string, error)
+
+	// Generate a JWT for a user, simulating a signin request
+	SignIn(ctx context.Context, loginID string, loginOptions *descope.MgmLoginOptions) (*descope.AuthenticationInfo, error)
+	// Generate a JWT for a user, simulating a signup request
+	SignUp(ctx context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error)
+	// Generate a JWT for a user, simulating a signup or in request
+	SignUpOrIn(ctx context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error)
 }
 
 // Provides functions for managing permissions in a project.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -101,6 +101,18 @@ type MockJWT struct {
 	ImpersonateAssert   func(impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string)
 	ImpersonateResponse string
 	ImpersonateError    error
+
+	SignInAssert   func(loginID string, loginOptions *descope.MgmLoginOptions)
+	SignInResponse *descope.AuthenticationInfo
+	SignInError    error
+
+	SignUpAssert   func(loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions)
+	SignUpResponse *descope.AuthenticationInfo
+	SignUpError    error
+
+	SignUpOrInAssert   func(loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions)
+	SignUpOrInResponse *descope.AuthenticationInfo
+	SignUpOrInError    error
 }
 
 func (m *MockJWT) UpdateJWTWithCustomClaims(_ context.Context, jwt string, customClaims map[string]any, refreshDuration int32) (string, error) {
@@ -115,6 +127,25 @@ func (m *MockJWT) Impersonate(_ context.Context, impersonatorID string, loginID 
 		m.ImpersonateAssert(impersonatorID, loginID, validateConcent, customClaims, tenantID)
 	}
 	return m.ImpersonateResponse, m.ImpersonateError
+}
+
+func (m *MockJWT) SignIn(_ context.Context, loginID string, loginOptions *descope.MgmLoginOptions) (*descope.AuthenticationInfo, error) {
+	if m.SignInAssert != nil {
+		m.SignInAssert(loginID, loginOptions)
+	}
+	return m.SignInResponse, m.SignInError
+}
+func (m *MockJWT) SignUp(_ context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error) {
+	if m.SignUpAssert != nil {
+		m.SignUpAssert(loginID, user, signUpOptions)
+	}
+	return m.SignUpResponse, m.SignUpError
+}
+func (m *MockJWT) SignUpOrIn(_ context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error) {
+	if m.SignUpOrInAssert != nil {
+		m.SignUpOrInAssert(loginID, user, signUpOptions)
+	}
+	return m.SignUpOrInResponse, m.SignUpOrInError
 }
 
 // Mock SSO

--- a/descope/types.go
+++ b/descope/types.go
@@ -1063,3 +1063,25 @@ type ThirdPartyApplicationConsentSearchOptions struct {
 func (c *ThirdPartyApplicationConsent) GetCreatedTime() time.Time {
 	return time.Unix(int64(c.CreatedTime), 0)
 }
+
+type MgmSignUpOptions struct {
+	CustomClaims map[string]interface{} `json:"customClaims,omitempty"`
+}
+type MgmLoginOptions struct {
+	Stepup              bool                   `json:"stepup,omitempty"`
+	MFA                 bool                   `json:"mfa,omitempty"`
+	RevokeOtherSessions bool                   `json:"revokeOtherSessions,omitempty"`
+	CustomClaims        map[string]interface{} `json:"customClaims,omitempty"`
+	JWT                 string                 `json:"jwt,omitempty"`
+}
+
+func (mlo *MgmLoginOptions) IsJWTRequired() bool {
+	return mlo != nil && (mlo.Stepup || mlo.MFA)
+}
+
+type MgmtUserRequest struct {
+	User          `json:",inline"`
+	EmailVerified bool   `json:"emailVerified"`
+	PhoneVerified bool   `json:"phoneVerified"`
+	SsoAppID      string `json:"ssoAppId"`
+}


### PR DESCRIPTION
This allows mgmt SDK to create a jwt via one call to descope backend
+ tests 
related to https://github.com/descope/etc/issues/9139 
