### PR TITLE
Save Schema "Dry Run" to Preview Deletes (GO-SDK)

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -213,6 +213,7 @@ var (
 			authzRETargetAll:                         "mgmt/authz/re/targetall",
 			authzRETargetWithRelation:                "mgmt/authz/re/targetwithrelation",
 			authzGetModified:                         "mgmt/authz/getmodified",
+			fgaSchemaDryRun:                          "mgmt/fga/schema/dryrun",
 			fgaSaveSchema:                            "mgmt/fga/schema",
 			fgaLoadSchema:                            "mgmt/fga/schema",
 			fgaCreateRelations:                       "mgmt/fga/relations",
@@ -466,6 +467,7 @@ type mgmtEndpoints struct {
 	authzGetModified          string
 
 	fgaSaveSchema              string
+	fgaSchemaDryRun            string
 	fgaLoadSchema              string
 	fgaCreateRelations         string
 	fgaDeleteRelations         string
@@ -1232,6 +1234,10 @@ func (e *endpoints) ManagementAuthzGetModified() string {
 
 func (e *endpoints) ManagementFGASaveSchema() string {
 	return path.Join(e.version, e.mgmt.fgaSaveSchema)
+}
+
+func (e *endpoints) ManagementFGASchemaDryRun() string {
+	return path.Join(e.version, e.mgmt.fgaSchemaDryRun)
 }
 
 func (e *endpoints) ManagementFGALoadSchema() string {

--- a/descope/authztypes.go
+++ b/descope/authztypes.go
@@ -153,3 +153,13 @@ type ResourceDetails struct {
 	ResourceType string `json:"resourceType"`
 	DisplayName  string `json:"displayName"`
 }
+
+type FGASchemaDryRunResponse struct {
+	DeletesPreview *FGASchemaDryDeletes `json:"deletesPreview,omitempty"`
+}
+
+type FGASchemaDryDeletes struct {
+	HasDeletes bool     `json:"hasDeletes"`
+	Relations  []string `json:"relations,omitempty"`
+	Types      []string `json:"types,omitempty"`
+}

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -21,6 +21,28 @@ type DSLSchema struct {
 	DSL string `json:"dsl"`
 }
 
+func (f *fga) DryRunSchema(ctx context.Context, schema *descope.FGASchema) (*descope.FGASchemaDryRunResponse, error) {
+	if schema == nil {
+		return nil, utils.NewInvalidArgumentError("schema")
+	}
+	body := &DSLSchema{
+		DSL: schema.Schema,
+	}
+
+	options := &api.HTTPRequest{}
+	res, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGASchemaDryRun(), body, options, f.conf.ManagementKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var dryRunResponse *descope.FGASchemaDryRunResponse
+	err = utils.Unmarshal([]byte(res.BodyStr), &dryRunResponse)
+	if err != nil {
+		return nil, err // notest
+	}
+	return dryRunResponse, nil
+}
+
 func (f *fga) SaveSchema(ctx context.Context, schema *descope.FGASchema) error {
 	if schema == nil {
 		return utils.NewInvalidArgumentError("schema")

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -876,6 +876,9 @@ type FGA interface {
 	// LoadSchema loads the schema for the project.
 	LoadSchema(ctx context.Context) (*descope.FGASchema, error)
 
+	// DryRunSchema validates a schema without saving it and returns what would be deleted from the current schema.
+	DryRunSchema(ctx context.Context, schema *descope.FGASchema) (*descope.FGASchemaDryRunResponse, error)
+
 	// CreateRelation creates new relations for the project.
 	CreateRelations(ctx context.Context, relations []*descope.FGARelation) error
 

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1635,6 +1635,10 @@ type MockFGA struct {
 	LoadSchemaResponse *descope.FGASchema
 	LoadSchemaError    error
 
+	DryRunSchemaAssert   func(schema *descope.FGASchema)
+	DryRunSchemaResponse *descope.FGASchemaDryRunResponse
+	DryRunSchemaError    error
+
 	CreateRelationsAssert func(relations []*descope.FGARelation)
 	CreateRelationsError  error
 
@@ -1670,6 +1674,13 @@ func (m *MockFGA) SaveSchema(_ context.Context, schema *descope.FGASchema) error
 
 func (m *MockFGA) LoadSchema(_ context.Context) (*descope.FGASchema, error) {
 	return m.LoadSchemaResponse, m.LoadSchemaError
+}
+
+func (m *MockFGA) DryRunSchema(_ context.Context, schema *descope.FGASchema) (*descope.FGASchemaDryRunResponse, error) {
+	if m.DryRunSchemaAssert != nil {
+		m.DryRunSchemaAssert(schema)
+	}
+	return m.DryRunSchemaResponse, m.DryRunSchemaError
 }
 
 func (m *MockFGA) CreateRelations(_ context.Context, relations []*descope.FGARelation) error {


### PR DESCRIPTION
## Related Issues
Required for: 
- https://github.com/descope/etc/issues/11356

## Description
Performs a "dry run" for saving a schema:
1. Validates the schema.
2. Calculates if any "types" or "relations" from the current schema might get deleted as a result of performing this change.
3. The `dryrun` calls does **not** make any changes to the schema or relations.

## Related PRs:
Depends on:
- https://github.com/descope/managementservice/pull/2507

## Must
- [x] Tests
- [ ] Documentation (if applicable)
