### PR TITLE
feat: add TenantRoleIDs and TenantRoleNames to user search

### DIFF
--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -10,6 +10,19 @@ import (
 	"github.com/descope/go-sdk/descope/sdk"
 )
 
+func mapToValuesObject(inputMap map[string][]string) map[string]map[string][]string {
+	if len(inputMap) == 0 {
+		return nil
+	}
+	result := make(map[string]map[string][]string)
+	for k, v := range inputMap {
+		result[k] = map[string][]string{
+			"values": v,
+		}
+	}
+	return result
+}
+
 type user struct {
 	managementBase
 }
@@ -975,6 +988,8 @@ func makeSearchAllRequest(options *descope.UserSearchOptions) map[string]any {
 		"fromModifiedTime": options.FromModifiedTime,
 		"toModifiedTime":   options.ToModifiedTime,
 		"userIds":          options.UserIDs,
+		"tenantRoleIds":    mapToValuesObject(options.TenantRoleIDs),
+		"tenantRoleNames":  mapToValuesObject(options.TenantRoleNames),
 	}
 }
 

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -760,6 +760,8 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 		require.EqualValues(t, []any{"+11111111"}, req["phones"])
 		require.EqualValues(t, "blue", req["text"])
 		require.EqualValues(t, []interface{}([]interface{}{map[string]interface{}{"Desc": true, "Field": "nono"}, map[string]interface{}{"Desc": false, "Field": "lolo"}}), req["sort"])
+		require.EqualValues(t, map[string]any{"tenant1": map[string]any{"values": []any{"id1", "id2"}}}, req["tenantRoleIds"])
+		require.EqualValues(t, map[string]any{"tenant2": map[string]any{"values": []any{"name1", "name2"}}}, req["tenantRoleNames"])
 	}, response))
 	res, total, err := m.User().SearchAll(context.Background(), &descope.UserSearchOptions{
 		Statuses:         []descope.UserStatus{descope.UserStatusDisabled},
@@ -774,6 +776,8 @@ func TestSearchAllUsersSuccess(t *testing.T) {
 			{Field: "nono", Desc: true},
 			{Field: "lolo", Desc: false},
 		},
+		TenantRoleIDs:   map[string][]string{"tenant1": {"id1", "id2"}},
+		TenantRoleNames: map[string][]string{"tenant2": {"name1", "name2"}},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -790,7 +794,6 @@ func TestSearchAllTestUsersSuccess(t *testing.T) {
 		}},
 		"total": 85,
 	}
-
 	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
 		require.NotNil(t, r.URL)
@@ -800,9 +803,13 @@ func TestSearchAllTestUsersSuccess(t *testing.T) {
 		require.EqualValues(t, true, req["testUsersOnly"].(bool))
 		require.EqualValues(t, true, req["withTestUser"].(bool))
 		require.EqualValues(t, []any{"a@b.com"}, req["emails"])
+		require.EqualValues(t, map[string]any{"tenant1": map[string]any{"values": []any{"id1", "id2"}}}, req["tenantRoleIds"])
+		require.EqualValues(t, map[string]any{"tenant2": map[string]any{"values": []any{"name1", "name2"}}}, req["tenantRoleNames"])
 	}, response))
 	res, _, err := m.User().SearchAllTestUsers(context.Background(), &descope.UserSearchOptions{
-		Emails: []string{"a@b.com"},
+		Emails:          []string{"a@b.com"},
+		TenantRoleIDs:   map[string][]string{"tenant1": {"id1", "id2"}},
+		TenantRoleNames: map[string][]string{"tenant2": {"name1", "name2"}},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)

--- a/descope/types.go
+++ b/descope/types.go
@@ -856,6 +856,8 @@ type UserSearchOptions struct {
 	ToCreatedTime    int64
 	FromModifiedTime int64
 	ToModifiedTime   int64
+	TenantRoleIDs    map[string][]string
+	TenantRoleNames  map[string][]string
 }
 
 type UserSearchSort struct {


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/11275

## Description
Added TenantRoleIDs and TenantRoleNames parameters to search users to allow for searching by tenants and roles. 
