### PR TITLE
Add login hint support for SSO and OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Users can authenticate using their social logins, using the OAuth protocol. Conf
 // If configured globally, the return URL is optional. If provided however, it will be used
 // instead of any global configuration.
 // Redirect the user to the returned URL to start the OAuth redirect chain
-url, err := descopeClient.Auth.OAuth().SignUpOrIn(context.Background(), "google", "https://my-app.com/handle-oauth", nil, nil, w)
+url, err := descopeClient.Auth.OAuth().SignUpOrIn(context.Background(), "google", "https://my-app.com/handle-oauth", "", nil, nil, w)
 if err != nil {
     // handle error
 }
@@ -285,7 +285,7 @@ Users can also connect the social login account to their existing user:
 ```go
 // A valid Refresh Token of the existing user is required and will be taken from the request header or cookies automatically.
 // If allowAllMerge is 'true' the users will be merged also if there is no common identifier between the social provider and the existing user (like email).
-url, err := descopeClient.Auth.OAuth().UpdateUser(context.Background(), "google", "https://my-app.com/handle-oauth", true, nil, nil, w)
+url, err := descopeClient.Auth.OAuth().UpdateUser(context.Background(), "google", "https://my-app.com/handle-oauth", "", true, nil, nil, w)
 if err != nil {
     // handle error
 }
@@ -357,7 +357,7 @@ Users can authenticate to a specific tenant using SAML or OIDC. Configure your S
 // If configured globally, the return URL is optional. If provided however, it will be used
 // instead of any global configuration.
 // Redirect the user to the returned URL to start the SSO SAML/OIDC redirect chain
-url, err := descopeClient.Auth.SSO().Start("my-tenant-ID", "https://my-app.com/handle-saml", "", "", nil, nil, w)
+url, err := descopeClient.Auth.SSO().Start("my-tenant-ID", "https://my-app.com/handle-saml", "", "", "", nil, nil, w)
 if err != nil {
     // handle error
 }
@@ -370,7 +370,7 @@ if err != nil {
 // If configured globally, the return URL is optional. If provided however, it will be used
 // instead of any global configuration.
 // Redirect the user to the returned URL to start the SSO/SAML redirect chain
-url, err := descopeClient.Auth.SAML().Start(context.Background(), "my-tenant-ID", "https://my-app.com/handle-saml", nil, nil, w)
+url, err := descopeClient.Auth.SAML().Start(context.Background(), "my-tenant-ID", "https://my-app.com/handle-saml", "", nil, nil, w)
 if err != nil {
     // handle error
 }

--- a/descope/internal/auth/oauth.go
+++ b/descope/internal/auth/oauth.go
@@ -19,8 +19,8 @@ type oauthStartResponse struct {
 	URL string `json:"url"`
 }
 
-func (auth *oauth) startAuth(ctx context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter, authorizeURL string) (url string, err error) {
-	m := generateOAuthRequestParams(ctx, provider, redirectURL)
+func (auth *oauth) startAuth(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter, authorizeURL string) (url string, err error) {
+	m := generateOAuthRequestParams(ctx, provider, redirectURL, loginHint)
 	var pswd string
 	if loginOptions.IsJWTRequired() {
 		pswd, err = getValidRefreshToken(r)
@@ -32,8 +32,8 @@ func (auth *oauth) startAuth(ctx context.Context, provider descope.OAuthProvider
 	return auth.doStart(ctx, provider, m, pswd, loginOptions, w, authorizeURL)
 }
 
-func (auth *oauth) startUpdate(ctx context.Context, provider descope.OAuthProvider, redirectURL string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter, authorizeURL string) (url string, err error) {
-	m := generateOAuthRequestParams(ctx, provider, redirectURL)
+func (auth *oauth) startUpdate(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter, authorizeURL string) (url string, err error) {
+	m := generateOAuthRequestParams(ctx, provider, redirectURL, loginHint)
 	if allowAllMerge {
 		m["allowAllMerge"] = strconv.FormatBool(allowAllMerge)
 	}
@@ -64,37 +64,39 @@ func (auth *oauth) doStart(ctx context.Context, provider descope.OAuthProvider, 
 	return
 }
 
-func (auth *oauth) SignUpOrIn(ctx context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
-	return auth.startAuth(ctx, provider, redirectURL, r, loginOptions, w, composeOAuthSignUpOrInURL())
+func (auth *oauth) SignUpOrIn(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+	return auth.startAuth(ctx, provider, redirectURL, loginHint, r, loginOptions, w, composeOAuthSignUpOrInURL())
 }
 
-func (auth *oauth) SignUp(ctx context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
-	return auth.startAuth(ctx, provider, redirectURL, r, loginOptions, w, composeOAuthSignUpURL())
+func (auth *oauth) SignUp(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+	return auth.startAuth(ctx, provider, redirectURL, loginHint, r, loginOptions, w, composeOAuthSignUpURL())
 }
 
-func (auth *oauth) SignIn(ctx context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
-	return auth.startAuth(ctx, provider, redirectURL, r, loginOptions, w, composeOAuthSignInURL())
+func (auth *oauth) SignIn(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+	return auth.startAuth(ctx, provider, redirectURL, loginHint, r, loginOptions, w, composeOAuthSignInURL())
 }
 
-func (auth *oauth) UpdateUser(ctx context.Context, provider descope.OAuthProvider, redirectURL string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
-	return auth.startUpdate(ctx, provider, redirectURL, allowAllMerge, r, loginOptions, w, composeOAuthUpdateUserURL())
+func (auth *oauth) UpdateUser(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+	return auth.startUpdate(ctx, provider, redirectURL, loginHint, allowAllMerge, r, loginOptions, w, composeOAuthUpdateUserURL())
 }
 
-func (auth *oauth) Start(ctx context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
-	return auth.SignUpOrIn(ctx, provider, redirectURL, r, loginOptions, w)
+func (auth *oauth) Start(ctx context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+	return auth.SignUpOrIn(ctx, provider, redirectURL, loginHint, r, loginOptions, w)
 }
 
 func (auth *oauth) ExchangeToken(ctx context.Context, code string, w http.ResponseWriter) (*descope.AuthenticationInfo, error) {
 	return auth.exchangeToken(ctx, code, composeOAuthExchangeTokenURL(), w)
 }
 
-func generateOAuthRequestParams(_ context.Context, provider descope.OAuthProvider, redirectURL string) map[string]string {
+func generateOAuthRequestParams(_ context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string) map[string]string {
 	params := map[string]string{
 		"provider": string(provider),
 	}
 	if len(redirectURL) > 0 {
 		params["redirectURL"] = redirectURL
 	}
-
+	if len(loginHint) > 0 {
+		params["loginHint"] = loginHint
+	}
 	return params
 }

--- a/descope/internal/auth/oauth_test.go
+++ b/descope/internal/auth/oauth_test.go
@@ -21,13 +21,14 @@ import (
 func TestOAuthStartForwardResponse(t *testing.T) {
 	uri := "http://test.me"
 	landingURL := "https://test.com"
+	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s&loginHint=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.OAuth().Start(context.Background(), provider, landingURL, nil, nil, w)
+	urlStr, err := a.OAuth().Start(context.Background(), provider, landingURL, loginHint, nil, nil, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -37,13 +38,14 @@ func TestOAuthStartForwardResponse(t *testing.T) {
 func TestOAuthSignInForwardResponse(t *testing.T) {
 	uri := "http://test.me"
 	landingURL := "https://test.com"
+	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s", composeOAuthSignInURL(), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s&loginHint=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.OAuth().SignIn(context.Background(), provider, landingURL, nil, nil, w)
+	urlStr, err := a.OAuth().SignIn(context.Background(), provider, landingURL, loginHint, nil, nil, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -53,13 +55,14 @@ func TestOAuthSignInForwardResponse(t *testing.T) {
 func TestOAuthSignUpForwardResponse(t *testing.T) {
 	uri := "http://test.me"
 	landingURL := "https://test.com"
+	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s", composeOAuthSignUpURL(), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s&loginHint=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.OAuth().SignUp(context.Background(), provider, landingURL, nil, nil, w)
+	urlStr, err := a.OAuth().SignUp(context.Background(), provider, landingURL, loginHint, nil, nil, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -69,13 +72,14 @@ func TestOAuthSignUpForwardResponse(t *testing.T) {
 func TestOAuthUpdateUserForwardResponse(t *testing.T) {
 	uri := "http://test.me"
 	landingURL := "https://test.com"
+	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?allowAllMerge=%s&provider=%s&redirectURL=%s", composeOAuthUpdateUserURL(), "true", provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?allowAllMerge=%s&provider=%s&redirectURL=%s&loginHint=%s", composeOAuthUpdateUserURL(), "true", provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.OAuth().UpdateUser(context.Background(), provider, landingURL, true, &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, nil, w)
+	urlStr, err := a.OAuth().UpdateUser(context.Background(), provider, landingURL, loginHint, true, &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, nil, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -89,7 +93,7 @@ func TestOAuthUpdateUserForwardResponsepNoJWT(t *testing.T) {
 	a, err := newTestAuth(nil, DoRedirect(uri, func(_ *http.Request) {}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	_, err = a.OAuth().UpdateUser(context.Background(), provider, landingURL, true, nil, nil, w)
+	_, err = a.OAuth().UpdateUser(context.Background(), provider, landingURL, "", true, nil, nil, w)
 	assert.ErrorIs(t, err, descope.ErrRefreshToken)
 }
 
@@ -112,7 +116,7 @@ func TestOAuthStartForwardResponseStepup(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.OAuth().Start(context.Background(), provider, landingURL, &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
+	urlStr, err := a.OAuth().Start(context.Background(), provider, landingURL, "", &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -126,7 +130,7 @@ func TestOAuthStartForwardResponseStepupNoJWT(t *testing.T) {
 	a, err := newTestAuth(nil, DoRedirect(uri, func(_ *http.Request) {}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	_, err = a.OAuth().Start(context.Background(), provider, landingURL, nil, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
+	_, err = a.OAuth().Start(context.Background(), provider, landingURL, "", nil, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
 	assert.ErrorIs(t, err, descope.ErrInvalidStepUpJWT)
 }
 
@@ -137,7 +141,7 @@ func TestOAuthStartInvalidForwardResponse(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.OAuth().Start(context.Background(), provider, "", nil, nil, w)
+	urlStr, err := a.OAuth().Start(context.Background(), provider, "", "", nil, nil, w)
 	require.Error(t, err)
 	assert.Empty(t, urlStr)
 }

--- a/descope/internal/auth/oauth_test.go
+++ b/descope/internal/auth/oauth_test.go
@@ -24,7 +24,7 @@ func TestOAuthStartForwardResponse(t *testing.T) {
 	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s&loginHint=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?loginHint=%s&provider=%s&redirectURL=%s", composeOAuthSignUpOrInURL(), url.QueryEscape(loginHint), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -41,7 +41,7 @@ func TestOAuthSignInForwardResponse(t *testing.T) {
 	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s&loginHint=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?loginHint=%s&provider=%s&redirectURL=%s", composeOAuthSignInURL(), url.QueryEscape(loginHint), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -58,7 +58,7 @@ func TestOAuthSignUpForwardResponse(t *testing.T) {
 	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?provider=%s&redirectURL=%s&loginHint=%s", composeOAuthSignUpOrInURL(), provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?loginHint=%s&provider=%s&redirectURL=%s", composeOAuthSignUpURL(), url.QueryEscape(loginHint), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -75,7 +75,7 @@ func TestOAuthUpdateUserForwardResponse(t *testing.T) {
 	loginHint := "aaaa@bb.com"
 	provider := descope.OAuthGithub
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?allowAllMerge=%s&provider=%s&redirectURL=%s&loginHint=%s", composeOAuthUpdateUserURL(), "true", provider, url.QueryEscape(landingURL), url.QueryEscape(loginHint)), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?allowAllMerge=%s&loginHint=%s&provider=%s&redirectURL=%s", composeOAuthUpdateUserURL(), "true", url.QueryEscape(loginHint), provider, url.QueryEscape(landingURL)), r.URL.RequestURI())
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()

--- a/descope/internal/auth/sso.go
+++ b/descope/internal/auth/sso.go
@@ -18,7 +18,7 @@ type ssoStartResponse struct {
 	URL string `json:"url"`
 }
 
-func (auth *sso) Start(ctx context.Context, tenant string, redirectURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
+func (auth *sso) Start(ctx context.Context, tenant string, redirectURL string, prompt string, ssoID string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (url string, err error) {
 	if tenant == "" {
 		return "", utils.NewInvalidArgumentError("tenant")
 	}
@@ -33,6 +33,9 @@ func (auth *sso) Start(ctx context.Context, tenant string, redirectURL string, p
 	}
 	if len(ssoID) > 0 {
 		m["ssoId"] = ssoID
+	}
+	if len(loginHint) > 0 {
+		m["loginHint"] = loginHint
 	}
 
 	var pswd string

--- a/descope/internal/auth/sso_test.go
+++ b/descope/internal/auth/sso_test.go
@@ -29,7 +29,7 @@ func TestSSOStart(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.SSO().Start(context.Background(), tenant, landingURL, prompt, "", nil, nil, w)
+	urlStr, err := a.SSO().Start(context.Background(), tenant, landingURL, prompt, "", "", nil, nil, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -42,13 +42,14 @@ func TestSSOStartWithSSOID(t *testing.T) {
 	prompt := "none"
 	landingURL := "https://test.com"
 	ssoID := "lu lu"
+	loginHint := "bu lu"
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?prompt=%s&redirectURL=%s&ssoId=%s&tenant=%s", composeSSOStartURL(), prompt, url.QueryEscape(landingURL), url.QueryEscape(ssoID), tenant), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?prompt=%s&redirectURL=%s&ssoId=%s&tenant=%s&loginHint=%s", composeSSOStartURL(), prompt, url.QueryEscape(landingURL), url.QueryEscape(ssoID), url.QueryEscape(loginHint), tenant), r.URL.RequestURI())
 		assert.Nil(t, r.Body)
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.SSO().Start(context.Background(), tenant, landingURL, prompt, ssoID, nil, nil, w)
+	urlStr, err := a.SSO().Start(context.Background(), tenant, landingURL, prompt, ssoID, loginHint, nil, nil, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -63,7 +64,7 @@ func TestSSOStartFailureNoTenant(t *testing.T) {
 	landingURL := "https://test.com"
 	prompt := "none"
 	tenant := ""
-	_, err = a.SSO().Start(context.Background(), tenant, landingURL, prompt, "", nil, nil, w)
+	_, err = a.SSO().Start(context.Background(), tenant, landingURL, prompt, "", "", nil, nil, w)
 	require.ErrorIs(t, err, utils.NewInvalidArgumentError("tenant"))
 }
 
@@ -87,7 +88,7 @@ func TestSSOStartStepup(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
-	urlStr, err := a.SSO().Start(context.Background(), tenant, landingURL, prompt, "", &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
+	urlStr, err := a.SSO().Start(context.Background(), tenant, landingURL, prompt, "", "", &http.Request{Header: http.Header{"Cookie": []string{"DSR=test"}}}, &descope.LoginOptions{Stepup: true, CustomClaims: map[string]interface{}{"k1": "v1"}}, w)
 	require.NoError(t, err)
 	assert.EqualValues(t, uri, urlStr)
 	assert.EqualValues(t, urlStr, w.Result().Header.Get(descope.RedirectLocationCookieName))
@@ -101,7 +102,7 @@ func TestSSOStartInvalidForwardResponse(t *testing.T) {
 	_, err = a.SAML().Start(context.Background(), "", "", nil, nil, w)
 	require.Error(t, err)
 
-	_, err = a.SSO().Start(context.Background(), "test", "", "", "", nil, &descope.LoginOptions{Stepup: true}, w)
+	_, err = a.SSO().Start(context.Background(), "test", "", "", "", "", nil, &descope.LoginOptions{Stepup: true}, w)
 	assert.ErrorIs(t, err, descope.ErrInvalidStepUpJWT)
 }
 

--- a/descope/internal/auth/sso_test.go
+++ b/descope/internal/auth/sso_test.go
@@ -44,7 +44,7 @@ func TestSSOStartWithSSOID(t *testing.T) {
 	ssoID := "lu lu"
 	loginHint := "bu lu"
 	a, err := newTestAuth(nil, DoRedirect(uri, func(r *http.Request) {
-		assert.EqualValues(t, fmt.Sprintf("%s?prompt=%s&redirectURL=%s&ssoId=%s&tenant=%s&loginHint=%s", composeSSOStartURL(), prompt, url.QueryEscape(landingURL), url.QueryEscape(ssoID), url.QueryEscape(loginHint), tenant), r.URL.RequestURI())
+		assert.EqualValues(t, fmt.Sprintf("%s?loginHint=%s&prompt=%s&redirectURL=%s&ssoId=%s&tenant=%s", composeSSOStartURL(), url.QueryEscape(loginHint), prompt, url.QueryEscape(landingURL), url.QueryEscape(ssoID), tenant), r.URL.RequestURI())
 		assert.Nil(t, r.Body)
 	}))
 	require.NoError(t, err)

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -209,32 +209,32 @@ type OAuth interface {
 	// returns an error upon failure and a string represent the redirect URL upon success.
 	// Uses the response writer to automatically redirect the client to the provider url for authentication.
 	// A successful authentication will result in a callback to the url defined in the current project settings.
-	Start(ctx context.Context, provider descope.OAuthProvider, returnURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
+	Start(ctx context.Context, provider descope.OAuthProvider, returnURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
 
 	// SignUpOrIn - Use to start an OAuth authentication using the given OAuthProvider.
 	// returns an error upon failure and a string represent the redirect URL upon success.
 	// Uses the response writer to automatically redirect the client to the provider url for authentication.
 	// A successful authentication will result in a callback to the url defined in the current project settings.
-	SignUpOrIn(ctx context.Context, provider descope.OAuthProvider, returnURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
+	SignUpOrIn(ctx context.Context, provider descope.OAuthProvider, returnURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
 
 	// SignUp - Use to start an OAuth authentication using the given OAuthProvider to create a new user.
 	// returns an error upon failure and a string represent the redirect URL upon success.
 	// Uses the response writer to automatically redirect the client to the provider url for authentication.
 	// A successful authentication will result in a callback to the url defined in the current project settings.
-	SignUp(ctx context.Context, provider descope.OAuthProvider, returnURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
+	SignUp(ctx context.Context, provider descope.OAuthProvider, returnURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
 
 	// SignIn - Use to start an OAuth authentication using the given OAuthProvider to sign in an existing user.
 	// returns an error upon failure and a string represent the redirect URL upon success.
 	// Uses the response writer to automatically redirect the client to the provider url for authentication.
 	// A successful authentication will result in a callback to the url defined in the current project settings.
-	SignIn(ctx context.Context, provider descope.OAuthProvider, returnURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
+	SignIn(ctx context.Context, provider descope.OAuthProvider, returnURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
 
 	// UserUpdate - Use to start an OAuth authentication using the given OAuthProvider to enable an existing user to sign in also with OAuth method.
 	// returns an error upon failure and a string represent the redirect URL upon success.
 	// Uses the response writer to automatically redirect the client to the provider url for authentication.
 	// A successful authentication will result in a callback to the url defined in the current project settings.
 	// allowAllMerge - allow updating the existing user also if there is no common identifier between the OAuth and the existing user (like email)
-	UpdateUser(ctx context.Context, provider descope.OAuthProvider, returnURL string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
+	UpdateUser(ctx context.Context, provider descope.OAuthProvider, returnURL string, loginHint string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error)
 
 	// ExchangeToken - Finalize OAuth
 	// code should be extracted from the redirect URL of OAth/SAML authentication flow
@@ -262,7 +262,8 @@ type SSOServiceProvider interface {
 	// and finalize with the ExchangeToken call
 	// prompt argument relevant only in case tenant configured with AuthType OIDC
 	// ssoID can be used for providing the relevant SSO configuration (when having multiple SSO configurations per tenant)
-	Start(ctx context.Context, tenant string, returnURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (redirectURL string, err error)
+	// loginHint Optional login hint sent to the IdP as a query parameter (e.g., pre-fill username)
+	Start(ctx context.Context, tenant string, returnURL string, prompt string, ssoID string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (redirectURL string, err error)
 
 	// ExchangeToken - Finalize tenant login authentication
 	// code should be extracted from the redirect URL of SAML/OIDC authentication flow

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -413,23 +413,23 @@ func (m *MockPassword) GetPasswordPolicy(_ context.Context) (*descope.PasswordPo
 // Mock OAuth
 
 type MockOAuth struct {
-	StartAssert   func(provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	StartAssert   func(provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	StartError    error
 	StartResponse string
 
-	SignUpOrInAssert   func(provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	SignUpOrInAssert   func(provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	SignUpOrInError    error
 	SignUpOrInResponse string
 
-	SignInAssert   func(provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	SignInAssert   func(provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	SignInError    error
 	SignInResponse string
 
-	SignUpAssert   func(provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	SignUpAssert   func(provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	SignUpError    error
 	SignUpResponse string
 
-	UpdateUserAssert   func(provider descope.OAuthProvider, redirectURL string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	UpdateUserAssert   func(provider descope.OAuthProvider, redirectURL string, loginHint string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	UpdateUserError    error
 	UpdateUserResponse string
 
@@ -438,37 +438,37 @@ type MockOAuth struct {
 	ExchangeTokenResponse *descope.AuthenticationInfo
 }
 
-func (m *MockOAuth) Start(_ context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockOAuth) Start(_ context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.StartAssert != nil {
-		m.StartAssert(provider, redirectURL, r, loginOptions, w)
+		m.StartAssert(provider, redirectURL, loginHint, r, loginOptions, w)
 	}
 	return m.StartResponse, m.StartError
 }
 
-func (m *MockOAuth) SignUpOrIn(_ context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockOAuth) SignUpOrIn(_ context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.SignUpOrInAssert != nil {
-		m.SignUpOrInAssert(provider, redirectURL, r, loginOptions, w)
+		m.SignUpOrInAssert(provider, redirectURL, loginHint, r, loginOptions, w)
 	}
 	return m.SignUpOrInResponse, m.SignUpOrInError
 }
 
-func (m *MockOAuth) SignIn(_ context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockOAuth) SignIn(_ context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.SignInAssert != nil {
-		m.SignInAssert(provider, redirectURL, r, loginOptions, w)
+		m.SignInAssert(provider, redirectURL, loginHint, r, loginOptions, w)
 	}
 	return m.SignInResponse, m.SignInError
 }
 
-func (m *MockOAuth) SignUp(_ context.Context, provider descope.OAuthProvider, redirectURL string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockOAuth) SignUp(_ context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.SignUpAssert != nil {
-		m.SignUpAssert(provider, redirectURL, r, loginOptions, w)
+		m.SignUpAssert(provider, redirectURL, loginHint, r, loginOptions, w)
 	}
 	return m.SignUpResponse, m.SignUpError
 }
 
-func (m *MockOAuth) UpdateUser(_ context.Context, provider descope.OAuthProvider, redirectURL string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockOAuth) UpdateUser(_ context.Context, provider descope.OAuthProvider, redirectURL string, loginHint string, allowAllMerge bool, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.UpdateUserAssert != nil {
-		m.UpdateUserAssert(provider, redirectURL, allowAllMerge, r, loginOptions, w)
+		m.UpdateUserAssert(provider, redirectURL, loginHint, allowAllMerge, r, loginOptions, w)
 	}
 	return m.UpdateUserResponse, m.UpdateUserError
 }
@@ -509,7 +509,7 @@ func (m *MockSAML) ExchangeToken(_ context.Context, code string, w http.Response
 // Mock SSO
 
 type MockSSO struct {
-	StartAssert   func(tenant string, redirectURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
+	StartAssert   func(tenant string, redirectURL string, prompt string, ssoID string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter)
 	StartError    error
 	StartResponse string
 
@@ -518,9 +518,9 @@ type MockSSO struct {
 	ExchangeTokenResponse *descope.AuthenticationInfo
 }
 
-func (m *MockSSO) Start(_ context.Context, tenant string, redirectURL string, prompt string, ssoID string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
+func (m *MockSSO) Start(_ context.Context, tenant string, redirectURL string, prompt string, ssoID string, loginHint string, r *http.Request, loginOptions *descope.LoginOptions, w http.ResponseWriter) (string, error) {
 	if m.StartAssert != nil {
-		m.StartAssert(tenant, redirectURL, prompt, ssoID, r, loginOptions, w)
+		m.StartAssert(tenant, redirectURL, prompt, ssoID, loginHint, r, loginOptions, w)
 	}
 	return m.StartResponse, m.StartError
 }

--- a/descope/tests/mocks/auth/authenticationmock_test.go
+++ b/descope/tests/mocks/auth/authenticationmock_test.go
@@ -18,7 +18,7 @@ func TestMockAuthentication(t *testing.T) {
 	descopeClient := client.DescopeClient{
 		Auth: &MockAuthentication{
 			MockOAuth: &MockOAuth{
-				StartAssert: func(provider descope.OAuthProvider, _ string, _ *http.Request, _ *descope.LoginOptions, _ http.ResponseWriter) {
+				StartAssert: func(provider descope.OAuthProvider, _ string, _ string, _ *http.Request, _ *descope.LoginOptions, _ http.ResponseWriter) {
 					called = true
 					assert.EqualValues(t, descope.OAuthApple, provider)
 				},
@@ -27,7 +27,7 @@ func TestMockAuthentication(t *testing.T) {
 		},
 	}
 	assert.NotNil(t, descopeClient.Auth)
-	startResponse, err := descopeClient.Auth.OAuth().Start(context.Background(), descope.OAuthApple, "", nil, nil, nil)
+	startResponse, err := descopeClient.Auth.OAuth().Start(context.Background(), descope.OAuthApple, "", "", nil, nil, nil)
 	require.NoError(t, err)
 	assert.True(t, called)
 	assert.EqualValues(t, startResponse, expectedStartResponse)

--- a/examples/webapp/main.go
+++ b/examples/webapp/main.go
@@ -208,7 +208,7 @@ func handleOAuth(w http.ResponseWriter, r *http.Request) {
 	if p, ok := r.URL.Query()["provider"]; ok {
 		provider = descope.OAuthProvider(p[0])
 	}
-	_, err := descopeClient.Auth.OAuth().Start(r.Context(), provider, "https://localhost:8085/oauth/exchange", nil, nil, w)
+	_, err := descopeClient.Auth.OAuth().Start(r.Context(), provider, "https://localhost:8085/oauth/exchange", "", nil, nil, w)
 	if err != nil {
 		setError(w, err.Error())
 	}


### PR DESCRIPTION
## Description
https://github.com/descope/etc/issues/9752
https://github.com/descope/etc/issues/10809

Add login hint support for SSO and OAuth.
Note: Breaking compilation.

## Must
- [x] Tests
- [ ] Documentation (if applicable)
