### PR TITLE
feat: add CheckWithABAC and ABACContext for user-based ABAC

### DIFF
--- a/descope/authztypes.go
+++ b/descope/authztypes.go
@@ -110,12 +110,12 @@ type FGARelation struct {
 // ABACContext bundles all ABAC inputs for an FGA check. Future fields (session, tenant, request, ...)
 // can be added without breaking callers.
 type ABACContext struct {
-	DescopeContext *FGADescopeContext `json:"descopeContext,omitempty"`
+	DescopeContext *ABACDescopeContext `json:"descopeContext,omitempty"`
 	ExtraContext   map[string]any     `json:"context,omitempty"`
 }
 
-// FGADescopeContext holds Descope-resolved inputs for ABAC condition evaluation.
-type FGADescopeContext struct {
+// ABACDescopeContext holds Descope-resolved inputs for ABAC condition evaluation.
+type ABACDescopeContext struct {
 	UserIdentifier string `json:"userIdentifier,omitempty"`
 }
 

--- a/descope/authztypes.go
+++ b/descope/authztypes.go
@@ -111,7 +111,7 @@ type FGARelation struct {
 // can be added without breaking callers.
 type ABACContext struct {
 	DescopeContext *ABACDescopeContext `json:"descopeContext,omitempty"`
-	ExtraContext   map[string]any     `json:"context,omitempty"`
+	ExtraContext   map[string]any      `json:"context,omitempty"`
 }
 
 // ABACDescopeContext holds Descope-resolved inputs for ABAC condition evaluation.

--- a/descope/authztypes.go
+++ b/descope/authztypes.go
@@ -107,6 +107,18 @@ type FGARelation struct {
 	TargetType   string `json:"targetType"`
 }
 
+// ABACContext bundles all ABAC inputs for an FGA check. Future fields (session, tenant, request, ...)
+// can be added without breaking callers.
+type ABACContext struct {
+	DescopeContext *FGADescopeContext `json:"descopeContext,omitempty"`
+	ExtraContext   map[string]any     `json:"context,omitempty"`
+}
+
+// FGADescopeContext holds Descope-resolved inputs for ABAC condition evaluation.
+type FGADescopeContext struct {
+	UserIdentifier string `json:"userIdentifier,omitempty"`
+}
+
 // FGACheck holds the result of a check
 type FGACheck struct {
 	Allowed  bool          `json:"allowed"`

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -130,7 +130,7 @@ func (f *fga) CheckWithABAC(ctx context.Context, relations []*descope.FGARelatio
 	if abacContext != nil && len(abacContext.ExtraContext) > 0 {
 		body["context"] = abacContext.ExtraContext
 	}
-	sendDescopeContext := abacContext != nil && abacContext.DescopeContext != nil && abacContext.DescopeContext.UserIdentifier != ""
+	sendDescopeContext := abacContext != nil && abacContext.DescopeContext != nil
 	if sendDescopeContext {
 		body["descopeContext"] = abacContext.DescopeContext
 	}

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -134,18 +134,17 @@ func (f *fga) CheckWithABAC(ctx context.Context, relations []*descope.FGARelatio
 	body := map[string]any{
 		"tuples": relations,
 	}
-	if abacContext != nil {
-		if len(abacContext.ExtraContext) > 0 {
-			body["context"] = abacContext.ExtraContext
-		}
-		if abacContext.DescopeContext != nil && abacContext.DescopeContext.UserIdentifier != "" {
-			body["descopeContext"] = abacContext.DescopeContext
-		}
+	if abacContext != nil && len(abacContext.ExtraContext) > 0 {
+		body["context"] = abacContext.ExtraContext
+	}
+	sendDescopeContext := abacContext != nil && abacContext.DescopeContext != nil && abacContext.DescopeContext.UserIdentifier != ""
+	if sendDescopeContext {
+		body["descopeContext"] = abacContext.DescopeContext
 	}
 
 	options := &api.HTTPRequest{}
-	if abacContext == nil || abacContext.DescopeContext == nil {
-		// Bypass fgaCacheURL only when DescopeContext is set — see field comment for why.
+	if !sendDescopeContext {
+		// Use fgaCacheURL unless we are actually sending descopeContext — the proxy doesn't forward it.
 		options.BaseURL = f.fgaCacheURL
 	}
 	res, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACheck(), body, options, "")

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -12,6 +12,13 @@ import (
 
 type fga struct {
 	managementBase
+	// fgaCacheURL is the base URL of the authzcache proxy — a caching layer that
+	// sits in front of authzservice and speeds up relation checks. When set, most
+	// FGA write and check operations are routed through it. Operations that rely on
+	// authzservice-only features (e.g. CheckWithABAC with DescopeContext, which
+	// requires server-side user resolution) must bypass fgaCacheURL and hit
+	// authzservice directly, because the proxy does not forward the descopeContext
+	// field and therefore cannot evaluate UserExists() or similar builtins.
 	fgaCacheURL string
 }
 
@@ -111,10 +118,15 @@ type checkResponse struct {
 }
 
 func (f *fga) Check(ctx context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error) {
-	return f.CheckWithContext(ctx, relations, nil)
+	return f.CheckWithABAC(ctx, relations, nil)
 }
 
+// Deprecated: use CheckWithABAC.
 func (f *fga) CheckWithContext(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error) {
+	return f.CheckWithABAC(ctx, relations, &descope.ABACContext{ExtraContext: extraContext})
+}
+
+func (f *fga) CheckWithABAC(ctx context.Context, relations []*descope.FGARelation, abacContext *descope.ABACContext) ([]*descope.FGACheck, error) {
 	if len(relations) == 0 {
 		return nil, utils.NewInvalidArgumentError("relations")
 	}
@@ -122,12 +134,20 @@ func (f *fga) CheckWithContext(ctx context.Context, relations []*descope.FGARela
 	body := map[string]any{
 		"tuples": relations,
 	}
-	if len(extraContext) > 0 {
-		body["context"] = extraContext
+	if abacContext != nil {
+		if len(abacContext.ExtraContext) > 0 {
+			body["context"] = abacContext.ExtraContext
+		}
+		if abacContext.DescopeContext != nil && abacContext.DescopeContext.UserIdentifier != "" {
+			body["descopeContext"] = abacContext.DescopeContext
+		}
 	}
 
 	options := &api.HTTPRequest{}
-	options.BaseURL = f.fgaCacheURL
+	if abacContext == nil || abacContext.DescopeContext == nil {
+		// Bypass fgaCacheURL only when DescopeContext is set — see field comment for why.
+		options.BaseURL = f.fgaCacheURL
+	}
 	res, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACheck(), body, options, "")
 	if err != nil {
 		return nil, err

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -12,13 +12,6 @@ import (
 
 type fga struct {
 	managementBase
-	// fgaCacheURL is the base URL of the authzcache proxy — a caching layer that
-	// sits in front of authzservice and speeds up relation checks. When set, most
-	// FGA write and check operations are routed through it. Operations that rely on
-	// authzservice-only features (e.g. CheckWithABAC with DescopeContext, which
-	// requires server-side user resolution) must bypass fgaCacheURL and hit
-	// authzservice directly, because the proxy does not forward the descopeContext
-	// field and therefore cannot evaluate UserExists() or similar builtins.
 	fgaCacheURL string
 }
 

--- a/descope/internal/mgmt/fga.go
+++ b/descope/internal/mgmt/fga.go
@@ -130,16 +130,12 @@ func (f *fga) CheckWithABAC(ctx context.Context, relations []*descope.FGARelatio
 	if abacContext != nil && len(abacContext.ExtraContext) > 0 {
 		body["context"] = abacContext.ExtraContext
 	}
-	sendDescopeContext := abacContext != nil && abacContext.DescopeContext != nil
-	if sendDescopeContext {
+	if abacContext != nil && abacContext.DescopeContext != nil {
 		body["descopeContext"] = abacContext.DescopeContext
 	}
 
 	options := &api.HTTPRequest{}
-	if !sendDescopeContext {
-		// Use fgaCacheURL unless we are actually sending descopeContext — the proxy doesn't forward it.
-		options.BaseURL = f.fgaCacheURL
-	}
+	options.BaseURL = f.fgaCacheURL
 	res, err := f.client.DoPostRequest(ctx, api.Routes.ManagementFGACheck(), body, options, "")
 	if err != nil {
 		return nil, err

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -372,16 +372,16 @@ func TestCheckFGAWithABACNilContext(t *testing.T) {
 	require.Len(t, checks, 1)
 }
 
-func TestCheckFGAWithABACCacheBypass(t *testing.T) {
+func TestCheckFGAWithABACUsesCacheURL(t *testing.T) {
 	response := map[string]any{
 		"tuples": []*descope.FGACheck{
 			{Allowed: true, Relation: &descope.FGARelation{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
 		}}
 	rel := []*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}}
 
-	t.Run("with_descope_context_bypasses_cache_url", func(t *testing.T) {
+	t.Run("with_descope_context_uses_cache_url", func(t *testing.T) {
 		mgmt := newTestMgmtConf(&ManagementParams{FGACacheURL: "https://my.auth"}, nil, helpers.DoOkWithBody(func(r *http.Request) {
-			require.True(t, strings.HasPrefix(r.URL.String(), "https://api.descope.co"), "expected authzservice URL, got %s", r.URL.String())
+			require.True(t, strings.HasPrefix(r.URL.String(), "https://my.auth"), "expected fgaCacheURL, got %s", r.URL.String())
 		}, response))
 		_, err := mgmt.FGA().CheckWithABAC(context.Background(), rel,
 			&descope.ABACContext{DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"}})

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -296,6 +296,89 @@ func TestCheckFGAWithContextMissingTuples(t *testing.T) {
 	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
 }
 
+func TestCheckFGAWithABACBothContexts(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{
+				Allowed:  true,
+				Relation: &descope.FGARelation{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"},
+				Info:     &descope.FGACheckInfo{Conditional: true},
+			},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.NotNil(t, req["tuples"])
+		ctx, ok := req["context"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "admin", ctx["role"])
+		dc, ok := req["descopeContext"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "U2abc", dc["userIdentifier"])
+	}, response))
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
+		[]*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
+		&descope.ABACContext{
+			DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"},
+			ExtraContext:   map[string]any{"role": "admin"},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+	require.True(t, checks[0].Allowed)
+}
+
+func TestCheckFGAWithABACDescopeContextOnly(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{Allowed: true, Relation: &descope.FGARelation{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		_, hasContext := req["context"]
+		require.False(t, hasContext)
+		dc, ok := req["descopeContext"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "U2abc", dc["userIdentifier"])
+	}, response))
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
+		[]*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
+		&descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}},
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+	require.True(t, checks[0].Allowed)
+}
+
+func TestCheckFGAWithABACNilContext(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{Allowed: true, Relation: &descope.FGARelation{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		_, hasContext := req["context"]
+		require.False(t, hasContext)
+		_, hasDescopeContext := req["descopeContext"]
+		require.False(t, hasDescopeContext)
+	}, response))
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
+		[]*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+}
+
+func TestCheckFGAWithABACMissingTuples(t *testing.T) {
+	mgmt := newTestMgmt(nil, nil)
+	_, err := mgmt.FGA().CheckWithABAC(context.Background(), nil, &descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}})
+	require.Error(t, err)
+	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
+}
+
 func TestCheckFGAConditionalResult(t *testing.T) {
 	response := map[string]any{
 		"tuples": []*descope.FGACheck{

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -372,6 +372,31 @@ func TestCheckFGAWithABACNilContext(t *testing.T) {
 	require.Len(t, checks, 1)
 }
 
+func TestCheckFGAWithABACCacheBypass(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{Allowed: true, Relation: &descope.FGARelation{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
+		}}
+	rel := []*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}}
+
+	t.Run("with_descope_context_bypasses_cache_url", func(t *testing.T) {
+		mgmt := newTestMgmtConf(&ManagementParams{FGACacheURL: "https://my.auth"}, nil, helpers.DoOkWithBody(func(r *http.Request) {
+			require.True(t, strings.HasPrefix(r.URL.String(), "https://api.descope.co"), "expected authzservice URL, got %s", r.URL.String())
+		}, response))
+		_, err := mgmt.FGA().CheckWithABAC(context.Background(), rel,
+			&descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}})
+		require.NoError(t, err)
+	})
+
+	t.Run("without_descope_context_uses_cache_url", func(t *testing.T) {
+		mgmt := newTestMgmtConf(&ManagementParams{FGACacheURL: "https://my.auth"}, nil, helpers.DoOkWithBody(func(r *http.Request) {
+			require.True(t, strings.HasPrefix(r.URL.String(), "https://my.auth"), "expected fgaCacheURL, got %s", r.URL.String())
+		}, response))
+		_, err := mgmt.FGA().CheckWithABAC(context.Background(), rel, nil)
+		require.NoError(t, err)
+	})
+}
+
 func TestCheckFGAWithABACMissingTuples(t *testing.T) {
 	mgmt := newTestMgmt(nil, nil)
 	_, err := mgmt.FGA().CheckWithABAC(context.Background(), nil, &descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}})

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -216,6 +216,27 @@ func TestCheckFGARelationsMissingTuples(t *testing.T) {
 	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
 }
 
+func TestCheckFGAWithContextDeprecatedDelegates(t *testing.T) {
+	response := map[string]any{
+		"tuples": []*descope.FGACheck{
+			{Allowed: true, Relation: &descope.FGARelation{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		ctx, ok := req["context"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "v", ctx["k"])
+	}, response))
+	//nolint:staticcheck
+	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
+		map[string]any{"k": "v"},
+	)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+}
+
 func TestCheckFGAWithContextPassthrough(t *testing.T) {
 	response := map[string]any{
 		"tuples": []*descope.FGACheck{

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -393,31 +393,6 @@ func TestCheckFGAWithABACNilContext(t *testing.T) {
 	require.Len(t, checks, 1)
 }
 
-func TestCheckFGAWithABACUsesCacheURL(t *testing.T) {
-	response := map[string]any{
-		"tuples": []*descope.FGACheck{
-			{Allowed: true, Relation: &descope.FGARelation{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
-		}}
-	rel := []*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}}
-
-	t.Run("with_descope_context_uses_cache_url", func(t *testing.T) {
-		mgmt := newTestMgmtConf(&ManagementParams{FGACacheURL: "https://my.auth"}, nil, helpers.DoOkWithBody(func(r *http.Request) {
-			require.True(t, strings.HasPrefix(r.URL.String(), "https://my.auth"), "expected fgaCacheURL, got %s", r.URL.String())
-		}, response))
-		_, err := mgmt.FGA().CheckWithABAC(context.Background(), rel,
-			&descope.ABACContext{DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"}})
-		require.NoError(t, err)
-	})
-
-	t.Run("without_descope_context_uses_cache_url", func(t *testing.T) {
-		mgmt := newTestMgmtConf(&ManagementParams{FGACacheURL: "https://my.auth"}, nil, helpers.DoOkWithBody(func(r *http.Request) {
-			require.True(t, strings.HasPrefix(r.URL.String(), "https://my.auth"), "expected fgaCacheURL, got %s", r.URL.String())
-		}, response))
-		_, err := mgmt.FGA().CheckWithABAC(context.Background(), rel, nil)
-		require.NoError(t, err)
-	})
-}
-
 func TestCheckFGAWithABACMissingTuples(t *testing.T) {
 	mgmt := newTestMgmt(nil, nil)
 	_, err := mgmt.FGA().CheckWithABAC(context.Background(), nil, &descope.ABACContext{DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"}})

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -319,7 +319,7 @@ func TestCheckFGAWithABACBothContexts(t *testing.T) {
 	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
 		&descope.ABACContext{
-			DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"},
+			DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"},
 			ExtraContext:   map[string]any{"role": "admin"},
 		},
 	)
@@ -344,7 +344,7 @@ func TestCheckFGAWithABACDescopeContextOnly(t *testing.T) {
 	}, response))
 	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "doc1", ResourceType: "document", Relation: "viewer", Target: "U2abc", TargetType: "user"}},
-		&descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}},
+		&descope.ABACContext{DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"}},
 	)
 	require.NoError(t, err)
 	require.Len(t, checks, 1)
@@ -384,7 +384,7 @@ func TestCheckFGAWithABACCacheBypass(t *testing.T) {
 			require.True(t, strings.HasPrefix(r.URL.String(), "https://api.descope.co"), "expected authzservice URL, got %s", r.URL.String())
 		}, response))
 		_, err := mgmt.FGA().CheckWithABAC(context.Background(), rel,
-			&descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}})
+			&descope.ABACContext{DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"}})
 		require.NoError(t, err)
 	})
 
@@ -399,7 +399,7 @@ func TestCheckFGAWithABACCacheBypass(t *testing.T) {
 
 func TestCheckFGAWithABACMissingTuples(t *testing.T) {
 	mgmt := newTestMgmt(nil, nil)
-	_, err := mgmt.FGA().CheckWithABAC(context.Background(), nil, &descope.ABACContext{DescopeContext: &descope.FGADescopeContext{UserIdentifier: "U2abc"}})
+	_, err := mgmt.FGA().CheckWithABAC(context.Background(), nil, &descope.ABACContext{DescopeContext: &descope.ABACDescopeContext{UserIdentifier: "U2abc"}})
 	require.Error(t, err)
 	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
 }

--- a/descope/internal/mgmt/fga_test.go
+++ b/descope/internal/mgmt/fga_test.go
@@ -234,9 +234,9 @@ func TestCheckFGAWithContextPassthrough(t *testing.T) {
 		require.Equal(t, "1.2.3.4", ctx["ip"])
 		require.Equal(t, "admin", ctx["role"])
 	}, response))
-	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
-		map[string]any{"ip": "1.2.3.4", "role": "admin"},
+		&descope.ABACContext{ExtraContext: map[string]any{"ip": "1.2.3.4", "role": "admin"}},
 	)
 	require.NoError(t, err)
 	require.Len(t, checks, 1)
@@ -259,7 +259,7 @@ func TestCheckFGAWithContextNil(t *testing.T) {
 		_, hasContext := req["context"]
 		require.False(t, hasContext)
 	}, response))
-	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
 		nil,
 	)
@@ -281,9 +281,9 @@ func TestCheckFGAWithContextEmpty(t *testing.T) {
 		_, hasContext := req["context"]
 		require.False(t, hasContext)
 	}, response))
-	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
-		map[string]any{},
+		&descope.ABACContext{ExtraContext: map[string]any{}},
 	)
 	require.NoError(t, err)
 	require.Len(t, checks, 1)
@@ -291,7 +291,7 @@ func TestCheckFGAWithContextEmpty(t *testing.T) {
 
 func TestCheckFGAWithContextMissingTuples(t *testing.T) {
 	mgmt := newTestMgmt(nil, nil)
-	_, err := mgmt.FGA().CheckWithContext(context.Background(), nil, map[string]any{"k": "v"})
+	_, err := mgmt.FGA().CheckWithABAC(context.Background(), nil, &descope.ABACContext{ExtraContext: map[string]any{"k": "v"}})
 	require.Error(t, err)
 	require.ErrorContains(t, err, utils.NewInvalidArgumentError("relations").Message)
 }
@@ -414,9 +414,9 @@ func TestCheckFGAConditionalResult(t *testing.T) {
 			},
 		}}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(nil, response))
-	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
-		map[string]any{"ip": "1.2.3.4"},
+		&descope.ABACContext{ExtraContext: map[string]any{"ip": "1.2.3.4"}},
 	)
 	require.NoError(t, err)
 	require.Len(t, checks, 1)
