### PR TITLE
feat: added support for redirecting FGA API calls to a middleware server which acts as a in cluster cache node for Authz checks

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/descope/go-sdk/descope"
 	"github.com/descope/go-sdk/descope/internal/utils"
 	"github.com/descope/go-sdk/descope/logger"
+	"github.com/google/uuid"
 )
 
 const (
@@ -221,6 +222,8 @@ var (
 		meTenants:    "auth/me/tenants",
 		history:      "auth/me/history",
 	}
+
+	instanceUUID = uuid.New().String()
 )
 
 type endpoints struct {
@@ -1469,6 +1472,7 @@ func (c *Client) addDescopeHeaders(req *http.Request) {
 	req.Header.Set("x-descope-sdk-go-version", c.sdkInfo.goVersion)
 	req.Header.Set("x-descope-sdk-version", c.sdkInfo.version)
 	req.Header.Set("x-descope-sdk-sha", c.sdkInfo.sha)
+	req.Header.Set("x-descope-sdk-uuid", instanceUUID)
 }
 
 func getSDKInfo() *sdkInfo {

--- a/descope/api/client_test.go
+++ b/descope/api/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/descope/go-sdk/descope"
 	"github.com/descope/go-sdk/descope/internal/utils"
 	"github.com/descope/go-sdk/descope/tests/mocks"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -267,11 +268,18 @@ func TestDoRequestDefault(t *testing.T) {
 	projectID := "test"
 	c := NewClient(ClientParams{ProjectID: projectID, DefaultClient: mocks.NewTestClient(func(r *http.Request) (*http.Response, error) {
 		assert.Nil(t, r.Body)
+		assert.True(t, strings.HasPrefix(r.URL.String(), defaultURL), "BaseURL should be defaultURL")
+		assertValidUUIDHeader(t, r)
 		return &http.Response{StatusCode: http.StatusOK}, nil
 	})})
 
 	_, err := c.DoRequest(context.Background(), http.MethodGet, "path", nil, nil, "")
 	require.NoError(t, err)
+}
+
+func assertValidUUIDHeader(t *testing.T, r *http.Request) {
+	_, err := uuid.Parse(r.Header.Get("x-descope-sdk-uuid"))
+	require.NoError(t, err, "uuid header should be a valid uuid")
 }
 
 func TestRoutesSignInOTP(t *testing.T) {

--- a/descope/authztypes.go
+++ b/descope/authztypes.go
@@ -111,4 +111,5 @@ type FGARelation struct {
 type FGACheck struct {
 	Allowed  bool         `json:"allowed"`
 	Relation *FGARelation `json:"relation"`
+	Direct   bool         `json:"direct"`
 }

--- a/descope/client/client.go
+++ b/descope/client/client.go
@@ -69,7 +69,7 @@ func NewWithConfig(config *Config) (*DescopeClient, error) {
 		return nil, err
 	}
 
-	managementService := mgmt.NewManagement(mgmt.ManagementParams{ProjectID: config.ProjectID, ManagementKey: config.ManagementKey}, c)
+	managementService := mgmt.NewManagement(mgmt.ManagementParams{ProjectID: config.ProjectID, ManagementKey: config.ManagementKey, FGACacheURL: config.FGACacheURL}, c)
 
 	return &DescopeClient{Auth: authService, Management: managementService, config: config}, nil
 }

--- a/descope/client/config.go
+++ b/descope/client/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	PublicKey string
 	// DescopeBaseURL (optional, "https://api.descope.com") - override the default base URL used to communicate with descope services.
 	DescopeBaseURL string
+	// FGACacheURL (optional, "https://api.descope.com") - pass FGA calls through a cache service, if set.
+	FGACacheURL string
 	// DefaultClient (optional, http.DefaultClient) - override the default client used to Do the actual http request.
 	DefaultClient api.IHttpClient
 	// CertificateVerifyMode (optional, CertificateVerifyAutomatic) - override the server certificate verification behavior when using the default client.

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -11,9 +11,10 @@ import (
 
 type fga struct {
 	managementBase
+	fgaCacheURL string
 }
 
-var _ sdk.FGA = &fga{}
+var _ sdk.FGA = &fga{} // Ensure that the fga struct implements the sdk.FGA interface
 
 func (f *fga) SaveSchema(ctx context.Context, schema *descope.FGASchema) error {
 	if schema == nil {
@@ -22,7 +23,10 @@ func (f *fga) SaveSchema(ctx context.Context, schema *descope.FGASchema) error {
 	body := map[string]any{
 		"dsl": schema.Schema,
 	}
-	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGASaveSchema(), body, nil, f.conf.ManagementKey)
+
+	options := &api.HTTPRequest{}
+	options.BaseURL = f.fgaCacheURL
+	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGASaveSchema(), body, options, f.conf.ManagementKey)
 	return err
 }
 
@@ -35,7 +39,9 @@ func (f *fga) CreateRelations(ctx context.Context, relations []*descope.FGARelat
 		"tuples": relations,
 	}
 
-	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACreateRelations(), body, nil, f.conf.ManagementKey)
+	options := &api.HTTPRequest{}
+	options.BaseURL = f.fgaCacheURL
+	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACreateRelations(), body, options, f.conf.ManagementKey)
 	return err
 }
 
@@ -48,13 +54,16 @@ func (f *fga) DeleteRelations(ctx context.Context, relations []*descope.FGARelat
 		"tuples": relations,
 	}
 
-	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGADeleteRelations(), body, nil, f.conf.ManagementKey)
+	options := &api.HTTPRequest{}
+	options.BaseURL = f.fgaCacheURL
+	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGADeleteRelations(), body, options, f.conf.ManagementKey)
 	return err
 }
 
 type CheckResponseTuple struct {
 	Allowed bool                 `json:"allowed"`
 	Tuple   *descope.FGARelation `json:"tuple"`
+	Direct  bool                 `json:"direct"`
 }
 
 type checkResponse struct {
@@ -70,7 +79,9 @@ func (f *fga) Check(ctx context.Context, relations []*descope.FGARelation) ([]*d
 		"tuples": relations,
 	}
 
-	res, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACheck(), body, nil, f.conf.ManagementKey)
+	options := &api.HTTPRequest{}
+	options.BaseURL = f.fgaCacheURL
+	res, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACheck(), body, options, f.conf.ManagementKey)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +97,7 @@ func (f *fga) Check(ctx context.Context, relations []*descope.FGARelation) ([]*d
 		checks[i] = &descope.FGACheck{
 			Relation: tuple.Tuple,
 			Allowed:  tuple.Allowed,
+			Direct:   tuple.Direct,
 		}
 	}
 

