### PR TITLE
feat(mgmt): add ReplyAllowedCallbacks to WS-Fed application request

### DIFF
--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -201,19 +201,20 @@ func makeCreateUpdateSAMLApplicationRequest(appRequest *descope.SAMLApplicationR
 
 func makeCreateUpdateWSFedApplicationRequest(appRequest *descope.WSFedApplicationRequest) map[string]any {
 	return map[string]any{
-		"id":                  appRequest.ID,
-		"name":                appRequest.Name,
-		"description":         appRequest.Description,
-		"enabled":             appRequest.Enabled,
-		"logo":                appRequest.Logo,
-		"loginPageUrl":        appRequest.LoginPageURL,
-		"realm":               appRequest.Realm,
-		"replyUrl":            appRequest.ReplyURL,
-		"attributeMapping":    appRequest.AttributeMapping,
-		"groupsMapping":       appRequest.GroupsMapping,
-		"forceAuthentication": appRequest.ForceAuthentication,
-		"logoutRedirectUrl":   appRequest.LogoutRedirectURL,
-		"errorRedirectUrl":    appRequest.ErrorRedirectURL,
+		"id":                    appRequest.ID,
+		"name":                  appRequest.Name,
+		"description":           appRequest.Description,
+		"enabled":               appRequest.Enabled,
+		"logo":                  appRequest.Logo,
+		"loginPageUrl":          appRequest.LoginPageURL,
+		"realm":                 appRequest.Realm,
+		"replyUrl":              appRequest.ReplyURL,
+		"replyAllowedCallbacks": appRequest.ReplyAllowedCallbacks,
+		"attributeMapping":      appRequest.AttributeMapping,
+		"groupsMapping":         appRequest.GroupsMapping,
+		"forceAuthentication":   appRequest.ForceAuthentication,
+		"logoutRedirectUrl":     appRequest.LogoutRedirectURL,
+		"errorRedirectUrl":      appRequest.ErrorRedirectURL,
 	}
 }
 

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -293,6 +293,7 @@ func TestSSOApplicationCreateWSFedApplicationSuccess(t *testing.T) {
 		require.Equal(t, "http://dummy.com/login", req["loginPageUrl"])
 		require.Equal(t, "urn:example:realm", req["realm"])
 		require.Equal(t, "http://dummy.com/reply", req["replyUrl"])
+		require.Equal(t, []any{"http://qa.example.com/reply", "http://*.staging.example.com/reply"}, req["replyAllowedCallbacks"])
 		require.Equal(t, []any{map[string]any{"name": "n1", "type": "t1", "value": "v1"}}, req["attributeMapping"])
 		require.Equal(t, []any{map[string]any{"filterType": "ft1", "name": "n1", "roles": []any{map[string]any{"id": "r1", "name": "rn1"}}, "type": "t1", "value": "v1"}}, req["groupsMapping"])
 		require.True(t, req["forceAuthentication"].(bool))
@@ -302,19 +303,20 @@ func TestSSOApplicationCreateWSFedApplicationSuccess(t *testing.T) {
 	}, response))
 
 	id, err := mgmt.SSOApplication().CreateWSFedApplication(context.Background(), &descope.WSFedApplicationRequest{
-		ID:                  "id1",
-		Name:                "abc",
-		Description:         "desc",
-		Enabled:             true,
-		Logo:                "logo",
-		LoginPageURL:        "http://dummy.com/login",
-		Realm:               "urn:example:realm",
-		ReplyURL:            "http://dummy.com/reply",
-		AttributeMapping:    []descope.SAMLIDPAttributeMappingInfo{{Name: "n1", Type: "t1", Value: "v1"}},
-		GroupsMapping:       []descope.SAMLIDPGroupsMappingInfo{{Name: "n1", Type: "t1", FilterType: "ft1", Value: "v1", Roles: []descope.SAMLIDPRoleGroupMappingInfo{{ID: "r1", Name: "rn1"}}}},
-		ForceAuthentication: true,
-		LogoutRedirectURL:   "http://dummy.com/logout",
-		ErrorRedirectURL:    "http://dummy.com/error",
+		ID:                    "id1",
+		Name:                  "abc",
+		Description:           "desc",
+		Enabled:               true,
+		Logo:                  "logo",
+		LoginPageURL:          "http://dummy.com/login",
+		Realm:                 "urn:example:realm",
+		ReplyURL:              "http://dummy.com/reply",
+		ReplyAllowedCallbacks: []string{"http://qa.example.com/reply", "http://*.staging.example.com/reply"},
+		AttributeMapping:      []descope.SAMLIDPAttributeMappingInfo{{Name: "n1", Type: "t1", Value: "v1"}},
+		GroupsMapping:         []descope.SAMLIDPGroupsMappingInfo{{Name: "n1", Type: "t1", FilterType: "ft1", Value: "v1", Roles: []descope.SAMLIDPRoleGroupMappingInfo{{ID: "r1", Name: "rn1"}}}},
+		ForceAuthentication:   true,
+		LogoutRedirectURL:     "http://dummy.com/logout",
+		ErrorRedirectURL:      "http://dummy.com/error",
 	})
 	require.NoError(t, err)
 	require.Equal(t, "qux", id)
