### PR TITLE
Add EnforceSSO, Disabled fields in tenant API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ __debug_bin
 *.pem
 
 !.vscode/launch.json.default
+**/__debug_bin*

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -168,7 +168,7 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 }
 
 func makeCreateUpdateTenantRequest(id string, tenantRequest *descope.TenantRequest) map[string]any {
-	return map[string]any{"id": id, "name": tenantRequest.Name, "selfProvisioningDomains": tenantRequest.SelfProvisioningDomains, "customAttributes": tenantRequest.CustomAttributes}
+	return map[string]any{"id": id, "name": tenantRequest.Name, "selfProvisioningDomains": tenantRequest.SelfProvisioningDomains, "customAttributes": tenantRequest.CustomAttributes, "enforceSSO": tenantRequest.EnforceSSO, "disabled": tenantRequest.Disabled}
 }
 
 func unmarshalLoadTenantResponse(res *api.HTTPResponse) (*descope.Tenant, error) {

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -26,9 +26,11 @@ func TestTenantCreateSuccess(t *testing.T) {
 		require.Equal(t, "bar", selfProvisioningDomains[1])
 		customAttributes := req["customAttributes"].(map[string]any)
 		assert.EqualValues(t, map[string]any{"k1": "v1"}, customAttributes)
+		require.True(t, req["enforceSSO"].(bool))
+		require.True(t, req["disabled"].(bool))
 	}, response))
 
-	id, err := mgmt.Tenant().Create(context.Background(), &descope.TenantRequest{Name: "abc", SelfProvisioningDomains: []string{"foo", "bar"}, CustomAttributes: map[string]any{"k1": "v1"}})
+	id, err := mgmt.Tenant().Create(context.Background(), &descope.TenantRequest{Name: "abc", SelfProvisioningDomains: []string{"foo", "bar"}, CustomAttributes: map[string]any{"k1": "v1"}, Disabled: true, EnforceSSO: true})
 	require.NoError(t, err)
 	require.Equal(t, "qux", id)
 }
@@ -80,8 +82,10 @@ func TestTenantUpdateSuccess(t *testing.T) {
 		require.Equal(t, "bar", selfProvisioningDomains[1])
 		customAttributes := req["customAttributes"].(map[string]any)
 		assert.EqualValues(t, map[string]any{"k1": "v1"}, customAttributes)
+		require.True(t, req["enforceSSO"].(bool))
+		require.True(t, req["disabled"].(bool))
 	}))
-	err := mgmt.Tenant().Update(context.Background(), "123", &descope.TenantRequest{Name: "abc", SelfProvisioningDomains: []string{"foo", "bar"}, CustomAttributes: map[string]any{"k1": "v1"}})
+	err := mgmt.Tenant().Update(context.Background(), "123", &descope.TenantRequest{Name: "abc", SelfProvisioningDomains: []string{"foo", "bar"}, CustomAttributes: map[string]any{"k1": "v1"}, Disabled: true, EnforceSSO: true})
 	require.NoError(t, err)
 }
 
@@ -118,6 +122,8 @@ func TestAllTenantsLoadSuccess(t *testing.T) {
 			"name":                    "abc",
 			"selfProvisioningDomains": []string{"domain.com"},
 			"createdTime":             int32(1726067547),
+			"disabled":                true,
+			"enforceSSO":              true,
 		}}}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
@@ -131,6 +137,8 @@ func TestAllTenantsLoadSuccess(t *testing.T) {
 	require.Len(t, res[0].SelfProvisioningDomains, 1)
 	require.Equal(t, "domain.com", res[0].SelfProvisioningDomains[0])
 	require.Equal(t, int32(1726067547), res[0].CreatedTime)
+	require.True(t, res[0].Disabled)
+	require.True(t, res[0].EnforceSSO)
 
 }
 
@@ -148,6 +156,7 @@ func TestSearchTenantsSuccess(t *testing.T) {
 			"id":                      "t1",
 			"name":                    "abc",
 			"selfProvisioningDomains": []string{"domain.com"},
+			"enforceSSO":              true,
 		}}}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
@@ -167,6 +176,8 @@ func TestSearchTenantsSuccess(t *testing.T) {
 	require.Equal(t, "abc", res[0].Name)
 	require.Len(t, res[0].SelfProvisioningDomains, 1)
 	require.Equal(t, "domain.com", res[0].SelfProvisioningDomains[0])
+	require.False(t, res[0].Disabled)
+	require.True(t, res[0].EnforceSSO)
 }
 
 func TestSearchTenantsLoadError(t *testing.T) {

--- a/descope/types.go
+++ b/descope/types.go
@@ -632,12 +632,16 @@ type Tenant struct {
 	AuthType                string         `json:"authType,omitempty"`
 	Domains                 []string       `json:"domains,omitempty"`
 	CreatedTime             int32          `json:"createdTime,omitempty"`
+	EnforceSSO              bool           `json:"enforceSSO,omitempty"`
+	Disabled                bool           `json:"disabled,omitempty"`
 }
 
 type TenantRequest struct {
 	Name                    string         `json:"name"`
 	SelfProvisioningDomains []string       `json:"selfProvisioningDomains"`
 	CustomAttributes        map[string]any `json:"customAttributes,omitempty"`
+	EnforceSSO              bool           `json:"enforceSSO,omitempty"`
+	Disabled                bool           `json:"disabled,omitempty"`
 }
 
 type TenantSearchOptions struct {


### PR DESCRIPTION
## Related Issues
Related: https://github.com/descope/etc/issues/8356
Related: https://github.com/descope/etc/issues/249

## Description

Added fields to create/update tenant API:
- EnforceSSO
- Disabled

## Must
- [x] Tests
- [ ] Documentation (if applicable)