@@ -435,7 +435,7 @@ func TestCheckFGAConditionalErr(t *testing.T) {
 			},
 		}}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(nil, response))
-	checks, err := mgmt.FGA().CheckWithContext(context.Background(),
+	checks, err := mgmt.FGA().CheckWithABAC(context.Background(),
 		[]*descope.FGARelation{{Resource: "g1", ResourceType: "group", Relation: "member", Target: "u1", TargetType: "user"}},
 		nil,
 	)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1005,8 +1005,8 @@ type FGA interface {
 	Check(ctx context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error)
 
 	// Deprecated: CheckWithContext only supports request-set context (the caller-supplied extraContext map)
-	// and cannot carry Descope-resolved context surfaces (e.g. descopeContext.userIdentifier) needed by
-	// builtins like UserExists. Use CheckWithABAC and pass an ABACContext, which supports both and is
+	// and cannot carry Descope-resolved context surfaces (e.g. descopeContext.userIdentifier)
+	// Use CheckWithABAC and pass an ABACContext, which supports both and is
 	// forward-compatible with future context surfaces.
 	CheckWithContext(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error)
 

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1004,11 +1004,17 @@ type FGA interface {
 	// against any attributes the backend already has on hand.
 	Check(ctx context.Context, relations []*descope.FGARelation) ([]*descope.FGACheck, error)
 
-	// CheckWithContext is like Check but additionally threads a caller-supplied context map to CEL
-	// conditions defined in the schema. Keys become available as context variables during evaluation
-	// (merged on top of any attributes the backend already has); values must be JSON-marshalable.
-	// Pass a nil or empty map if you do not need to supply any extra context.
+	// Deprecated: CheckWithContext only supports request-set context (the caller-supplied extraContext map)
+	// and cannot carry Descope-resolved context surfaces (e.g. descopeContext.userIdentifier) needed by
+	// builtins like UserExists. Use CheckWithABAC and pass an ABACContext, which supports both and is
+	// forward-compatible with future context surfaces.
 	CheckWithContext(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error)
+
+	// CheckWithABAC is like Check but accepts an ABACContext that can carry both a caller-supplied
+	// ExtraContext map (CEL condition variables) and a DescopeContext (Descope-resolved inputs such as
+	// userIdentifier for the UserExists builtin). Either field may be nil. Pass a nil ABACContext to
+	// behave identically to Check.
+	CheckWithABAC(ctx context.Context, relations []*descope.FGARelation, abacContext *descope.ABACContext) ([]*descope.FGACheck, error)
 
 	// LoadMappableSchema loads the mappable schema for the project (only listing the RDs for a Namespace), along with a list of mappable resources.
 	LoadMappableSchema(ctx context.Context, tenantID string, options *descope.FGAMappableResourcesOptions) (*descope.FGAMappableSchema, error)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1011,8 +1011,8 @@ type FGA interface {
 	CheckWithContext(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error)
 
 	// CheckWithABAC is like Check but accepts an ABACContext that can carry both a caller-supplied
-	// ExtraContext map (CEL condition variables) and a DescopeContext (Descope-resolved inputs such as
-	// userIdentifier for the UserExists builtin). Either field may be nil. Pass a nil ABACContext to
+	// ExtraContext map (constraint/condition variables) and a DescopeContext (Descope-resolved inputs such as
+	// userIdentifier). Either field may be nil. Pass a nil ABACContext to
 	// behave identically to Check.
 	CheckWithABAC(ctx context.Context, relations []*descope.FGARelation, abacContext *descope.ABACContext) ([]*descope.FGACheck, error)
 

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1860,6 +1860,10 @@ type MockFGA struct {
 	CheckWithContextResponse []*descope.FGACheck
 	CheckWithContextError    error
 
+	CheckWithABACAssert   func(relations []*descope.FGARelation, abacContext *descope.ABACContext)
+	CheckWithABACResponse []*descope.FGACheck
+	CheckWithABACError    error
+
 	LoadMappableSchemaAssert   func(tenantID string, options *descope.FGAMappableResourcesOptions)
 	LoadMappableSchemaResponse *descope.FGAMappableSchema
 	LoadMappableSchemaError    error
@@ -1920,6 +1924,13 @@ func (m *MockFGA) CheckWithContext(_ context.Context, relations []*descope.FGARe
 		m.CheckWithContextAssert(relations, extraContext)
 	}
 	return m.CheckWithContextResponse, m.CheckWithContextError
+}
+
+func (m *MockFGA) CheckWithABAC(_ context.Context, relations []*descope.FGARelation, abacContext *descope.ABACContext) ([]*descope.FGACheck, error) {
+	if m.CheckWithABACAssert != nil {
+		m.CheckWithABACAssert(relations, abacContext)
+	}
+	return m.CheckWithABACResponse, m.CheckWithABACError
 }
 
 func (m *MockFGA) LoadMappableSchema(_ context.Context, tenantID string, options *descope.FGAMappableResourcesOptions) (*descope.FGAMappableSchema, error) {


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/15693

## Related PRs
### Downstream PRs
- https://github.com/descope/integrationtests/pull/14016

## In a Nutshell
- Add `CheckWithABAC` + `ABACContext` / `ABACDescopeContext` types
- Deprecate `CheckWithContext` in favour of `CheckWithABAC`
- Migrate all test call sites off deprecated method; add coverage test for deprecated delegation

## Description
Adds `CheckWithABAC(ctx, relations, *ABACContext)` to the FGA interface. `ABACContext` wraps `DescopeContext` (carries `userIdentifier` for the `UserExists()` ABAC builtin) and `ExtraContext` (caller-supplied CEL variables) in a forward-compatible struct, allowing future context surfaces to be added without breaking callers. `descopeContext` is forwarded in the request body whenever `DescopeContext` is non-nil (nil-check only — no field-specific guard, for forward compatibility with new fields). The method always routes through `fgaCacheURL` if set, consistent with all other FGA operations.

## Must
- [x] Tests