### PR TITLE
Add export snapshot request parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1446,7 +1446,7 @@ You can manage your project's settings and configurations by exporting a snapsho
 
 ```go
 // Exports the current state of the project
-exportRes, err := descopeClient.Management.Project().ExportSnapshot(context.Background())
+exportRes, err := descopeClient.Management.Project().ExportSnapshot(context.Background(), nil)
 if err != nil {
 	// unexpected failure
 }

--- a/descope/internal/mgmt/project.go
+++ b/descope/internal/mgmt/project.go
@@ -71,6 +71,9 @@ func (p *project) ListProjects(ctx context.Context) ([]*descope.Project, error) 
 
 func (p *project) ExportSnapshot(ctx context.Context, req *descope.ExportSnapshotRequest) (*descope.ExportSnapshotResponse, error) {
 	body := map[string]any{}
+	if req == nil {
+		req = &descope.ExportSnapshotRequest{} // notest
+	}
 	if req.Format != "" {
 		body["format"] = req.Format
 	}

--- a/descope/internal/mgmt/project.go
+++ b/descope/internal/mgmt/project.go
@@ -69,8 +69,11 @@ func (p *project) ListProjects(ctx context.Context) ([]*descope.Project, error) 
 	return response.Projects, nil
 }
 
-func (p *project) ExportSnapshot(ctx context.Context) (*descope.ExportSnapshotResponse, error) {
+func (p *project) ExportSnapshot(ctx context.Context, req *descope.ExportSnapshotRequest) (*descope.ExportSnapshotResponse, error) {
 	body := map[string]any{}
+	if req.Format != "" {
+		body["format"] = req.Format
+	}
 	res, err := p.client.DoPostRequest(ctx, api.Routes.ManagementProjectExportSnapshot(), body, nil, p.conf.ManagementKey)
 	if err != nil {
 		return nil, err

--- a/descope/internal/mgmt/project_test.go
+++ b/descope/internal/mgmt/project_test.go
@@ -15,8 +15,9 @@ func TestProjectExport(t *testing.T) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
+		require.EqualValues(t, "split", req["format"])
 	}, map[string]any{"files": map[string]any{"foo": "bar"}}))
-	m, err := mgmt.Project().ExportSnapshot(context.Background())
+	m, err := mgmt.Project().ExportSnapshot(context.Background(), &descope.ExportSnapshotRequest{Format: "split"})
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	require.Equal(t, "bar", m.Files["foo"])

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -711,7 +711,7 @@ type Project interface {
 	//
 	// This API is meant to be used via the 'descopecli' command line tool that can be
 	// found at https://github.com/descope/descopecli
-	ExportSnapshot(ctx context.Context) (*descope.ExportSnapshotResponse, error)
+	ExportSnapshot(ctx context.Context, req *descope.ExportSnapshotRequest) (*descope.ExportSnapshotResponse, error)
 
 	// Imports a snapshot of all settings and configurations into a project, overriding any
 	// current configuration.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1241,6 +1241,7 @@ func (m *MockFlow) ImportTheme(_ context.Context, theme map[string]any) error {
 // Mock Project
 
 type MockProject struct {
+	ExportSnapshotAssert   func(req *descope.ExportSnapshotRequest)
 	ExportSnapshotResponse *descope.ExportSnapshotResponse
 	ExportSnapshotError    error
 
@@ -1269,7 +1270,10 @@ type MockProject struct {
 	ListProjectsError    error
 }
 
-func (m *MockProject) ExportSnapshot(_ context.Context) (*descope.ExportSnapshotResponse, error) {
+func (m *MockProject) ExportSnapshot(_ context.Context, req *descope.ExportSnapshotRequest) (*descope.ExportSnapshotResponse, error) {
+	if m.ExportSnapshotAssert != nil {
+		m.ExportSnapshotAssert(req)
+	}
 	return m.ExportSnapshotResponse, m.ExportSnapshotError
 }
 

--- a/descope/types.go
+++ b/descope/types.go
@@ -883,6 +883,11 @@ type AuditCreateOptions struct {
 	TenantID string                 `json:"tenantId,omitempty"`
 }
 
+type ExportSnapshotRequest struct {
+	// An optional string to set the output format (leave empty for default)
+	Format string `json:"format"`
+}
+
 type ExportSnapshotResponse struct {
 	// All project settings and configurations represented as JSON files
 	Files map[string]any `json:"files"`


### PR DESCRIPTION
## Description
- Add export snapshot request parameter.

## Breaking Change
This is a minor breaking change as the `ExportSnapshot` function now expects another parameter. Calls such as:
```go
descopeClient.Management.Project().ExportSnapshot(ctx)
```
will need to be updated as follows:
```go
descopeClient.Management.Project().ExportSnapshot(ctx, nil)
```

## Must
- [X] Tests
- [X] Documentation (if applicable)