@@ -349,6 +351,7 @@ func TestSSOApplicationUpdateWSFedApplicationSuccess(t *testing.T) {
 		require.Equal(t, "http://dummy.com/login", req["loginPageUrl"])
 		require.Equal(t, "urn:example:realm", req["realm"])
 		require.Equal(t, "http://dummy.com/reply", req["replyUrl"])
+		require.Equal(t, []any{"http://qa.example.com/reply", "http://*.staging.example.com/reply"}, req["replyAllowedCallbacks"])
 		require.Equal(t, []any{map[string]any{"name": "n1", "type": "t1", "value": "v1"}}, req["attributeMapping"])
 		require.Equal(t, []any{map[string]any{"filterType": "ft1", "name": "n1", "roles": []any{map[string]any{"id": "r1", "name": "rn1"}}, "type": "t1", "value": "v1"}}, req["groupsMapping"])
 		require.True(t, req["forceAuthentication"].(bool))
@@ -358,19 +361,20 @@ func TestSSOApplicationUpdateWSFedApplicationSuccess(t *testing.T) {
 	}, response))
 
 	err := mgmt.SSOApplication().UpdateWSFedApplication(context.Background(), &descope.WSFedApplicationRequest{
-		ID:                  "id1",
-		Name:                "abc",
-		Description:         "desc",
-		Enabled:             true,
-		Logo:                "logo",
-		LoginPageURL:        "http://dummy.com/login",
-		Realm:               "urn:example:realm",
-		ReplyURL:            "http://dummy.com/reply",
-		AttributeMapping:    []descope.SAMLIDPAttributeMappingInfo{{Name: "n1", Type: "t1", Value: "v1"}},
-		GroupsMapping:       []descope.SAMLIDPGroupsMappingInfo{{Name: "n1", Type: "t1", FilterType: "ft1", Value: "v1", Roles: []descope.SAMLIDPRoleGroupMappingInfo{{ID: "r1", Name: "rn1"}}}},
-		ForceAuthentication: true,
-		LogoutRedirectURL:   "http://dummy.com/logout",
-		ErrorRedirectURL:    "http://dummy.com/error",
+		ID:                    "id1",
+		Name:                  "abc",
+		Description:           "desc",
+		Enabled:               true,
+		Logo:                  "logo",
+		LoginPageURL:          "http://dummy.com/login",
+		Realm:                 "urn:example:realm",
+		ReplyURL:              "http://dummy.com/reply",
+		ReplyAllowedCallbacks: []string{"http://qa.example.com/reply", "http://*.staging.example.com/reply"},
+		AttributeMapping:      []descope.SAMLIDPAttributeMappingInfo{{Name: "n1", Type: "t1", Value: "v1"}},
+		GroupsMapping:         []descope.SAMLIDPGroupsMappingInfo{{Name: "n1", Type: "t1", FilterType: "ft1", Value: "v1", Roles: []descope.SAMLIDPRoleGroupMappingInfo{{ID: "r1", Name: "rn1"}}}},
+		ForceAuthentication:   true,
+		LogoutRedirectURL:     "http://dummy.com/logout",
+		ErrorRedirectURL:      "http://dummy.com/error",
 	})
 	require.NoError(t, err)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -141,7 +141,8 @@ type SSOApplication interface {
 	// Logo: Optional sso application logo.
 	// LoginPageURL: The URL where login page is hosted.
 	// Realm: The WS-Fed realm identifier.
-	// ReplyURL: The WS-Fed reply URL.
+	// ReplyURL: The default WS-Fed reply URL. Used for IdP-initiated flows and as the fallback when the RP doesn't supply a wreply.
+	// ReplyAllowedCallbacks: Optional list of additional allowed wreply URLs (supports * wildcards). Used in addition to ReplyURL when the RP supplies a wreply.
 	// AttributeMapping: Optional list of Descope (IdP) attributes to SP mapping.
 	// GroupsMapping: Optional list of Descope (IdP) roles that will be mapped to SP groups.
 	// ForceAuthentication: Optional determine if the IdP should force the user to re-authenticate.

--- a/descope/types.go
+++ b/descope/types.go
@@ -893,35 +893,37 @@ type SAMLApplicationRequest struct {
 }
 
 type WSFedApplicationRequest struct {
-	ID                  string                        `json:"id"`
-	Name                string                        `json:"name"`
-	Description         string                        `json:"description"`
-	Enabled             bool                          `json:"enabled"`
-	Logo                string                        `json:"logo"`
-	LoginPageURL        string                        `json:"loginPageUrl"`
-	Realm               string                        `json:"realm"`
-	ReplyURL            string                        `json:"replyUrl"`
-	AttributeMapping    []SAMLIDPAttributeMappingInfo `json:"attributeMapping"`
-	GroupsMapping       []SAMLIDPGroupsMappingInfo    `json:"groupsMapping"`
-	ForceAuthentication bool                          `json:"forceAuthentication"`
-	LogoutRedirectURL   string                        `json:"logoutRedirectUrl"`
-	ErrorRedirectURL    string                        `json:"errorRedirectUrl"`
+	ID                    string                        `json:"id"`
+	Name                  string                        `json:"name"`
+	Description           string                        `json:"description"`
+	Enabled               bool                          `json:"enabled"`
+	Logo                  string                        `json:"logo"`
+	LoginPageURL          string                        `json:"loginPageUrl"`
+	Realm                 string                        `json:"realm"`
+	ReplyURL              string                        `json:"replyUrl"`
+	ReplyAllowedCallbacks []string                      `json:"replyAllowedCallbacks"`
+	AttributeMapping      []SAMLIDPAttributeMappingInfo `json:"attributeMapping"`
+	GroupsMapping         []SAMLIDPGroupsMappingInfo    `json:"groupsMapping"`
+	ForceAuthentication   bool                          `json:"forceAuthentication"`
+	LogoutRedirectURL     string                        `json:"logoutRedirectUrl"`
+	ErrorRedirectURL      string                        `json:"errorRedirectUrl"`
 }
 
 type SSOApplicationWSFedSettings struct {
-	LoginPageURL        string                        `json:"loginPageUrl"`
-	Realm               string                        `json:"realm"`
-	ReplyURL            string                        `json:"replyUrl"`
-	AttributeMapping    []SAMLIDPAttributeMappingInfo `json:"attributeMapping"`
-	GroupsMapping       []SAMLIDPGroupsMappingInfo    `json:"groupsMapping"`
-	ForceAuthentication bool                          `json:"forceAuthentication"`
-	LogoutRedirectURL   string                        `json:"logoutRedirectUrl"`
-	ErrorRedirectURL    string                        `json:"errorRedirectUrl"`
-	IdpInitiatedURL     string                        `json:"idpInitiatedUrl"`
-	IdpMetadataURL      string                        `json:"idpMetadataUrl"`
-	IdpEntityID         string                        `json:"idpEntityId"`
-	IdpSSOURL           string                        `json:"idpSsoUrl"`
-	IdpCert             string                        `json:"idpCert"`
+	LoginPageURL          string                        `json:"loginPageUrl"`
+	Realm                 string                        `json:"realm"`
+	ReplyURL              string                        `json:"replyUrl"`
+	ReplyAllowedCallbacks []string                      `json:"replyAllowedCallbacks"`
+	AttributeMapping      []SAMLIDPAttributeMappingInfo `json:"attributeMapping"`
+	GroupsMapping         []SAMLIDPGroupsMappingInfo    `json:"groupsMapping"`
+	ForceAuthentication   bool                          `json:"forceAuthentication"`
+	LogoutRedirectURL     string                        `json:"logoutRedirectUrl"`
+	ErrorRedirectURL      string                        `json:"errorRedirectUrl"`
+	IdpInitiatedURL       string                        `json:"idpInitiatedUrl"`
+	IdpMetadataURL        string                        `json:"idpMetadataUrl"`
+	IdpEntityID           string                        `json:"idpEntityId"`
+	IdpSSOURL             string                        `json:"idpSsoUrl"`
+	IdpCert               string                        `json:"idpCert"`
 }
 
 type SSOApplicationSearchOptions struct {


### PR DESCRIPTION
## Summary
- Adds \`ReplyAllowedCallbacks []string\` to \`WSFedApplicationRequest\` and \`SSOApplicationWSFedSettings\`.
- Wires the field through \`makeCreateUpdateWSFedApplicationRequest\` so it's sent to the management API on create/update.
- Mirrors the existing SAML \`AcsAllowedCallbacks\` pattern. The default \`ReplyURL\` remains the primary; entries here are additional callback URLs (with \`*\` wildcard support) the RP may supply as \`wreply\`.

Pairs with [descope/backend#1002](https://github.com/descope/backend/pull/1002) and tracks [descope/etc#15707](https://github.com/descope/etc/issues/15707).

## Test plan
- [x] Existing WSFed marshal test extended to assert the new field shape.
- [x] Full \`go test ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)