### PR TITLE
fix: Remove unnecessary toolchain directive forcing Go 1.24.1

### DIFF
--- a/descope/gin/go.mod
+++ b/descope/gin/go.mod
@@ -2,8 +2,6 @@ module github.com/descope/go-sdk/descope/gin
 
 go 1.23.0
 
-toolchain go1.24.1
-
 replace github.com/descope/go-sdk => ../../
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/descope/go-sdk
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/google/uuid v1.6.0
 	github.com/lestrrat-go/jwx/v2 v2.1.4


### PR DESCRIPTION
This PR removes the `toolchain go1.24.1` directive from the `go.mod` file.

**Reasoning:**
* The `toolchain` directive was likely added unintentionally due to Go tooling behavior prior to Go 1.25 (related to Go issue https://github.com/golang/go/issues/65847), where `go mod` commands could automatically add it based on the local environment.
* Specifying a toolchain version in a library forces consumers to adopt at least that toolchain version (1.24.1), which is often undesirable and unnecessary.
* The SDK's actual requirement is Go language version 1.23, as specified by the `go 1.23` directive.

**Impact:**
By removing this line, consumers of the SDK will only be constrained by the `go 1.23` language version requirement and can use any compatible Go toolchain (Go 1.23 or newer) without being forced to upgrade specifically to 1.24.1+.

Thanks to @erane-opti for pointing this out.