### PR TITLE
feat(fga): add CheckWithContext for ABAC/CEL evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1559,6 +1559,21 @@ relations, err := descopeClient.Management.FGA().Check(context.Background(), []*
 		TargetType: "user"
     }
 })
+
+// Supply a context map for CEL condition evaluation (ABAC). The backend may
+// also have attributes of its own; this map is merged on top for evaluation.
+checks, err := descopeClient.Management.FGA().CheckWithContext(
+    context.Background(),
+    []*descope.FGARelation{{Resource: "some-doc", ResourceType: "doc", Relation: "can_view", Target: "u1", TargetType: "user"}},
+    map[string]any{"ip": "10.0.0.1", "role": "admin"},
+)
+info := checks[0].Info
+if info.Conditional && len(info.MissingContext) > 0 {
+    // supply the missing context variables and retry
+}
+if info.ConditionalErr != "" {
+    // CEL evaluation failed; checks[0].Allowed is false
+}
 ```
 
 Response times of repeated FGA `Check` calls, especially in high volume scenarios, can be reduced to sub-millisecond scales by re-directing the calls to a Descope FGA Cache Proxy running in the same backend cluster as your application.

--- a/descope/authztypes.go
+++ b/descope/authztypes.go
@@ -118,6 +118,14 @@ type FGACheckInfo struct {
 	// A relation is considered "direct" if, based solely on the schema, its "allowed" state can only be
 	// changed by creating or deleting relations involving its resource, its target, or both (including itself)
 	Direct bool `json:"direct,omitempty"`
+	// Conditional is true when the result was decided by evaluating a CEL condition in the schema.
+	Conditional bool `json:"conditional,omitempty"`
+	// MissingContext lists context variable names that were referenced by a condition but not supplied
+	// to CheckWithContext (and not known to the backend), causing partial evaluation.
+	MissingContext []string `json:"missingContext,omitempty"`
+	// ConditionalErr holds the CEL evaluation error message when a condition could not be evaluated
+	// (e.g. wrong context value type). Allowed will be false in that case.
+	ConditionalErr string `json:"conditionalErr,omitempty"`
 }
 
 type FGAMappableResourcesOptions struct {

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -111,12 +111,19 @@ type checkResponse struct {
 }
 
 func (f *fga) Check(ctx context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error) {
+	return f.CheckWithContext(ctx, relations, nil)
+}
+
+func (f *fga) CheckWithContext(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error) {
 	if len(relations) == 0 {
 		return nil, utils.NewInvalidArgumentError("relations")
 	}
 
 	body := map[string]any{
 		"tuples": relations,
+	}
+	if len(extraContext) > 0 {
+		body["context"] = extraContext
 	}
 
 	options := &api.HTTPRequest{}
@@ -134,14 +141,14 @@ func (f *fga) Check(ctx context.Context, relations []*descope.FGARelation) ([]*d
 
 	checks := make([]*descope.FGACheck, len(response.CheckResponseTuple))
 	for i, tuple := range response.CheckResponseTuple {
-		var direct bool
-		if tuple.Info != nil {
-			direct = tuple.Info.Direct
+		info := tuple.Info
+		if info == nil {
+			info = &descope.FGACheckInfo{}
 		}
 		checks[i] = &descope.FGACheck{
 			Relation: tuple.Tuple,
 			Allowed:  tuple.Allowed,
-			Info:     &descope.FGACheckInfo{Direct: direct},
+			Info:     info,
 		}
 	}
 

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -216,6 +216,127 @@ func TestCheckFGARelationsMissingTuples(t *testing.T) {
 	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
 }
 
+func TestCheckFGAWithContextPassthrough(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{
+				Allowed:  true,
+				Relation: &descope.FGARelation{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"},
+				Info:     &descope.FGACheckInfo{Direct: true},
+			},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.NotNil(t, req["tuples"])
+		ctx, ok := req["context"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "1.2.3.4", ctx["ip"])
+		require.Equal(t, "admin", ctx["role"])
+	}, response))
+	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		map[string]any{"ip": "1.2.3.4", "role": "admin"},
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+	require.True(t, checks[0].Allowed)
+	require.True(t, checks[0].Info.Direct)
+}
+
+func TestCheckFGAWithContextNil(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{
+				Allowed:  true,
+				Relation: &descope.FGARelation{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"},
+			},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.NotNil(t, req["tuples"])
+		_, hasContext := req["context"]
+		require.False(t, hasContext)
+	}, response))
+	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+}
+
+func TestCheckFGAWithContextEmpty(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{
+				Allowed:  true,
+				Relation: &descope.FGARelation{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"},
+			},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		_, hasContext := req["context"]
+		require.False(t, hasContext)
+	}, response))
+	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		map[string]any{},
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+}
+
+func TestCheckFGAWithContextMissingTuples(t *testing.T) {
+	mgmt := newTestMgmt(nil, nil)
+	_, err := mgmt.FGA().CheckWithContext(context.Background(), nil, map[string]any{"k": "v"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
+}
+
+func TestCheckFGAConditionalResult(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{
+				Allowed:  true,
+				Relation: &descope.FGARelation{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"},
+				Info:     &descope.FGACheckInfo{Conditional: true, MissingContext: []string{"user.dept"}},
+			},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(nil, response))
+	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		map[string]any{"ip": "1.2.3.4"},
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+	require.True(t, checks[0].Allowed)
+	require.True(t, checks[0].Info.Conditional)
+	require.Equal(t, []string{"user.dept"}, checks[0].Info.MissingContext)
+}
+
+func TestCheckFGAConditionalErr(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{
+				Allowed:  false,
+				Relation: &descope.FGARelation{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"},
+				Info:     &descope.FGACheckInfo{ConditionalErr: "no such attribute"},
+			},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(nil, response))
+	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+	require.False(t, checks[0].Allowed)
+	require.Equal(t, "no such attribute", checks[0].Info.ConditionalErr)
+}
+
 func TestLoadMappableSchemaSuccess(t *testing.T) {
 	response := &descope.FGAMappableSchema{
 		Schema: &descope.AuthzSchema{

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -978,8 +978,15 @@ type FGA interface {
 	// DeleteRelations deletes relations for the project.
 	DeleteRelations(ctx context.Context, relations []*descope.FGARelation) error
 
-	// Check checks if the given relations are satisfied.
+	// Check checks if the given relations are satisfied. Conditions in the schema are evaluated
+	// against any attributes the backend already has on hand.
 	Check(ctx context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error)
+
+	// CheckWithContext is like Check but additionally threads a caller-supplied context map to CEL
+	// conditions defined in the schema. Keys become available as context variables during evaluation
+	// (merged on top of any attributes the backend already has); values must be JSON-marshalable.
+	// Pass a nil or empty map if you do not need to supply any extra context.
+	CheckWithContext(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error)
 
 	// LoadMappableSchema loads the mappable schema for the project (only listing the RDs for a Namespace), along with a list of mappable resources.
 	LoadMappableSchema(ctx context.Context, tenantID string, options *descope.FGAMappableResourcesOptions) (*descope.FGAMappableSchema, error)

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1816,6 +1816,10 @@ type MockFGA struct {
 	CheckResponse []*descope.FGACheck
 	CheckError    error
 
+	CheckWithContextAssert   func(relations []*descope.FGARelation, extraContext map[string]any)
+	CheckWithContextResponse []*descope.FGACheck
+	CheckWithContextError    error
+
 	LoadMappableSchemaAssert   func(tenantID string, options *descope.FGAMappableResourcesOptions)
 	LoadMappableSchemaResponse *descope.FGAMappableSchema
 	LoadMappableSchemaError    error
@@ -1869,6 +1873,13 @@ func (m *MockFGA) Check(_ context.Context, relations []*descope.FGARelation) ([]
 		m.CheckAssert(relations)
 	}
 	return m.CheckResponse, m.CheckError
+}
+
+func (m *MockFGA) CheckWithContext(_ context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error) {
+	if m.CheckWithContextAssert != nil {
+		m.CheckWithContextAssert(relations, extraContext)
+	}
+	return m.CheckWithContextResponse, m.CheckWithContextError
 }
 
 func (m *MockFGA) LoadMappableSchema(_ context.Context, tenantID string, options *descope.FGAMappableResourcesOptions) (*descope.FGAMappableSchema, error) {


### PR DESCRIPTION
## Related Issues

Required for:
https://github.com/descope/etc/issues/14728

Companion to backend PR descope/descope#271.

## Description

Surfaces the new ABAC/CEL capabilities added by descope/descope#271 in the Go SDK.

- Adds `FGA().CheckWithContext(ctx, relations, extraContext)` that threads a caller-supplied context map (serialized as the `context` field) to CEL condition evaluation. The existing `Check` is preserved and now delegates to `CheckWithContext(ctx, relations, nil)`.
- Extends `FGACheckInfo` with `Conditional`, `MissingContext`, and `ConditionalErr` so callers can detect conditional/partially-evaluated results and CEL evaluation errors (the backend returns 200 with `allowed=false` on eval error — surfaced on `Info`, not as a Go `error`).
- Updates the mock `MockFGA` with matching `CheckWithContext*` fields and method.
- README gets a new snippet showing the ABAC usage pattern.

The `extraContext` parameter is only included in the wire payload when non-empty, so existing traffic is unchanged.
