### PR TITLE
feat: add UpdateWithID and DeleteWithID for roles and permissions

### DIFF
--- a/descope/internal/mgmt/permission.go
+++ b/descope/internal/mgmt/permission.go
@@ -43,11 +43,36 @@ func (p *permission) Update(ctx context.Context, name, newName, description stri
 	return err
 }
 
+func (p *permission) UpdateWithID(ctx context.Context, id, newName, description string) error {
+	if id == "" {
+		return utils.NewInvalidArgumentError("id")
+	}
+	if newName == "" {
+		return utils.NewInvalidArgumentError("newName")
+	}
+	body := map[string]any{
+		"id":          id,
+		"newName":     newName,
+		"description": description,
+	}
+	_, err := p.client.DoPostRequest(ctx, api.Routes.ManagementPermissionUpdate(), body, nil, "")
+	return err
+}
+
 func (p *permission) Delete(ctx context.Context, name string) error {
 	if name == "" {
 		return utils.NewInvalidArgumentError("name")
 	}
 	body := map[string]any{"name": name}
+	_, err := p.client.DoPostRequest(ctx, api.Routes.ManagementPermissionDelete(), body, nil, "")
+	return err
+}
+
+func (p *permission) DeleteWithID(ctx context.Context, id string) error {
+	if id == "" {
+		return utils.NewInvalidArgumentError("id")
+	}
+	body := map[string]any{"id": id}
 	_, err := p.client.DoPostRequest(ctx, api.Routes.ManagementPermissionDelete(), body, nil, "")
 	return err
 }

