### PR TITLE
feat(fga): add DeleteAndCreateRelations to FGA interface and SDK

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -525,17 +525,17 @@ type mgmtEndpoints struct {
 	authzRETargetWithRelation string
 	authzGetModified          string
 
-	fgaSaveSchema              string
-	fgaSchemaDryRun            string
-	fgaLoadSchema              string
-	fgaCreateRelations              string
-	fgaDeleteRelations              string
-	fgaDeleteAndCreateRelations     string
-	fgaCheck                   string
-	fgaLoadMappableSchema      string
-	fgaSearchMappableResources string
-	fgaResourcesLoad           string
-	fgaResourcesSave           string
+	fgaSaveSchema               string
+	fgaSchemaDryRun             string
+	fgaLoadSchema               string
+	fgaCreateRelations          string
+	fgaDeleteRelations          string
+	fgaDeleteAndCreateRelations string
+	fgaCheck                    string
+	fgaLoadMappableSchema       string
+	fgaSearchMappableResources  string
+	fgaResourcesLoad            string
+	fgaResourcesSave            string
 
 	outboundApplicationCreate           string
 	outboundApplicationUpdate           string

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -234,6 +234,7 @@ var (
 			fgaLoadSchema:                            "mgmt/fga/schema",
 			fgaCreateRelations:                       "mgmt/fga/relations",
 			fgaDeleteRelations:                       "mgmt/fga/relations/delete",
+			fgaDeleteAndCreateRelations:              "mgmt/fga/relations/delete-and-create",
 			fgaCheck:                                 "mgmt/fga/check",
 			fgaLoadMappableSchema:                    "mgmt/fga/mappable/schema",
 			fgaSearchMappableResources:               "mgmt/fga/mappable/resources",
@@ -527,8 +528,9 @@ type mgmtEndpoints struct {
 	fgaSaveSchema              string
 	fgaSchemaDryRun            string
 	fgaLoadSchema              string
-	fgaCreateRelations         string
-	fgaDeleteRelations         string
+	fgaCreateRelations              string
+	fgaDeleteRelations              string
+	fgaDeleteAndCreateRelations     string
 	fgaCheck                   string
 	fgaLoadMappableSchema      string
 	fgaSearchMappableResources string
@@ -1393,6 +1395,10 @@ func (e *endpoints) ManagementFGACreateRelations() string {
 
 func (e *endpoints) ManagementFGADeleteRelations() string {
 	return path.Join(e.version, e.mgmt.fgaDeleteRelations)
+}
+
+func (e *endpoints) ManagementFGADeleteAndCreateRelations() string {
+	return path.Join(e.version, e.mgmt.fgaDeleteAndCreateRelations)
 }
 
 func (e *endpoints) ManagementFGALoadMappableSchema() string {

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -100,6 +100,22 @@ func (f *fga) DeleteRelations(ctx context.Context, relations []*descope.FGARelat
 	return err
 }
 
+func (f *fga) DeleteAndCreateRelations(ctx context.Context, deleteRelations, createRelations []*descope.FGARelation) error {
+	if len(deleteRelations) == 0 && len(createRelations) == 0 {
+		return utils.NewInvalidArgumentError("relations")
+	}
+
+	body := map[string]any{
+		"deleteTuples": deleteRelations,
+		"createTuples": createRelations,
+	}
+
+	options := &api.HTTPRequest{}
+	options.BaseURL = f.fgaCacheURL
+	_, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGADeleteAndCreateRelations(), body, options, "")
+	return err
+}
+
 type CheckResponseTuple struct {
 	Allowed bool                  `json:"allowed"`
 	Tuple   *descope.FGARelation  `json:"tuple"`

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -978,6 +978,9 @@ type FGA interface {
 	// DeleteRelations deletes relations for the project.
 	DeleteRelations(ctx context.Context, relations []*descope.FGARelation) error
 
+	// DeleteAndCreateRelations atomically deletes deleteRelations and creates createRelations in one server-side transaction.
+	DeleteAndCreateRelations(ctx context.Context, deleteRelations, createRelations []*descope.FGARelation) error
+
 	// Check checks if the given relations are satisfied. Conditions in the schema are evaluated
 	// against any attributes the backend already has on hand.
 	Check(ctx context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error)

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1812,6 +1812,9 @@ type MockFGA struct {
 	DeleteRelationsAssert func(relations []*descope.FGARelation)
 	DeleteRelationsError  error
 
+	DeleteAndCreateRelationsAssert func(deleteRelations, createRelations []*descope.FGARelation)
+	DeleteAndCreateRelationsError  error
+
 	CheckAssert   func(relations []*descope.FGARelation)
 	CheckResponse []*descope.FGACheck
 	CheckError    error
@@ -1866,6 +1869,13 @@ func (m *MockFGA) DeleteRelations(_ context.Context, relations []*descope.FGARel
 		m.DeleteRelationsAssert(relations)
 	}
 	return m.DeleteRelationsError
+}
+
+func (m *MockFGA) DeleteAndCreateRelations(_ context.Context, deleteRelations, createRelations []*descope.FGARelation) error {
+	if m.DeleteAndCreateRelationsAssert != nil {
+		m.DeleteAndCreateRelationsAssert(deleteRelations, createRelations)
+	}
+	return m.DeleteAndCreateRelationsError
 }
 
 func (m *MockFGA) Check(_ context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error) {


### PR DESCRIPTION
Adds atomic delete-and-create operation to the FGA management SDK, backed by a single HTTP POST to mgmt/fga/relations/delete-and-create.

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)
