### PR TITLE
Add jwt bearer (external token) + ciba logout url settings

### DIFF
--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -124,13 +124,15 @@ func (s *ssoApplication) LoadAll(ctx context.Context) ([]*descope.SSOApplication
 
 func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationRequest) map[string]any {
 	return map[string]any{
-		"id":                  appRequest.ID,
-		"name":                appRequest.Name,
-		"description":         appRequest.Description,
-		"enabled":             appRequest.Enabled,
-		"logo":                appRequest.Logo,
-		"loginPageUrl":        appRequest.LoginPageURL,
-		"forceAuthentication": appRequest.ForceAuthentication,
+		"id":                   appRequest.ID,
+		"name":                 appRequest.Name,
+		"description":          appRequest.Description,
+		"enabled":              appRequest.Enabled,
+		"logo":                 appRequest.Logo,
+		"loginPageUrl":         appRequest.LoginPageURL,
+		"forceAuthentication":  appRequest.ForceAuthentication,
+		"jwtBearerSettings":    appRequest.JWTBearerSettings,
+		"backChannelLogoutUrl": appRequest.BackChannelLogoutURL,
 	}
 }
 

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -45,7 +45,7 @@ func TestSSOApplicationCreateOIDCApplicationSuccess(t *testing.T) {
 		ForceAuthentication:  true,
 		BackChannelLogoutURL: "http://dummy.com/backchannel-logout",
 		JWTBearerSettings: &descope.JWTBearerSettings{
-			Issuers: map[string]descope.IssuerSettings{
+			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {
 					JWKsURI:             "http://dummy.com/jwks",
 					SignAlgorithm:       "RS256",
@@ -176,7 +176,7 @@ func TestSSOApplicationUpdateOIDCApplicationSuccess(t *testing.T) {
 		ForceAuthentication:  true,
 		BackChannelLogoutURL: "http://dummy.com/backchannel-logout",
 		JWTBearerSettings: &descope.JWTBearerSettings{
-			Issuers: map[string]descope.IssuerSettings{
+			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {
 					JWKsURI:             "http://dummy.com/jwks",
 					SignAlgorithm:       "RS256",

--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -201,6 +201,7 @@ func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdParty
 		"approvedCallbackUrls": appRequest.ApprovedCallbackUrls,
 		"permissionsScopes":    appRequest.PermissionsScopes,
 		"attributesScopes":     appRequest.AttributesScopes,
+		"jwtBearerSettings":    appRequest.JWTBearerSettings,
 	}
 }
 

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -40,7 +40,7 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		Logo:         "logo",
 		LoginPageURL: "http://dummy.com",
 		JWTBearerSettings: &descope.JWTBearerSettings{
-			Issuers: map[string]descope.IssuerSettings{
+			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {
 					JWKsURI:             "http://dummy.com/jwks",
 					SignAlgorithm:       "RS256",
@@ -106,7 +106,7 @@ func TestThirdPartyApplicationUpdateSuccess(t *testing.T) {
 		PermissionsScopes:    []*descope.ThirdPartyApplicationScope{{Name: "scope1", Description: "desc1", Values: []string{"v1"}}},
 		AttributesScopes:     []*descope.ThirdPartyApplicationScope{{Name: "scope2", Description: "desc2", Values: []string{"v2"}}},
 		JWTBearerSettings: &descope.JWTBearerSettings{
-			Issuers: map[string]descope.IssuerSettings{
+			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {
 					JWKsURI:             "http://dummy.com/jwks",
 					SignAlgorithm:       "RS256",

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -22,6 +22,15 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		require.Equal(t, "desc", req["description"])
 		require.Equal(t, "logo", req["logo"])
 		require.Equal(t, "http://dummy.com", req["loginPageUrl"])
+		d, ok := req["jwtBearerSettings"].(map[string]any)
+		require.True(t, ok)
+		d, ok = d["issuers"].(map[string]any)
+		require.True(t, ok)
+		require.Len(t, d, 1)
+		require.EqualValues(t, "http://dummy.com/jwks", d["issuer1"].(map[string]any)["jwksUri"])
+		require.EqualValues(t, "RS256", d["issuer1"].(map[string]any)["signAlgorithm"])
+		require.EqualValues(t, "http://dummy.com/userinfo", d["issuer1"].(map[string]any)["userInfoUri"])
+		require.EqualValues(t, "sub", d["issuer1"].(map[string]any)["externalIdFieldName"])
 	}, response))
 
 	id, secret, err := mgmt.ThirdPartyApplication().CreateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
@@ -30,6 +39,16 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		Description:  "desc",
 		Logo:         "logo",
 		LoginPageURL: "http://dummy.com",
+		JWTBearerSettings: &descope.JWTBearerSettings{
+			Issuers: map[string]descope.IssuerSettings{
+				"issuer1": {
+					JWKsURI:             "http://dummy.com/jwks",
+					SignAlgorithm:       "RS256",
+					UserInfoURI:         "http://dummy.com/userinfo",
+					ExternalIDFieldName: "sub",
+				},
+			},
+		},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "qux", id)
@@ -66,6 +85,15 @@ func TestThirdPartyApplicationUpdateSuccess(t *testing.T) {
 		require.Equal(t, []any{"http://dummy.com/callback"}, req["approvedCallbackUrls"])
 		require.Equal(t, []any{map[string]any{"name": "scope1", "description": "desc1", "values": []any{"v1"}}}, req["permissionsScopes"])
 		require.Equal(t, []any{map[string]any{"name": "scope2", "description": "desc2", "values": []any{"v2"}}}, req["attributesScopes"])
+		d, ok := req["jwtBearerSettings"].(map[string]any)
+		require.True(t, ok)
+		d, ok = d["issuers"].(map[string]any)
+		require.True(t, ok)
+		require.Len(t, d, 1)
+		require.EqualValues(t, "http://dummy.com/jwks", d["issuer1"].(map[string]any)["jwksUri"])
+		require.EqualValues(t, "RS256", d["issuer1"].(map[string]any)["signAlgorithm"])
+		require.EqualValues(t, "http://dummy.com/userinfo", d["issuer1"].(map[string]any)["userInfoUri"])
+		require.EqualValues(t, "sub", d["issuer1"].(map[string]any)["externalIdFieldName"])
 	}, response))
 
 	err := mgmt.ThirdPartyApplication().UpdateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
@@ -77,6 +105,16 @@ func TestThirdPartyApplicationUpdateSuccess(t *testing.T) {
 		ApprovedCallbackUrls: []string{"http://dummy.com/callback"},
 		PermissionsScopes:    []*descope.ThirdPartyApplicationScope{{Name: "scope1", Description: "desc1", Values: []string{"v1"}}},
 		AttributesScopes:     []*descope.ThirdPartyApplicationScope{{Name: "scope2", Description: "desc2", Values: []string{"v2"}}},
+		JWTBearerSettings: &descope.JWTBearerSettings{
+			Issuers: map[string]descope.IssuerSettings{
+				"issuer1": {
+					JWKsURI:             "http://dummy.com/jwks",
+					SignAlgorithm:       "RS256",
+					UserInfoURI:         "http://dummy.com/userinfo",
+					ExternalIDFieldName: "sub",
+				},
+			},
+		},
 	})
 	require.NoError(t, err)
 }
@@ -214,6 +252,16 @@ func TestThirdPartyApplicationLoadSuccess(t *testing.T) {
 		"attributesScopes": []map[string]any{
 			{"name": "scope2", "description": "desc2"},
 		},
+		"jwtBearerSettings": map[string]any{
+			"issuers": map[string]any{
+				"issuer1": map[string]any{
+					"jwksUri":             "http://dummy.com/jwks",
+					"signAlgorithm":       "RS256",
+					"userInfoUri":         "http://dummy.com/userinfo",
+					"externalIdFieldName": "sub",
+				},
+			},
+		},
 	}
 
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
@@ -233,6 +281,11 @@ func TestThirdPartyApplicationLoadSuccess(t *testing.T) {
 	require.Len(t, res.AttributesScopes, 1)
 	require.Equal(t, "scope2", res.AttributesScopes[0].Name)
 	require.Equal(t, "desc2", res.AttributesScopes[0].Description)
+	require.Len(t, res.JWTBearerSettings.Issuers, 1)
+	require.EqualValues(t, "http://dummy.com/jwks", res.JWTBearerSettings.Issuers["issuer1"].JWKsURI)
+	require.EqualValues(t, "RS256", res.JWTBearerSettings.Issuers["issuer1"].SignAlgorithm)
+	require.EqualValues(t, "http://dummy.com/userinfo", res.JWTBearerSettings.Issuers["issuer1"].UserInfoURI)
+	require.EqualValues(t, "sub", res.JWTBearerSettings.Issuers["issuer1"].ExternalIDFieldName)
 }
 
 func TestThirdPartyApplicationLoadError(t *testing.T) {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -82,6 +82,8 @@ type SSOApplication interface {
 	// Logo: Optional sso application logo.
 	// LoginPageURL: The URL where login page is hosted.
 	// ForceAuthentication: Optional determine if the IdP should force the user to re-authenticate.
+	// JWTBearerSettings: Optional JWT Bearer settings which used to validate external token.
+	// BackChannelLogoutURL: Optional Back-Channel Logout URL (as per CIBA spec)
 	//
 	// The argument appRequest.Id value is optional and will be auto generated if provided with empty value
 	// The argument appRequest.Id and appRequest.Name must be unique per project.
@@ -904,6 +906,7 @@ type ThirdPartyApplication interface {
 	// ApprovedCallbackUrls: List of approved callback URLs.
 	// PermissionsScopes: List of permissions scopes.
 	// AttributesScopes: List of attributes scopes.
+	// JWTBearerSettings: Optional JWT Bearer settings which used to validate external token.
 	//
 	// The argument appRequest.Name must be unique per project.
 	CreateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) (id string, secret string, err error)

--- a/descope/types.go
+++ b/descope/types.go
@@ -740,10 +740,12 @@ type SSOApplicationSAMLSettings struct {
 }
 
 type SSOApplicationOIDCSettings struct {
-	LoginPageURL        string `json:"loginPageUrl"`
-	Issuer              string `json:"issuer"`
-	DiscoveryURL        string `json:"discoveryUrl"`
-	ForceAuthentication bool   `json:"forceAuthentication"`
+	LoginPageURL         string             `json:"loginPageUrl"`
+	Issuer               string             `json:"issuer"`
+	DiscoveryURL         string             `json:"discoveryUrl"`
+	ForceAuthentication  bool               `json:"forceAuthentication"`
+	JWTBearerSettings    *JWTBearerSettings `json:"jwtBearerSettings,omitempty"`
+	BackChannelLogoutURL string             `json:"backChannelLogoutUrl,omitempty"`
 }
 
 type SSOApplication struct {
@@ -758,13 +760,15 @@ type SSOApplication struct {
 }
 
 type OIDCApplicationRequest struct {
-	ID                  string `json:"id"`
-	Name                string `json:"name"`
-	Description         string `json:"description"`
-	Enabled             bool   `json:"enabled"`
-	Logo                string `json:"logo"`
-	LoginPageURL        string `json:"loginPageUrl"`
-	ForceAuthentication bool   `json:"forceAuthentication"`
+	ID                   string             `json:"id"`
+	Name                 string             `json:"name"`
+	Description          string             `json:"description"`
+	Enabled              bool               `json:"enabled"`
+	Logo                 string             `json:"logo"`
+	LoginPageURL         string             `json:"loginPageUrl"`
+	ForceAuthentication  bool               `json:"forceAuthentication"`
+	JWTBearerSettings    *JWTBearerSettings `json:"jwtBearerSettings,omitempty"`
+	BackChannelLogoutURL string             `json:"backChannelLogoutUrl,omitempty"`
 }
 
 type SAMLApplicationRequest struct {
@@ -1071,6 +1075,17 @@ type ThirdPartyApplicationScope struct {
 	Values      []string `json:"values"`
 }
 
+type IssuerSettings struct {
+	JWKsURI             string `json:"jwksUri,omitempty"`
+	SignAlgorithm       string `json:"signAlgorithm,omitempty"`
+	UserInfoURI         string `json:"userInfoUri,omitempty"`
+	ExternalIDFieldName string `json:"externalIdFieldName,omitempty"`
+}
+
+type JWTBearerSettings struct {
+	Issuers map[string]IssuerSettings `json:"issuers,omitempty"`
+}
+
 type ThirdPartyApplication struct {
 	ID                   string                        `json:"id"`
 	Name                 string                        `json:"name"`
@@ -1081,6 +1096,7 @@ type ThirdPartyApplication struct {
 	ApprovedCallbackUrls []string                      `json:"approvedCallbackUrls"`
 	PermissionsScopes    []*ThirdPartyApplicationScope `json:"permissionsScopes"`
 	AttributesScopes     []*ThirdPartyApplicationScope `json:"attributesScopes"`
+	JWTBearerSettings    *JWTBearerSettings            `json:"jwtBearerSettings,omitempty"`
 }
 
 type ThirdPartyApplicationRequest struct {
@@ -1092,6 +1108,7 @@ type ThirdPartyApplicationRequest struct {
 	ApprovedCallbackUrls []string                      `json:"approvedCallbackUrls"`
 	PermissionsScopes    []*ThirdPartyApplicationScope `json:"permissionsScopes"`
 	AttributesScopes     []*ThirdPartyApplicationScope `json:"attributesScopes"`
+	JWTBearerSettings    *JWTBearerSettings            `json:"jwtBearerSettings,omitempty"`
 }
 
 type ThirdPartyApplicationConsent struct {

--- a/descope/types.go
+++ b/descope/types.go
@@ -1083,7 +1083,7 @@ type IssuerSettings struct {
 }
 
 type JWTBearerSettings struct {
-	Issuers map[string]IssuerSettings `json:"issuers,omitempty"`
+	Issuers map[string]*IssuerSettings `json:"issuers,omitempty"`
 }
 
 type ThirdPartyApplication struct {


### PR DESCRIPTION
Related to https://github.com/descope/etc/issues/9630
Related to https://github.com/descope/etc/issues/10782

Add jwt bearer (external token) settings for federated and Inbound apps
Add CIBA logout url settings to federated apps