### PR TITLE
feat: add IDPResponse to AuthenticationInfo for SSO exchange

### DIFF
--- a/descope/internal/auth/oauth_test.go
+++ b/descope/internal/auth/oauth_test.go
@@ -213,6 +213,82 @@ func TestExchangeTokenSAML(t *testing.T) {
 	assert.True(t, authInfo.FirstSeen)
 }
 
+func TestExchangeTokenSAMLWithIDPResponse(t *testing.T) {
+	code := "code"
+	expectedIDPResponse := &descope.IDPResponse{
+		IDPGroups:         []string{"engineering", "devops"},
+		IDPSAMLAttributes: map[string]interface{}{"department": "engineering", "title": "Staff Engineer"},
+	}
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		req := exchangeTokenBody{}
+		err := readBody(r, &req)
+		require.NoError(t, err)
+		assert.EqualValues(t, code, req.Code)
+		resp := &descope.JWTResponse{
+			RefreshJwt: jwtTokenValid,
+			User: &descope.UserResponse{
+				User: descope.User{
+					Name: "name",
+				},
+			},
+			FirstSeen:   true,
+			IDPResponse: expectedIDPResponse,
+		}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	authInfo, err := a.SAML().ExchangeToken(context.Background(), code, w)
+	require.NoError(t, err)
+	require.NotNil(t, authInfo)
+	assert.EqualValues(t, "name", authInfo.User.Name)
+	assert.True(t, authInfo.FirstSeen)
+	require.NotNil(t, authInfo.IDPResponse)
+	assert.EqualValues(t, expectedIDPResponse.IDPGroups, authInfo.IDPResponse.IDPGroups)
+	assert.EqualValues(t, expectedIDPResponse.IDPSAMLAttributes, authInfo.IDPResponse.IDPSAMLAttributes)
+	assert.Nil(t, authInfo.IDPResponse.IDPOIDCClaims)
+}
+
+func TestExchangeTokenOAuthWithIDPResponse(t *testing.T) {
+	code := "code"
+	expectedIDPResponse := &descope.IDPResponse{
+		IDPGroups:     []string{"users"},
+		IDPOIDCClaims: map[string]interface{}{"email_verified": true, "locale": "en-US"},
+	}
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		req := exchangeTokenBody{}
+		err := readBody(r, &req)
+		require.NoError(t, err)
+		assert.EqualValues(t, code, req.Code)
+		resp := &descope.JWTResponse{
+			RefreshJwt: jwtTokenValid,
+			User: &descope.UserResponse{
+				User: descope.User{
+					Name: "name",
+				},
+			},
+			FirstSeen:   true,
+			IDPResponse: expectedIDPResponse,
+		}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	authInfo, err := a.OAuth().ExchangeToken(context.Background(), code, w)
+	require.NoError(t, err)
+	require.NotNil(t, authInfo)
+	assert.EqualValues(t, "name", authInfo.User.Name)
+	assert.True(t, authInfo.FirstSeen)
+	require.NotNil(t, authInfo.IDPResponse)
+	assert.EqualValues(t, expectedIDPResponse.IDPGroups, authInfo.IDPResponse.IDPGroups)
+	assert.Nil(t, authInfo.IDPResponse.IDPSAMLAttributes)
+	assert.EqualValues(t, expectedIDPResponse.IDPOIDCClaims, authInfo.IDPResponse.IDPOIDCClaims)
+}
+
 func TestExchangeTokenError(t *testing.T) {
 	code := ""
 	a, err := newTestAuth(nil, nil)

--- a/descope/internal/auth/oauth_test.go
+++ b/descope/internal/auth/oauth_test.go
@@ -217,7 +217,7 @@ func TestExchangeTokenSAMLWithIDPResponse(t *testing.T) {
 	code := "code"
 	expectedIDPResponse := &descope.IDPResponse{
 		IDPGroups:         []string{"engineering", "devops"},
-		IDPSAMLAttributes: map[string]interface{}{"department": "engineering", "title": "Staff Engineer"},
+		IDPSAMLAttributes: map[string]any{"department": "engineering", "title": "Staff Engineer"},
 	}
 	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
 		req := exchangeTokenBody{}
@@ -255,7 +255,7 @@ func TestExchangeTokenOAuthWithIDPResponse(t *testing.T) {
 	code := "code"
 	expectedIDPResponse := &descope.IDPResponse{
 		IDPGroups:     []string{"users"},
-		IDPOIDCClaims: map[string]interface{}{"email_verified": true, "locale": "en-US"},
+		IDPOIDCClaims: map[string]any{"email_verified": true, "locale": "en-US"},
 	}
 	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
 		req := exchangeTokenBody{}

--- a/descope/internal/auth/sso_test.go
+++ b/descope/internal/auth/sso_test.go
@@ -139,8 +139,8 @@ func TestExchangeTokenSSOWithIDPResponse(t *testing.T) {
 	code := "code"
 	expectedIDPResponse := &descope.IDPResponse{
 		IDPGroups:         []string{"group1", "group2"},
-		IDPSAMLAttributes: map[string]interface{}{"attr1": "value1", "attr2": "value2"},
-		IDPOIDCClaims:     map[string]interface{}{"claim1": "claimValue1", "sub": "user123"},
+		IDPSAMLAttributes: map[string]any{"attr1": "value1", "attr2": "value2"},
+		IDPOIDCClaims:     map[string]any{"claim1": "claimValue1", "sub": "user123"},
 	}
 	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
 		req := exchangeTokenBody{}
@@ -177,6 +177,10 @@ func TestExchangeTokenSSOWithIDPResponse(t *testing.T) {
 func TestExchangeTokenSSOWithoutIDPResponse(t *testing.T) {
 	code := "code"
 	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		req := exchangeTokenBody{}
+		err := readBody(r, &req)
+		require.NoError(t, err)
+		assert.EqualValues(t, code, req.Code)
 		resp := &descope.JWTResponse{
 			RefreshJwt: jwtTokenValid,
 			User: &descope.UserResponse{
@@ -204,6 +208,10 @@ func TestExchangeTokenSSOWithPartialIDPResponse(t *testing.T) {
 		IDPGroups: []string{"admins"},
 	}
 	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		req := exchangeTokenBody{}
+		err := readBody(r, &req)
+		require.NoError(t, err)
+		assert.EqualValues(t, code, req.Code)
 		resp := &descope.JWTResponse{
 			RefreshJwt: jwtTokenValid,
 			User: &descope.UserResponse{

--- a/descope/internal/auth/sso_test.go
+++ b/descope/internal/auth/sso_test.go
@@ -134,3 +134,97 @@ func TestExchangeTokenSSO(t *testing.T) {
 	assert.EqualValues(t, "name", authInfo.User.Name)
 	assert.True(t, authInfo.FirstSeen)
 }
+
+func TestExchangeTokenSSOWithIDPResponse(t *testing.T) {
+	code := "code"
+	expectedIDPResponse := &descope.IDPResponse{
+		IDPGroups:         []string{"group1", "group2"},
+		IDPSAMLAttributes: map[string]interface{}{"attr1": "value1", "attr2": "value2"},
+		IDPOIDCClaims:     map[string]interface{}{"claim1": "claimValue1", "sub": "user123"},
+	}
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		req := exchangeTokenBody{}
+		err := readBody(r, &req)
+		require.NoError(t, err)
+		assert.EqualValues(t, code, req.Code)
+		resp := &descope.JWTResponse{
+			RefreshJwt: jwtTokenValid,
+			User: &descope.UserResponse{
+				User: descope.User{
+					Name: "name",
+				},
+			},
+			FirstSeen:   true,
+			IDPResponse: expectedIDPResponse,
+		}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	authInfo, err := a.SSO().ExchangeToken(context.Background(), code, w)
+	require.NoError(t, err)
+	require.NotNil(t, authInfo)
+	assert.EqualValues(t, "name", authInfo.User.Name)
+	assert.True(t, authInfo.FirstSeen)
+	require.NotNil(t, authInfo.IDPResponse)
+	assert.EqualValues(t, expectedIDPResponse.IDPGroups, authInfo.IDPResponse.IDPGroups)
+	assert.EqualValues(t, expectedIDPResponse.IDPSAMLAttributes, authInfo.IDPResponse.IDPSAMLAttributes)
+	assert.EqualValues(t, expectedIDPResponse.IDPOIDCClaims, authInfo.IDPResponse.IDPOIDCClaims)
+}
+
+func TestExchangeTokenSSOWithoutIDPResponse(t *testing.T) {
+	code := "code"
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		resp := &descope.JWTResponse{
+			RefreshJwt: jwtTokenValid,
+			User: &descope.UserResponse{
+				User: descope.User{
+					Name: "name",
+				},
+			},
+			FirstSeen: true,
+		}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	authInfo, err := a.SSO().ExchangeToken(context.Background(), code, w)
+	require.NoError(t, err)
+	require.NotNil(t, authInfo)
+	assert.Nil(t, authInfo.IDPResponse)
+}
+
+func TestExchangeTokenSSOWithPartialIDPResponse(t *testing.T) {
+	code := "code"
+	expectedIDPResponse := &descope.IDPResponse{
+		IDPGroups: []string{"admins"},
+	}
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		resp := &descope.JWTResponse{
+			RefreshJwt: jwtTokenValid,
+			User: &descope.UserResponse{
+				User: descope.User{
+					Name: "name",
+				},
+			},
+			FirstSeen:   true,
+			IDPResponse: expectedIDPResponse,
+		}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	authInfo, err := a.SSO().ExchangeToken(context.Background(), code, w)
+	require.NoError(t, err)
+	require.NotNil(t, authInfo)
+	require.NotNil(t, authInfo.IDPResponse)
+	assert.EqualValues(t, []string{"admins"}, authInfo.IDPResponse.IDPGroups)
+	assert.Nil(t, authInfo.IDPResponse.IDPSAMLAttributes)
+	assert.Nil(t, authInfo.IDPResponse.IDPOIDCClaims)
+}

--- a/descope/types.go
+++ b/descope/types.go
@@ -33,9 +33,9 @@ type AuthenticationInfo struct {
 
 // IDPResponse contains IDP groups, SAML attributes, and OIDC claims returned from SSO authentication.
 type IDPResponse struct {
-	IDPGroups         []string               `json:"idpGroups,omitempty"`
-	IDPSAMLAttributes map[string]interface{} `json:"idpSAMLAttributes,omitempty"`
-	IDPOIDCClaims     map[string]interface{} `json:"idpOIDCClaims,omitempty"`
+	IDPGroups         []string       `json:"idpGroups,omitempty"`
+	IDPSAMLAttributes map[string]any `json:"idpSAMLAttributes,omitempty"`
+	IDPOIDCClaims     map[string]any `json:"idpOIDCClaims,omitempty"`
 }
 
 type AnonymousAuthenticationInfo struct {

--- a/descope/types.go
+++ b/descope/types.go
@@ -28,6 +28,14 @@ type AuthenticationInfo struct {
 	RefreshToken *Token        `json:"refreshToken,omitempty"`
 	User         *UserResponse `json:"user,omitempty"`
 	FirstSeen    bool          `json:"firstSeen,omitempty"`
+	IDPResponse  *IDPResponse  `json:"idpResponse,omitempty"`
+}
+
+// IDPResponse contains IDP groups, SAML attributes, and OIDC claims returned from SSO authentication.
+type IDPResponse struct {
+	IDPGroups         []string               `json:"idpGroups,omitempty"`
+	IDPSAMLAttributes map[string]interface{} `json:"idpSAMLAttributes,omitempty"`
+	IDPOIDCClaims     map[string]interface{} `json:"idpOIDCClaims,omitempty"`
 }
 
 type AnonymousAuthenticationInfo struct {
@@ -398,6 +406,7 @@ type JWTResponse struct {
 	CookieExpiration int32         `json:"cookieExpiration,omitempty"`
 	User             *UserResponse `json:"user,omitempty"`
 	FirstSeen        bool          `json:"firstSeen,omitempty"`
+	IDPResponse      *IDPResponse  `json:"idpResponse,omitempty"`
 }
 
 type EnchantedLinkResponse struct {
@@ -420,6 +429,7 @@ func NewAuthenticationInfo(jRes *JWTResponse, sessionToken, refreshToken *Token)
 		RefreshToken: refreshToken,
 		User:         jRes.User,
 		FirstSeen:    jRes.FirstSeen,
+		IDPResponse:  jRes.IDPResponse,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `IDPResponse` type with `IDPGroups`, `IDPSAMLAttributes`, and `IDPOIDCClaims` fields
- Add `IDPResponse` field to `JWTResponse` and `AuthenticationInfo`
- Wire through in `NewAuthenticationInfo()` so SDK consumers can access IDP data after SSO token exchange

## Related PRs
- Backend: descope/descope — `feat/expose-idp-response-to-sdk`
- Node SDK: descope/node-sdk — `feat/wsfed-sso-application`

## Test plan
- [x] All existing Go SDK tests pass
- [x] New tests: `TestExchangeTokenSSOWithIDPResponse`, `TestExchangeTokenSSOWithoutIDPResponse`, `TestExchangeTokenSSOWithPartialIDPResponse`
- [x] New tests: `TestExchangeTokenSAMLWithIDPResponse`, `TestExchangeTokenOAuthWithIDPResponse`

fixes: https://github.com/descope/etc/issues/15153

🤖 Generated with [Claude Code](https://claude.com/claude-code)