### PR TITLE
Add Support for custom logic to provider tokens from request

### DIFF
--- a/descope/client/client.go
+++ b/descope/client/client.go
@@ -69,7 +69,7 @@ func NewWithConfig(config *Config) (*DescopeClient, error) {
 		SessionCookieName:   config.SessionCookieName,
 	}
 	provider := auth.NewProvider(authClient, conf)
-	authService, err := auth.NewAuthWithProvider(*conf, provider, authClient)
+	authService, err := auth.NewAuthWithProvider(*conf, provider, authClient, config.RequestTokensProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/descope/client/config.go
+++ b/descope/client/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/descope/go-sdk/descope/api"
 	"github.com/descope/go-sdk/descope/internal/utils"
 	"github.com/descope/go-sdk/descope/logger"
+	"github.com/descope/go-sdk/descope/sdk"
 )
 
 // Conf - Configuration struct describes the configurational data for the authentication methods.
@@ -64,6 +65,8 @@ type Config struct {
 	RefreshCookieName string
 	// When using custom DS cookie name, set the correct value here, to make the SDK fetch the correct cookie
 	SessionCookieName string
+	// When using custom request tokens provider, set the correct value here, to make the SDK fetch the correct tokens
+	RequestTokensProvider sdk.RequestTokensProvider
 }
 
 func (c *Config) setProjectID() string {

--- a/descope/sdk/token_provider.go
+++ b/descope/sdk/token_provider.go
@@ -1,0 +1,7 @@
+package sdk
+
+import "net/http"
+
+type RequestTokensProvider interface {
+	ProvideTokens(r *http.Request) (sessionToken string, refreshToken string)
+}


### PR DESCRIPTION
## Description
Added an option to override the default logic to extract tokens from request.

I love the api this sdk exposes to validate requests incoming to my server, however In our auth flow we have some custom quircks for token storage. would like to be able to override the default behaviour and extract them from how we store them.

## Must
- [x] Tests
- [X] Documentation (if applicable)