--- a/descope/internal/mgmt/mgmt.go
+++ b/descope/internal/mgmt/mgmt.go
@@ -10,6 +10,7 @@ import (
 type ManagementParams struct {
 	ProjectID     string
 	ManagementKey string
+	FGACacheURL   string
 }
 
 type managementBase struct {
@@ -56,7 +57,7 @@ func NewManagement(conf ManagementParams, c *api.Client) *managementService {
 	service.audit = &audit{managementBase: base}
 	service.authz = &authz{managementBase: base}
 	service.password = &passwordManagement{managementBase: base}
-	service.fga = &fga{managementBase: base}
+	service.fga = &fga{managementBase: base, fgaCacheURL: conf.FGACacheURL}
 	return service
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/descope/go-sdk
 go 1.18
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/lestrrat-go/blackmagic v1.0.2 h1:Cg2gVSc9h7sz9NOByczrbUvLopQmXrfFx//N+AkAr5k=
 github.com/lestrrat-go/blackmagic v1.0.2/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=


### PR DESCRIPTION
## Description
To enable an efficient FGA Cache (Authz cache), this PR also includes 2 additional changes:
1. Adding a new UUID header to each request
2. Parsing the new `Direct` flag in the Checks response. This field will be used by the new FGA Cache server in its own use of the SDK.

## Must
- [x] Tests
- [ ] Documentation (if applicable)
