### PR TITLE
Allow custom refresh token duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,27 +1335,27 @@ if err != nil {
 ```
 
 Generate a JWT for a user, simulating a signin request.
-
+refreshDuration - a custom refresh duration in seconds for the impersonation JWT, 0 will use project configuration
 ```go
-const res, err := updatedJWT, err := descopeClient.Management.JWT().SignIn(context.Background(), "dummy");
+const res, err := updatedJWT, err := descopeClient.Management.JWT().SignIn(context.Background(), "dummy"), 0;
 if err != nil {
     // handle error
 }
 ```
 
 Generate a JWT for a user, simulating a signup request.
-
+refreshDuration - a custom refresh duration in seconds for the impersonation JWT, 0 will use project configuration
 ```go
-const res, err := updatedJWT, err := descopeClient.Management.JWT().SignUp(context.Background(), "dummy");
+const res, err := updatedJWT, err := descopeClient.Management.JWT().SignUp(context.Background(), "dummy", 0);
 if err != nil {
     // handle error
 }
 ```
 
 Generate a JWT for a user, simulating a signup or in request.
-
+refreshDuration - a custom refresh duration in seconds for the impersonation JWT, 0 will use project configuration
 ```go
-const res, err := updatedJWT, err := descopeClient.Management.JWT().SignUpOrIn(context.Background(), "dummy");
+const res, err := updatedJWT, err := descopeClient.Management.JWT().SignUpOrIn(context.Background(), "dummy", 0);
 if err != nil {
     // handle error
 }
@@ -1368,9 +1368,10 @@ The impersonator user must have the `impersonation` permission in order for this
 The response would be a refresh JWT of the impersonated user
 TenantID would be the tenant to set as DCT claim, in case set
 customClaims - would be extra claims that are needed on the JWT
+refreshDuration - a custom refresh duration in seconds for the impersonation JWT, 0 will use project configuration
 
 ```go
-refreshJWT, err := descopeClient.Management.JWT().Impersonate(context.Background(), "impersonator id", "login id", true, map[string]any{"k1":"v1"}, "T1")
+refreshJWT, err := descopeClient.Management.JWT().Impersonate(context.Background(), "impersonator id", "login id", true, map[string]any{"k1":"v1"}, "T1", 0)
 if err != nil {
     // handle error
 }

--- a/descope/internal/mgmt/jwt_test.go
+++ b/descope/internal/mgmt/jwt_test.go
@@ -68,7 +68,7 @@ func TestImpersonate(t *testing.T) {
 		require.EqualValues(t, map[string]any{"k1": "v1"}, req["customClaims"])
 
 	}, map[string]interface{}{"jwt": expectedJWT}))
-	jwtRes, err := mgmt.JWT().Impersonate(context.Background(), impID, loginID, true, map[string]any{"k1": "v1"}, "t1")
+	jwtRes, err := mgmt.JWT().Impersonate(context.Background(), impID, loginID, true, map[string]any{"k1": "v1"}, "t1", 0)
 	require.NoError(t, err)
 	require.EqualValues(t, expectedJWT, jwtRes)
 }
@@ -78,7 +78,7 @@ func TestImpersonateMissingLoginID(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
 		called = true
 	}))
-	jwtRes, err := mgmt.JWT().Impersonate(context.Background(), "test", "", true, map[string]any{"k1": "v1"}, "t1")
+	jwtRes, err := mgmt.JWT().Impersonate(context.Background(), "test", "", true, map[string]any{"k1": "v1"}, "t1", 0)
 	require.Error(t, err)
 	require.False(t, called)
 	require.Empty(t, jwtRes)
@@ -89,7 +89,7 @@ func TestImpersonateMissingImpersonator(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
 		called = true
 	}))
-	jwtRes, err := mgmt.JWT().Impersonate(context.Background(), "", "test", true, map[string]any{"k1": "v1"}, "t1")
+	jwtRes, err := mgmt.JWT().Impersonate(context.Background(), "", "test", true, map[string]any{"k1": "v1"}, "t1", 0)
 	require.Error(t, err)
 	require.False(t, called)
 	require.Empty(t, jwtRes)
@@ -282,7 +282,7 @@ func TestAnonymous(t *testing.T) {
 		},
 		FirstSeen: true,
 	}))
-	jwtRes, err := mgmt.JWT().Anonymous(context.Background(), map[string]any{"k1": "v1"}, "st")
+	jwtRes, err := mgmt.JWT().Anonymous(context.Background(), map[string]any{"k1": "v1"}, "st", 0)
 	require.NoError(t, err)
 	require.EqualValues(t, jwtRTokenValid, jwtRes.RefreshToken.JWT)
 	require.True(t, checked)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -586,7 +586,7 @@ type JWT interface {
 	// Impersonate another user
 	// The impersonator user must have `impersonation` permission in order for this request to work
 	// The response would be a refresh JWT of the impersonated user
-	Impersonate(ctx context.Context, impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string) (string, error)
+	Impersonate(ctx context.Context, impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string, refreshDuration int32) (string, error)
 
 	// Generate a JWT for a user, simulating a signin request
 	SignIn(ctx context.Context, loginID string, loginOptions *descope.MgmLoginOptions) (*descope.AuthenticationInfo, error)
@@ -595,7 +595,7 @@ type JWT interface {
 	// Generate a JWT for a user, simulating a signup or in request
 	SignUpOrIn(ctx context.Context, loginID string, user *descope.MgmtUserRequest, signUpOptions *descope.MgmSignUpOptions) (*descope.AuthenticationInfo, error)
 	// Generate a JWT for a user, this user will be an anonymous user
-	Anonymous(ctx context.Context, customClaims map[string]any, selectedTenant string) (*descope.AnonymousAuthenticationInfo, error)
+	Anonymous(ctx context.Context, customClaims map[string]any, selectedTenant string, refreshDuration int32) (*descope.AnonymousAuthenticationInfo, error)
 }
 
 // Provides functions for managing permissions in a project.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -98,7 +98,7 @@ type MockJWT struct {
 	UpdateJWTWithCustomClaimsResponse string
 	UpdateJWTWithCustomClaimsError    error
 
-	ImpersonateAssert   func(impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string)
+	ImpersonateAssert   func(impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string, refreshDuration int32)
 	ImpersonateResponse string
 	ImpersonateError    error
 
@@ -114,7 +114,7 @@ type MockJWT struct {
 	SignUpOrInResponse *descope.AuthenticationInfo
 	SignUpOrInError    error
 
-	AnonymousAssert   func(customClaims map[string]any, selectedTenant string)
+	AnonymousAssert   func(customClaims map[string]any, selectedTenant string, refreshDuration int32)
 	AnonymousResponse *descope.AnonymousAuthenticationInfo
 	AnonymousError    error
 }
@@ -126,9 +126,9 @@ func (m *MockJWT) UpdateJWTWithCustomClaims(_ context.Context, jwt string, custo
 	return m.UpdateJWTWithCustomClaimsResponse, m.UpdateJWTWithCustomClaimsError
 }
 
-func (m *MockJWT) Impersonate(_ context.Context, impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string) (string, error) {
+func (m *MockJWT) Impersonate(_ context.Context, impersonatorID string, loginID string, validateConcent bool, customClaims map[string]any, tenantID string, refreshDuration int32) (string, error) {
 	if m.ImpersonateAssert != nil {
-		m.ImpersonateAssert(impersonatorID, loginID, validateConcent, customClaims, tenantID)
+		m.ImpersonateAssert(impersonatorID, loginID, validateConcent, customClaims, tenantID, refreshDuration)
 	}
 	return m.ImpersonateResponse, m.ImpersonateError
 }
@@ -152,9 +152,9 @@ func (m *MockJWT) SignUpOrIn(_ context.Context, loginID string, user *descope.Mg
 	return m.SignUpOrInResponse, m.SignUpOrInError
 }
 
-func (m *MockJWT) Anonymous(_ context.Context, customClaims map[string]any, selectedTenant string) (*descope.AnonymousAuthenticationInfo, error) {
+func (m *MockJWT) Anonymous(_ context.Context, customClaims map[string]any, selectedTenant string, refreshDuration int32) (*descope.AnonymousAuthenticationInfo, error) {
 	if m.AnonymousAssert != nil {
-		m.AnonymousAssert(customClaims, selectedTenant)
+		m.AnonymousAssert(customClaims, selectedTenant, refreshDuration)
 	}
 	return m.AnonymousResponse, m.AnonymousError
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -1150,7 +1150,8 @@ func (c *ThirdPartyApplicationConsent) GetCreatedTime() time.Time {
 }
 
 type MgmSignUpOptions struct {
-	CustomClaims map[string]interface{} `json:"customClaims,omitempty"`
+	CustomClaims    map[string]interface{} `json:"customClaims,omitempty"`
+	RefreshDuration int32                  `json:"refreshDuration,omitempty"`
 }
 type MgmLoginOptions struct {
 	Stepup              bool                   `json:"stepup,omitempty"`
@@ -1158,6 +1159,7 @@ type MgmLoginOptions struct {
 	RevokeOtherSessions bool                   `json:"revokeOtherSessions,omitempty"`
 	CustomClaims        map[string]interface{} `json:"customClaims,omitempty"`
 	JWT                 string                 `json:"jwt,omitempty"`
+	RefreshDuration     int32                  `json:"refreshDuration,omitempty"`
 }
 
 func (mlo *MgmLoginOptions) IsJWTRequired() bool {


### PR DESCRIPTION
For SDK calls initiated by MGMT SDK
related to https://github.com/descope/etc/issues/10354 Breaks compilation