--- a/descope/internal/mgmt/permission_test.go
+++ b/descope/internal/mgmt/permission_test.go
@@ -48,6 +48,27 @@ func TestPermissionUpdateError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPermissionUpdateWithIDSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "PERM3D57zwRsVJhImuBMdlYSg88To4W0", req["id"])
+		require.Equal(t, "def", req["newName"])
+		require.Equal(t, "description", req["description"])
+		require.Nil(t, req["name"])
+	}))
+	err := mgmt.Permission().UpdateWithID(context.Background(), "PERM3D57zwRsVJhImuBMdlYSg88To4W0", "def", "description")
+	require.NoError(t, err)
+}
+
+func TestPermissionUpdateWithIDError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	err := mgmt.Permission().UpdateWithID(context.Background(), "", "def", "description")
+	require.Error(t, err)
+	err = mgmt.Permission().UpdateWithID(context.Background(), "PERM3D57zwRsVJhImuBMdlYSg88To4W0", "", "description")
+	require.Error(t, err)
+}
+
 func TestPermissionDeleteSuccess(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
@@ -65,9 +86,27 @@ func TestPermissionDeleteError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPermissionDeleteWithIDSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "PERM3D57zwRsVJhImuBMdlYSg88To4W0", req["id"])
+		require.Nil(t, req["name"])
+	}))
+	err := mgmt.Permission().DeleteWithID(context.Background(), "PERM3D57zwRsVJhImuBMdlYSg88To4W0")
+	require.NoError(t, err)
+}
+
+func TestPermissionDeleteWithIDError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	err := mgmt.Permission().DeleteWithID(context.Background(), "")
+	require.Error(t, err)
+}
+
 func TestPermissionLoadSuccess(t *testing.T) {
 	response := map[string]any{
 		"permissions": []map[string]any{{
+			"id":   "PERM3D57zwRsVJhImuBMdlYSg88To4W0",
 			"name": "abc",
 		}}}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
@@ -78,6 +117,7 @@ func TestPermissionLoadSuccess(t *testing.T) {
 	require.NotNil(t, res)
 	require.Len(t, res, 1)
 	require.Equal(t, "abc", res[0].Name)
+	require.Equal(t, "PERM3D57zwRsVJhImuBMdlYSg88To4W0", res[0].ID)
 }
 
 func TestPermissionLoadError(t *testing.T) {

--- a/descope/internal/mgmt/role.go
+++ b/descope/internal/mgmt/role.go
@@ -51,12 +51,44 @@ func (r *role) Update(ctx context.Context, name, tenantID, newName, description 
 	return err
 }
 
+func (r *role) UpdateWithID(ctx context.Context, id, tenantID, newName, description string, permissionNames []string, defaultRole bool, private bool) error {
+	if id == "" {
+		return utils.NewInvalidArgumentError("id")
+	}
+	if newName == "" {
+		return utils.NewInvalidArgumentError("newName")
+	}
+	body := map[string]any{
+		"id":              id,
+		"newName":         newName,
+		"description":     description,
+		"permissionNames": permissionNames,
+		"tenantId":        tenantID,
+		"default":         defaultRole,
+		"private":         private,
+	}
+	_, err := r.client.DoPostRequest(ctx, api.Routes.ManagementRoleUpdate(), body, nil, "")
+	return err
+}
+
 func (r *role) Delete(ctx context.Context, name, tenantID string) error {
 	if name == "" {
 		return utils.NewInvalidArgumentError("name")
 	}
 	body := map[string]any{
 		"name":     name,
+		"tenantId": tenantID,
+	}
+	_, err := r.client.DoPostRequest(ctx, api.Routes.ManagementRoleDelete(), body, nil, "")
+	return err
+}
+
+func (r *role) DeleteWithID(ctx context.Context, id, tenantID string) error {
+	if id == "" {
+		return utils.NewInvalidArgumentError("id")
+	}
+	body := map[string]any{
+		"id":       id,
 		"tenantId": tenantID,
 	}
 	_, err := r.client.DoPostRequest(ctx, api.Routes.ManagementRoleDelete(), body, nil, "")

--- a/descope/internal/mgmt/role_test.go
+++ b/descope/internal/mgmt/role_test.go
@@ -61,6 +61,30 @@ func TestRoleUpdateError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRoleUpdateWithIDSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "ROL3D57zwRsVJhImuBMdlYSg88To4W0", req["id"])
+		require.Equal(t, "def", req["newName"])
+		require.Equal(t, "description", req["description"])
+		require.Equal(t, "t1", req["tenantId"])
+		require.Equal(t, true, req["default"])
+		require.Equal(t, true, req["private"])
+		require.Nil(t, req["name"])
+	}))
+	err := mgmt.Role().UpdateWithID(context.Background(), "ROL3D57zwRsVJhImuBMdlYSg88To4W0", "t1", "def", "description", []string{"foo"}, true, true)
+	require.NoError(t, err)
+}
+
+func TestRoleUpdateWithIDError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	err := mgmt.Role().UpdateWithID(context.Background(), "", "t1", "def", "description", nil, false, false)
+	require.Error(t, err)
+	err = mgmt.Role().UpdateWithID(context.Background(), "ROL3D57zwRsVJhImuBMdlYSg88To4W0", "t1", "", "description", nil, false, false)
+	require.Error(t, err)
+}
+
 func TestRoleDeleteSuccess(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
@@ -79,9 +103,28 @@ func TestRoleDeleteError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRoleDeleteWithIDSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "ROL3D57zwRsVJhImuBMdlYSg88To4W0", req["id"])
+		require.Equal(t, "t1", req["tenantId"])
+		require.Nil(t, req["name"])
+	}))
+	err := mgmt.Role().DeleteWithID(context.Background(), "ROL3D57zwRsVJhImuBMdlYSg88To4W0", "t1")
+	require.NoError(t, err)
+}
+
+func TestRoleDeleteWithIDError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	err := mgmt.Role().DeleteWithID(context.Background(), "", "t1")
+	require.Error(t, err)
+}
+
 func TestRoleLoadSuccess(t *testing.T) {
 	response := map[string]any{
 		"roles": []map[string]any{{
+			"id":      "ROL3D57zwRsVJhImuBMdlYSg88To4W0",
 			"name":    "abc",
 			"default": true,
 		}}}
@@ -94,6 +137,7 @@ func TestRoleLoadSuccess(t *testing.T) {
 	require.Len(t, res, 1)
 	require.Equal(t, "abc", res[0].Name)
 	require.Equal(t, true, res[0].Default)
+	require.Equal(t, "ROL3D57zwRsVJhImuBMdlYSg88To4W0", res[0].ID)
 }
 
 func TestRoleLoadError(t *testing.T) {
@@ -134,4 +178,24 @@ func TestRoleSearchError(t *testing.T) {
 	res, err := mgmt.Role().Search(context.Background(), &descope.RoleSearchOptions{})
 	require.Error(t, err)
 	require.Nil(t, res)
+}
+
+func TestRoleSearchWithIDsSuccess(t *testing.T) {
+	response := map[string]any{
+		"roles": []map[string]any{{
+			"id":   "ROL3D57zwRsVJhImuBMdlYSg88To4W0",
+			"name": "abc",
+		}}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.ElementsMatch(t, []string{"ROL3D57zwRsVJhImuBMdlYSg88To4W0"}, req["roleIds"])
+	}, response))
+	res, err := mgmt.Role().Search(context.Background(), &descope.RoleSearchOptions{
+		RoleIDs: []string{"ROL3D57zwRsVJhImuBMdlYSg88To4W0"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res, 1)
+	require.Equal(t, "ROL3D57zwRsVJhImuBMdlYSg88To4W0", res[0].ID)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -703,10 +703,21 @@ type Permission interface {
 	// in the existing permission. Use carefully.
 	Update(ctx context.Context, name, newName, description string) error
 
+	// UpdateWithID updates an existing permission identified by its ID.
+	//
+	// IMPORTANT: All parameters will override whatever values are currently set
+	// in the existing permission. Use carefully.
+	UpdateWithID(ctx context.Context, id, newName, description string) error
+
 	// Delete an existing permission.
 	//
 	// IMPORTANT: This action is irreversible. Use carefully.
 	Delete(ctx context.Context, name string) error
+
+	// DeleteWithID deletes an existing permission identified by its ID.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	DeleteWithID(ctx context.Context, id string) error
 
 	// Load all permissions.
 	LoadAll(ctx context.Context) ([]*descope.Permission, error)
@@ -734,10 +745,21 @@ type Role interface {
 	// in the existing role. Use carefully.
 	Update(ctx context.Context, name, tenantID, newName, description string, permissionNames []string, defaultRole bool, private bool) error
 
+	// UpdateWithID updates an existing role identified by its ID.
+	//
+	// IMPORTANT: All parameters will override whatever values are currently set
+	// in the existing role. Use carefully.
+	UpdateWithID(ctx context.Context, id, tenantID, newName, description string, permissionNames []string, defaultRole bool, private bool) error
+
 	// Delete an existing role.
 	//
 	// IMPORTANT: This action is irreversible. Use carefully.
 	Delete(ctx context.Context, name, tenantID string) error
+
+	// DeleteWithID deletes an existing role identified by its ID.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	DeleteWithID(ctx context.Context, id, tenantID string) error
 
 	// Load all roles.
 	LoadAll(ctx context.Context) ([]*descope.Role, error)

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1255,8 +1255,14 @@ type MockPermission struct {
 	UpdateAssert func(name, newName, description string)
 	UpdateError  error
 
+	UpdateWithIDAssert func(id, newName, description string)
+	UpdateWithIDError  error
+
 	DeleteAssert func(name string)
 	DeleteError  error
+
+	DeleteWithIDAssert func(id string)
+	DeleteWithIDError  error
 
 	LoadAllResponse []*descope.Permission
 	LoadAllError    error
@@ -1276,11 +1282,25 @@ func (m *MockPermission) Update(_ context.Context, name, newName, description st
 	return m.UpdateError
 }
 
+func (m *MockPermission) UpdateWithID(_ context.Context, id, newName, description string) error {
+	if m.UpdateWithIDAssert != nil {
+		m.UpdateWithIDAssert(id, newName, description)
+	}
+	return m.UpdateWithIDError
+}
+
 func (m *MockPermission) Delete(_ context.Context, name string) error {
 	if m.DeleteAssert != nil {
 		m.DeleteAssert(name)
 	}
 	return m.DeleteError
+}
+
+func (m *MockPermission) DeleteWithID(_ context.Context, id string) error {
+	if m.DeleteWithIDAssert != nil {
+		m.DeleteWithIDAssert(id)
+	}
+	return m.DeleteWithIDError
 }
 
 func (m *MockPermission) LoadAll(_ context.Context) ([]*descope.Permission, error) {
@@ -1296,8 +1316,14 @@ type MockRole struct {
 	UpdateAssert func(name, tenantID, newName, description string, permissionNames []string, defaultRole bool, private bool)
 	UpdateError  error
 
+	UpdateWithIDAssert func(id, tenantID, newName, description string, permissionNames []string, defaultRole bool, private bool)
+	UpdateWithIDError  error
+
 	DeleteAssert func(name, tenantID string)
 	DeleteError  error
+
+	DeleteWithIDAssert func(id, tenantID string)
+	DeleteWithIDError  error
 
 	LoadAllResponse []*descope.Role
 	LoadAllError    error
@@ -1320,11 +1346,25 @@ func (m *MockRole) Update(_ context.Context, name, tenantID string, newName, des
 	return m.UpdateError
 }
 
+func (m *MockRole) UpdateWithID(_ context.Context, id, tenantID, newName, description string, permissionNames []string, defaultRole bool, private bool) error {
+	if m.UpdateWithIDAssert != nil {
+		m.UpdateWithIDAssert(id, tenantID, newName, description, permissionNames, defaultRole, private)
+	}
+	return m.UpdateWithIDError
+}
+
 func (m *MockRole) Delete(_ context.Context, name, tenantID string) error {
 	if m.DeleteAssert != nil {
 		m.DeleteAssert(name, tenantID)
 	}
 	return m.DeleteError
+}
+
+func (m *MockRole) DeleteWithID(_ context.Context, id, tenantID string) error {
+	if m.DeleteWithIDAssert != nil {
+		m.DeleteWithIDAssert(id, tenantID)
+	}
+	return m.DeleteWithIDError
 }
 
 func (m *MockRole) LoadAll(_ context.Context) ([]*descope.Role, error) {

--- a/descope/types.go
+++ b/descope/types.go
@@ -929,11 +929,13 @@ type SSOApplicationSearchOptions struct {
 }
 
 type Permission struct {
+	ID          string `json:"id,omitempty"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 }
 
 type Role struct {
+	ID              string   `json:"id,omitempty"`
 	Name            string   `json:"name"`
 	Description     string   `json:"description,omitempty"`
 	PermissionNames []string `json:"permissionNames,omitempty"`
@@ -952,6 +954,7 @@ type RoleSearchOptions struct {
 	RoleNames           []string `json:"roleNames,omitempty"`
 	RoleNameLike        string   `json:"roleNameLike,omitempty"`
 	PermissionNames     []string `json:"permissionNames,omitempty"`
+	RoleIDs             []string `json:"roleIds,omitempty"`
 	IncludeProjectRoles *bool    `json:"includeProjectRoles,omitempty"`
 }
 


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/15352

## Related PRs
### Upstream PRs
- https://github.com/descope/descope/pull/692

### Sibling PRs
- https://github.com/descope/python-sdk/pull/1456

### Downstream PRs
- https://github.com/descope/integrationtests/pull/13850

## Description
Adds `UpdateWithID` and `DeleteWithID` to both `Role` and `Permission` management interfaces in the Go SDK, enabling callers to identify resources by their stable IDs instead of mutable names. Also adds `RoleIDs` filter to `RoleSearchOptions`. Requested by 6sense, whose IDs are visible in the console UI but were not previously accessible via the SDK.

## Must
- [x] Tests
- [ ] Documentation (if applicable)