### PR TITLE
chore: revert fix external groups functions docs

### DIFF
--- a/descope/internal/mgmt/group_test.go
+++ b/descope/internal/mgmt/group_test.go
@@ -18,6 +18,13 @@ func TestLoadAllGroupsSuccess(t *testing.T) {
 		{
 			ID:      "some-id",
 			Display: "some-display",
+			Members: []descope.GroupMember{
+				{
+					LoginID: "some-loginID",
+					UserID:  "some-userID",
+					Display: "some-display",
+				},
+			},
 		},
 	}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
@@ -55,6 +62,13 @@ func TestLoadAllGroupsForMembersSuccess(t *testing.T) {
 		{
 			ID:      "some-id",
 			Display: "some-display",
+			Members: []descope.GroupMember{
+				{
+					LoginID: "some-loginID",
+					UserID:  "some-userIDs",
+					Display: "some-display",
+				},
+			},
 		},
 	}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {


### PR DESCRIPTION
Reverts descope/go-sdk#671