### PR TITLE
Add the ability to pass email and templateId parameters to generateSSOConfigurationLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,9 +769,10 @@ settingsRequest.InactivityTimeUnit = "days"
 // update the tenant settings
 err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(), "My Tenant", settingsRequest)
 
-// Generate tenant admin self service link for SSO configuration (valid for 24 hours)
+// Generate tenant admin self service link for SSO Suite (valid for 24 hours)
 // sso id can be provided for a specific sso configuration
-link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "")
+// email can be provided to send the link to (email's templateID can be provided as well)
+link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "")
 
 ```
 

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -147,7 +147,7 @@ func (t *tenant) ConfigureSettings(ctx context.Context, tenantID string, setting
 	return err
 }
 
-func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string) (string, error) {
+func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string) (string, error) {
 	if tenantID == "" {
 		return "", utils.NewInvalidArgumentError("tenantID")
 	}
@@ -156,6 +156,8 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 		"tenantId":   tenantID,
 		"expireTime": expireDuration,
 		"ssoId":      ssoID,
+		"email":      email,
+		"templateId": templateID,
 	}
 
 	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementTenantGenerateSSOConfigurationLink(), req, nil, t.conf.ManagementKey)

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -300,7 +300,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccess(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -316,8 +316,10 @@ func TestTenantGenerateSSOConfigurationLinkSuccessWithSSOID(t *testing.T) {
 		require.Equal(t, "tenant", req["tenantId"])
 		require.Equal(t, "bla", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
+		require.Equal(t, "a@a.com", req["email"])
+		require.Equal(t, "template-id", req["templateId"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -331,7 +333,7 @@ func TestTenantGenerateSSOConfigurationLinkError(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
 	require.Error(t, err)
 	assert.Empty(t, link)
 }
@@ -345,7 +347,7 @@ func TestTenantGenerateSSOConfigurationLinkNoTenantID(t *testing.T) {
 		require.Equal(t, "ssoId", "")
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "")
 	require.ErrorIs(t, err, utils.NewInvalidArgumentError("tenantId"))
 	assert.Empty(t, link)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -59,9 +59,11 @@ type Tenant interface {
 	ConfigureSettings(ctx context.Context, tenantID string, settings *descope.TenantSettings) error
 
 	// Generate tenant admin self service SSO configuration link
-	// The expireDuration parameter indicates the link expiration duration in seconds
-	// ssoID can be provided for a specific sso configuration
-	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string) (string, error)
+	// expireDuration - indicates the link expiration duration in seconds
+	// ssoID - Optional, in case provided, the specified sso configuration will be used
+	// email - Optional, in case provided, email will be sent according to the given email
+	// templateID - Optional, in case provided, the specified email's template will be used
+	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string) (string, error)
 }
 
 // Provides functions for managing SSO applications in a project.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -907,7 +907,7 @@ type MockTenant struct {
 	ConfigureSettingsResponse *descope.TenantSettings
 	ConfigureSettingsError    error
 
-	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string) error
+	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string) error
 	GenerateSSOConfigurationLinkResponse string
 	GenerateSSOConfigurationLinkError    error
 }
@@ -969,9 +969,9 @@ func (m *MockTenant) ConfigureSettings(_ context.Context, tenantID string, setti
 	return m.ConfigureSettingsError
 }
 
-func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string) (string, error) {
+func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string) (string, error) {
 	if m.GenerateSSOConfigurationLinkAssert != nil {
-		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID)
+		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID)
 	}
 	return m.GenerateSSOConfigurationLinkResponse, m.GenerateSSOConfigurationLinkError
 }


### PR DESCRIPTION
## Description
Add the ability to pass email and templateId parameters to generateSSOConfigurationLink

** Compilation breaking **

## Must
- [x] Tests
- [ ] Documentation (if applicable)
