### PR TITLE
feat: add SSO OIDC dedicated client config, secret get/rotate, and force-PKCE

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -108,6 +108,8 @@ var (
 			ssoApplicationDelete:                     "mgmt/sso/idp/app/delete",
 			ssoApplicationLoad:                       "mgmt/sso/idp/app/load",
 			ssoApplicationLoadAll:                    "mgmt/sso/idp/apps/load",
+			ssoApplicationSecret:                     "mgmt/sso/idp/app/secret",
+			ssoApplicationRotate:                     "mgmt/sso/idp/app/rotate",
 			userCreate:                               "mgmt/user/create",
 			testUserCreate:                           "mgmt/user/create/test",
 			userCreateBatch:                          "mgmt/user/create/batch",
@@ -386,6 +388,8 @@ type mgmtEndpoints struct {
 	ssoApplicationDelete      string
 	ssoApplicationLoad        string
 	ssoApplicationLoadAll     string
+	ssoApplicationSecret      string
+	ssoApplicationRotate      string
 
 	userCreate                string
 	testUserCreate            string
@@ -888,6 +892,14 @@ func (e *endpoints) ManagementSSOApplicationLoad() string {
 
 func (e *endpoints) ManagementSSOApplicationLoadAll() string {
 	return path.Join(e.version, e.mgmt.ssoApplicationLoadAll)
+}
+
+func (e *endpoints) ManagementSSOApplicationSecret() string {
+	return path.Join(e.version, e.mgmt.ssoApplicationSecret)
+}
+
+func (e *endpoints) ManagementSSOApplicationRotate() string {
+	return path.Join(e.version, e.mgmt.ssoApplicationRotate)
 }
 
 func (e *endpoints) ManagementUserCreate() string {

--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -178,6 +178,7 @@ func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationR
 		"refreshTokenDisabled":      appRequest.RefreshTokenDisabled,
 		"jwtBearerDisabled":         appRequest.JWTBearerDisabled,
 		"deviceCodeDisabled":        appRequest.DeviceCodeDisabled,
+		"forcePkce":                 appRequest.ForcePkce,
 	}
 }
 

--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -179,6 +179,7 @@ func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationR
 		"jwtBearerDisabled":         appRequest.JWTBearerDisabled,
 		"deviceCodeDisabled":        appRequest.DeviceCodeDisabled,
 		"forcePkce":                 appRequest.ForcePkce,
+		"defaultAudience":           appRequest.DefaultAudience,
 	}
 	// ClientID/ClientSecret import an existing OIDC client and are immutable after create, so
 	// they are only sent on create — never on update, where they would clear the stored secret.

--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -171,6 +171,8 @@ func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationR
 		"forceAuthentication":       appRequest.ForceAuthentication,
 		"jwtBearerSettings":         appRequest.JWTBearerSettings,
 		"backChannelLogoutUrl":      appRequest.BackChannelLogoutURL,
+		"clientId":                  appRequest.ClientID,
+		"clientSecret":              appRequest.ClientSecret,
 		"clientType":                appRequest.ClientType,
 		"approvedRedirectUrls":      appRequest.ApprovedRedirectURLs,
 		"authorizationCodeDisabled": appRequest.AuthorizationCodeDisabled,

--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -162,16 +162,61 @@ func (s *ssoApplication) LoadAll(ctx context.Context) ([]*descope.SSOApplication
 
 func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationRequest) map[string]any {
 	return map[string]any{
-		"id":                   appRequest.ID,
-		"name":                 appRequest.Name,
-		"description":          appRequest.Description,
-		"enabled":              appRequest.Enabled,
-		"logo":                 appRequest.Logo,
-		"loginPageUrl":         appRequest.LoginPageURL,
-		"forceAuthentication":  appRequest.ForceAuthentication,
-		"jwtBearerSettings":    appRequest.JWTBearerSettings,
-		"backChannelLogoutUrl": appRequest.BackChannelLogoutURL,
+		"id":                        appRequest.ID,
+		"name":                      appRequest.Name,
+		"description":               appRequest.Description,
+		"enabled":                   appRequest.Enabled,
+		"logo":                      appRequest.Logo,
+		"loginPageUrl":              appRequest.LoginPageURL,
+		"forceAuthentication":       appRequest.ForceAuthentication,
+		"jwtBearerSettings":         appRequest.JWTBearerSettings,
+		"backChannelLogoutUrl":      appRequest.BackChannelLogoutURL,
+		"clientType":                appRequest.ClientType,
+		"approvedRedirectUrls":      appRequest.ApprovedRedirectURLs,
+		"authorizationCodeDisabled": appRequest.AuthorizationCodeDisabled,
+		"clientCredentialsDisabled": appRequest.ClientCredentialsDisabled,
+		"refreshTokenDisabled":      appRequest.RefreshTokenDisabled,
+		"jwtBearerDisabled":         appRequest.JWTBearerDisabled,
+		"deviceCodeDisabled":        appRequest.DeviceCodeDisabled,
 	}
+}
+
+func (s *ssoApplication) GetApplicationSecret(ctx context.Context, id string) (string, error) {
+	if id == "" {
+		return "", utils.NewInvalidArgumentError("id")
+	}
+	req := &api.HTTPRequest{
+		QueryParams: map[string]string{"id": id},
+	}
+	httpRes, err := s.client.DoGetRequest(ctx, api.Routes.ManagementSSOApplicationSecret(), req, "")
+	if err != nil {
+		return "", err
+	}
+	res := struct {
+		Cleartext string `json:"cleartext"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return "", err
+	}
+	return res.Cleartext, nil
+}
+
+func (s *ssoApplication) RotateApplicationSecret(ctx context.Context, id string) (string, error) {
+	if id == "" {
+		return "", utils.NewInvalidArgumentError("id")
+	}
+	req := map[string]any{"id": id}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOApplicationRotate(), req, nil, "")
+	if err != nil {
+		return "", err
+	}
+	res := struct {
+		Cleartext string `json:"cleartext"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return "", err
+	}
+	return res.Cleartext, nil
 }
 
 func makeCreateUpdateSAMLApplicationRequest(appRequest *descope.SAMLApplicationRequest) map[string]any {

--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -23,7 +23,7 @@ func (s *ssoApplication) CreateOIDCApplication(ctx context.Context, appRequest *
 		return "", utils.NewInvalidArgumentError("appRequest.Name")
 	}
 
-	req := makeCreateUpdateOIDCApplicationRequest(appRequest)
+	req := makeCreateUpdateOIDCApplicationRequest(appRequest, true)
 	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOApplicationOIDCCreate(), req, nil, "")
 	if err != nil {
 		return "", err
@@ -70,7 +70,7 @@ func (s *ssoApplication) UpdateOIDCApplication(ctx context.Context, appRequest *
 		return utils.NewInvalidArgumentError("appRequest.Name")
 	}
 
-	req := makeCreateUpdateOIDCApplicationRequest(appRequest)
+	req := makeCreateUpdateOIDCApplicationRequest(appRequest, false)
 	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOApplicationOIDCUpdate(), req, nil, "")
 	return err
 }
@@ -160,8 +160,8 @@ func (s *ssoApplication) LoadAll(ctx context.Context) ([]*descope.SSOApplication
 	return unmarshalLoadAllSSOApplicationsResponse(res)
 }
 
-func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationRequest) map[string]any {
-	return map[string]any{
+func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationRequest, forCreate bool) map[string]any {
+	req := map[string]any{
 		"id":                        appRequest.ID,
 		"name":                      appRequest.Name,
 		"description":               appRequest.Description,
@@ -171,8 +171,6 @@ func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationR
 		"forceAuthentication":       appRequest.ForceAuthentication,
 		"jwtBearerSettings":         appRequest.JWTBearerSettings,
 		"backChannelLogoutUrl":      appRequest.BackChannelLogoutURL,
-		"clientId":                  appRequest.ClientID,
-		"clientSecret":              appRequest.ClientSecret,
 		"clientType":                appRequest.ClientType,
 		"approvedRedirectUrls":      appRequest.ApprovedRedirectURLs,
 		"authorizationCodeDisabled": appRequest.AuthorizationCodeDisabled,
@@ -182,6 +180,13 @@ func makeCreateUpdateOIDCApplicationRequest(appRequest *descope.OIDCApplicationR
 		"deviceCodeDisabled":        appRequest.DeviceCodeDisabled,
 		"forcePkce":                 appRequest.ForcePkce,
 	}
+	// ClientID/ClientSecret import an existing OIDC client and are immutable after create, so
+	// they are only sent on create — never on update, where they would clear the stored secret.
+	if forCreate {
+		req["clientId"] = appRequest.ClientID
+		req["clientSecret"] = appRequest.ClientSecret
+	}
+	return req
 }
 
 func (s *ssoApplication) GetApplicationSecret(ctx context.Context, id string) (string, error) {

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -668,6 +668,7 @@ func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing
 		require.Equal(t, false, req["authorizationCodeDisabled"])
 		require.Equal(t, true, req["deviceCodeDisabled"])
 		require.Equal(t, true, req["forcePkce"])
+		require.Equal(t, "clientId", req["defaultAudience"])
 		// A caller-imported client_id / client_secret must be forwarded in the create request.
 		require.Equal(t, "my-imported-client", req["clientId"])
 		require.Equal(t, "my-imported-secret", req["clientSecret"])
@@ -681,6 +682,7 @@ func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing
 		ClientCredentialsDisabled: true,
 		DeviceCodeDisabled:        true,
 		ForcePkce:                 true,
+		DefaultAudience:           "clientId",
 	})
 	require.NoError(t, err)
 	require.Equal(t, "qux", id)

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -667,9 +667,14 @@ func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing
 		require.Equal(t, true, req["clientCredentialsDisabled"])
 		require.Equal(t, false, req["authorizationCodeDisabled"])
 		require.Equal(t, true, req["deviceCodeDisabled"])
+		// A caller-imported client_id / client_secret must be forwarded in the create request.
+		require.Equal(t, "my-imported-client", req["clientId"])
+		require.Equal(t, "my-imported-secret", req["clientSecret"])
 	}, response))
 	id, err := mgmt.SSOApplication().CreateOIDCApplication(context.Background(), &descope.OIDCApplicationRequest{
 		Name:                      "abc",
+		ClientID:                  "my-imported-client",
+		ClientSecret:              "my-imported-secret",
 		ClientType:                "confidential",
 		ApprovedRedirectURLs:      []string{"https://app.example.com/cb"},
 		ClientCredentialsDisabled: true,

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -604,3 +604,77 @@ func TestAllSSOApplicationsLoadError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, res)
 }
+
+func TestSSOApplicationGetSecretSuccess(t *testing.T) {
+	response := map[string]any{"cleartext": "secret-123"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		require.Equal(t, "id1", r.URL.Query().Get("id"))
+	}, response))
+	res, err := mgmt.SSOApplication().GetApplicationSecret(context.Background(), "id1")
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", res)
+}
+
+func TestSSOApplicationGetSecretErrorEmpty(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	res, err := mgmt.SSOApplication().GetApplicationSecret(context.Background(), "")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestSSOApplicationGetSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	res, err := mgmt.SSOApplication().GetApplicationSecret(context.Background(), "test")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestSSOApplicationRotateSecretSuccess(t *testing.T) {
+	response := map[string]any{"cleartext": "rotated-456"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "id1", req["id"])
+	}, response))
+	res, err := mgmt.SSOApplication().RotateApplicationSecret(context.Background(), "id1")
+	require.NoError(t, err)
+	require.Equal(t, "rotated-456", res)
+}
+
+func TestSSOApplicationRotateSecretErrorEmpty(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	res, err := mgmt.SSOApplication().RotateApplicationSecret(context.Background(), "")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestSSOApplicationRotateSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	res, err := mgmt.SSOApplication().RotateApplicationSecret(context.Background(), "test")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing.T) {
+	response := map[string]any{"id": "qux"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "confidential", req["clientType"])
+		require.ElementsMatch(t, []any{"https://app.example.com/cb"}, req["approvedRedirectUrls"])
+		require.Equal(t, true, req["clientCredentialsDisabled"])
+		require.Equal(t, false, req["authorizationCodeDisabled"])
+		require.Equal(t, true, req["deviceCodeDisabled"])
+	}, response))
+	id, err := mgmt.SSOApplication().CreateOIDCApplication(context.Background(), &descope.OIDCApplicationRequest{
+		Name:                      "abc",
+		ClientType:                "confidential",
+		ApprovedRedirectURLs:      []string{"https://app.example.com/cb"},
+		ClientCredentialsDisabled: true,
+		DeviceCodeDisabled:        true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "qux", id)
+}

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -667,6 +667,7 @@ func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing
 		require.Equal(t, true, req["clientCredentialsDisabled"])
 		require.Equal(t, false, req["authorizationCodeDisabled"])
 		require.Equal(t, true, req["deviceCodeDisabled"])
+		require.Equal(t, true, req["forcePkce"])
 		// A caller-imported client_id / client_secret must be forwarded in the create request.
 		require.Equal(t, "my-imported-client", req["clientId"])
 		require.Equal(t, "my-imported-secret", req["clientSecret"])
@@ -679,7 +680,31 @@ func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing
 		ApprovedRedirectURLs:      []string{"https://app.example.com/cb"},
 		ClientCredentialsDisabled: true,
 		DeviceCodeDisabled:        true,
+		ForcePkce:                 true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "qux", id)
+}
+
+func TestSSOApplicationUpdateOIDCApplicationOmitsImmutableClientCredentials(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		// ClientID/ClientSecret are create-only and immutable afterward; an update must not send
+		// them — doing so would clear the stored secret on an otherwise unrelated update.
+		require.NotContains(t, req, "clientId")
+		require.NotContains(t, req, "clientSecret")
+		// Mutable config and policy fields are still forwarded on update.
+		require.Equal(t, true, req["forcePkce"])
+		require.Equal(t, "confidential", req["clientType"])
+	}, map[string]any{"id": "id1"}))
+	err := mgmt.SSOApplication().UpdateOIDCApplication(context.Background(), &descope.OIDCApplicationRequest{
+		ID:           "id1",
+		Name:         "abc",
+		ClientID:     "should-be-dropped",
+		ClientSecret: "should-be-dropped",
+		ClientType:   "confidential",
+		ForcePkce:    true,
+	})
+	require.NoError(t, err)
 }

--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -226,6 +226,7 @@ func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdParty
 		"attributesScopes":     appRequest.AttributesScopes,
 		"jwtBearerSettings":    appRequest.JWTBearerSettings,
 		"customAttributes":     appRequest.CustomAttributes,
+		"forcePkce":            appRequest.ForcePkce,
 	}
 }
 

--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -227,6 +227,7 @@ func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdParty
 		"jwtBearerSettings":    appRequest.JWTBearerSettings,
 		"customAttributes":     appRequest.CustomAttributes,
 		"forcePkce":            appRequest.ForcePkce,
+		"defaultAudience":      appRequest.DefaultAudience,
 	}
 }
 

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -31,6 +31,7 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		require.EqualValues(t, "RS256", d["issuer1"].(map[string]any)["signAlgorithm"])
 		require.EqualValues(t, "http://dummy.com/userinfo", d["issuer1"].(map[string]any)["userInfoUri"])
 		require.EqualValues(t, "sub", d["issuer1"].(map[string]any)["externalIdFieldName"])
+		require.Equal(t, true, req["forcePkce"])
 	}, response))
 
 	id, secret, err := mgmt.ThirdPartyApplication().CreateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
@@ -39,6 +40,7 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		Description:  "desc",
 		Logo:         "logo",
 		LoginPageURL: "http://dummy.com",
+		ForcePkce:    true,
 		JWTBearerSettings: &descope.JWTBearerSettings{
 			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -32,15 +32,17 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		require.EqualValues(t, "http://dummy.com/userinfo", d["issuer1"].(map[string]any)["userInfoUri"])
 		require.EqualValues(t, "sub", d["issuer1"].(map[string]any)["externalIdFieldName"])
 		require.Equal(t, true, req["forcePkce"])
+		require.Equal(t, "clientId", req["defaultAudience"])
 	}, response))
 
 	id, secret, err := mgmt.ThirdPartyApplication().CreateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
-		ID:           "id1",
-		Name:         "abc",
-		Description:  "desc",
-		Logo:         "logo",
-		LoginPageURL: "http://dummy.com",
-		ForcePkce:    true,
+		ID:              "id1",
+		Name:            "abc",
+		Description:     "desc",
+		Logo:            "logo",
+		LoginPageURL:    "http://dummy.com",
+		ForcePkce:       true,
+		DefaultAudience: "clientId",
 		JWTBearerSettings: &descope.JWTBearerSettings{
 			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -169,6 +169,13 @@ type SSOApplication interface {
 
 	// Load all project sso applications
 	LoadAll(ctx context.Context) ([]*descope.SSOApplication, error)
+
+	// Get the dedicated OIDC client secret of an SSO application by its id.
+	// Only relevant for OIDC apps configured with dedicated client credentials (ClientType "confidential").
+	GetApplicationSecret(ctx context.Context, id string) (string, error)
+
+	// Rotate the dedicated OIDC client secret of an SSO application by its id, returning the new cleartext secret.
+	RotateApplicationSecret(ctx context.Context, id string) (string, error)
 }
 
 // Provides functions for managing users in a project.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1184,6 +1184,13 @@ type MockSSOApplication struct {
 
 	LoadAllResponse []*descope.SSOApplication
 	LoadAllError    error
+
+	GetApplicationSecretAssert      func(id string)
+	GetApplicationSecretResponse    string
+	GetApplicationSecretError       error
+	RotateApplicationSecretAssert   func(id string)
+	RotateApplicationSecretResponse string
+	RotateApplicationSecretError    error
 }
 
 func (m *MockSSOApplication) CreateOIDCApplication(_ context.Context, appRequest *descope.OIDCApplicationRequest) (id string, err error) {
@@ -1244,6 +1251,20 @@ func (m *MockSSOApplication) Load(_ context.Context, id string) (*descope.SSOApp
 
 func (m *MockSSOApplication) LoadAll(_ context.Context) ([]*descope.SSOApplication, error) {
 	return m.LoadAllResponse, m.LoadAllError
+}
+
+func (m *MockSSOApplication) GetApplicationSecret(_ context.Context, id string) (string, error) {
+	if m.GetApplicationSecretAssert != nil {
+		m.GetApplicationSecretAssert(id)
+	}
+	return m.GetApplicationSecretResponse, m.GetApplicationSecretError
+}
+
+func (m *MockSSOApplication) RotateApplicationSecret(_ context.Context, id string) (string, error) {
+	if m.RotateApplicationSecretAssert != nil {
+		m.RotateApplicationSecretAssert(id)
+	}
+	return m.RotateApplicationSecretResponse, m.RotateApplicationSecretError
 }
 
 // Mock Permission

--- a/descope/types.go
+++ b/descope/types.go
@@ -1463,6 +1463,8 @@ type ThirdPartyApplication struct {
 	CustomAttributes     map[string]any                `json:"customAttributes,omitempty"`
 	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
 	ForcePkce bool `json:"forcePkce,omitempty"`
+	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
+	DefaultAudience string `json:"defaultAudience,omitempty"`
 }
 
 type ThirdPartyApplicationRequest struct {
@@ -1478,6 +1480,8 @@ type ThirdPartyApplicationRequest struct {
 	CustomAttributes     map[string]any                `json:"customAttributes,omitempty"`
 	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
 	ForcePkce bool `json:"forcePkce,omitempty"`
+	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
+	DefaultAudience string `json:"defaultAudience,omitempty"`
 }
 
 // Options for loading third party applications

--- a/descope/types.go
+++ b/descope/types.go
@@ -855,10 +855,10 @@ type SSOApplicationOIDCSettings struct {
 	ForceAuthentication  bool               `json:"forceAuthentication"`
 	JWTBearerSettings    *JWTBearerSettings `json:"jwtBearerSettings,omitempty"`
 	BackChannelLogoutURL string             `json:"backChannelLogoutUrl,omitempty"`
-	// Dedicated client credentials and per-app policy. ClientID is computed; ClientSecret is returned
-	// only on create/rotate responses (never on load). Empty values preserve legacy access-key behavior.
+	// Dedicated client credentials and per-app policy. ClientID is computed (populated on load).
+	// The client secret is obtained via GetApplicationSecret / RotateApplicationSecret, not this struct.
+	// Empty values preserve legacy access-key behavior.
 	ClientID                  string   `json:"clientId,omitempty"`
-	ClientSecret              string   `json:"clientSecret,omitempty"`
 	ClientType                string   `json:"clientType,omitempty"` // "", "confidential", or "public"
 	ApprovedRedirectURLs      []string `json:"approvedRedirectUrls,omitempty"`
 	AuthorizationCodeDisabled bool     `json:"authorizationCodeDisabled,omitempty"`

--- a/descope/types.go
+++ b/descope/types.go
@@ -893,7 +893,11 @@ type OIDCApplicationRequest struct {
 	JWTBearerSettings    *JWTBearerSettings `json:"jwtBearerSettings,omitempty"`
 	BackChannelLogoutURL string             `json:"backChannelLogoutUrl,omitempty"`
 	// Dedicated client credentials and per-app policy (all optional; empty preserves legacy behavior).
-	// The client secret is generated server-side (set ClientType to "confidential" to get one on create).
+	// ClientID / ClientSecret let you import an existing OIDC client on create only (immutable
+	// afterward): ClientID must be unique within the project; when empty the client_id is computed and
+	// the client_secret is generated server-side (fetch/rotate it via the application secret methods).
+	ClientID                  string   `json:"clientId,omitempty"`
+	ClientSecret              string   `json:"clientSecret,omitempty"`
 	ClientType                string   `json:"clientType,omitempty"`
 	ApprovedRedirectURLs      []string `json:"approvedRedirectUrls,omitempty"`
 	AuthorizationCodeDisabled bool     `json:"authorizationCodeDisabled,omitempty"`

--- a/descope/types.go
+++ b/descope/types.go
@@ -868,6 +868,9 @@ type SSOApplicationOIDCSettings struct {
 	DeviceCodeDisabled        bool     `json:"deviceCodeDisabled,omitempty"`
 	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
 	ForcePkce bool `json:"forcePkce,omitempty"`
+	// DefaultAudience controls the default aud of issued tokens for modern apps (non-empty ClientType):
+	// "projectId", "clientId", or "" (both). Legacy apps always use the project ID; empty preserves it.
+	DefaultAudience string `json:"defaultAudience,omitempty"`
 }
 
 type SSOApplication struct {
@@ -907,6 +910,9 @@ type OIDCApplicationRequest struct {
 	DeviceCodeDisabled        bool     `json:"deviceCodeDisabled,omitempty"`
 	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
 	ForcePkce bool `json:"forcePkce,omitempty"`
+	// DefaultAudience controls the default aud of issued tokens for modern apps (non-empty ClientType):
+	// "projectId", "clientId", or "" (both). Legacy apps always use the project ID; empty preserves it.
+	DefaultAudience string `json:"defaultAudience,omitempty"`
 }
 
 type SAMLApplicationRequest struct {

--- a/descope/types.go
+++ b/descope/types.go
@@ -866,6 +866,8 @@ type SSOApplicationOIDCSettings struct {
 	RefreshTokenDisabled      bool     `json:"refreshTokenDisabled,omitempty"`
 	JWTBearerDisabled         bool     `json:"jwtBearerDisabled,omitempty"`
 	DeviceCodeDisabled        bool     `json:"deviceCodeDisabled,omitempty"`
+	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
+	ForcePkce bool `json:"forcePkce,omitempty"`
 }
 
 type SSOApplication struct {
@@ -899,6 +901,8 @@ type OIDCApplicationRequest struct {
 	RefreshTokenDisabled      bool     `json:"refreshTokenDisabled,omitempty"`
 	JWTBearerDisabled         bool     `json:"jwtBearerDisabled,omitempty"`
 	DeviceCodeDisabled        bool     `json:"deviceCodeDisabled,omitempty"`
+	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
+	ForcePkce bool `json:"forcePkce,omitempty"`
 }
 
 type SAMLApplicationRequest struct {
@@ -1447,6 +1451,8 @@ type ThirdPartyApplication struct {
 	AttributesScopes     []*ThirdPartyApplicationScope `json:"attributesScopes"`
 	JWTBearerSettings    *JWTBearerSettings            `json:"jwtBearerSettings,omitempty"`
 	CustomAttributes     map[string]any                `json:"customAttributes,omitempty"`
+	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
+	ForcePkce bool `json:"forcePkce,omitempty"`
 }
 
 type ThirdPartyApplicationRequest struct {
@@ -1460,6 +1466,8 @@ type ThirdPartyApplicationRequest struct {
 	AttributesScopes     []*ThirdPartyApplicationScope `json:"attributesScopes"`
 	JWTBearerSettings    *JWTBearerSettings            `json:"jwtBearerSettings,omitempty"`
 	CustomAttributes     map[string]any                `json:"customAttributes,omitempty"`
+	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
+	ForcePkce bool `json:"forcePkce,omitempty"`
 }
 
 // Options for loading third party applications

--- a/descope/types.go
+++ b/descope/types.go
@@ -855,6 +855,17 @@ type SSOApplicationOIDCSettings struct {
 	ForceAuthentication  bool               `json:"forceAuthentication"`
 	JWTBearerSettings    *JWTBearerSettings `json:"jwtBearerSettings,omitempty"`
 	BackChannelLogoutURL string             `json:"backChannelLogoutUrl,omitempty"`
+	// Dedicated client credentials and per-app policy. ClientID is computed; ClientSecret is returned
+	// only on create/rotate responses (never on load). Empty values preserve legacy access-key behavior.
+	ClientID                  string   `json:"clientId,omitempty"`
+	ClientSecret              string   `json:"clientSecret,omitempty"`
+	ClientType                string   `json:"clientType,omitempty"` // "", "confidential", or "public"
+	ApprovedRedirectURLs      []string `json:"approvedRedirectUrls,omitempty"`
+	AuthorizationCodeDisabled bool     `json:"authorizationCodeDisabled,omitempty"`
+	ClientCredentialsDisabled bool     `json:"clientCredentialsDisabled,omitempty"`
+	RefreshTokenDisabled      bool     `json:"refreshTokenDisabled,omitempty"`
+	JWTBearerDisabled         bool     `json:"jwtBearerDisabled,omitempty"`
+	DeviceCodeDisabled        bool     `json:"deviceCodeDisabled,omitempty"`
 }
 
 type SSOApplication struct {
@@ -879,6 +890,15 @@ type OIDCApplicationRequest struct {
 	ForceAuthentication  bool               `json:"forceAuthentication"`
 	JWTBearerSettings    *JWTBearerSettings `json:"jwtBearerSettings,omitempty"`
 	BackChannelLogoutURL string             `json:"backChannelLogoutUrl,omitempty"`
+	// Dedicated client credentials and per-app policy (all optional; empty preserves legacy behavior).
+	// The client secret is generated server-side (set ClientType to "confidential" to get one on create).
+	ClientType                string   `json:"clientType,omitempty"`
+	ApprovedRedirectURLs      []string `json:"approvedRedirectUrls,omitempty"`
+	AuthorizationCodeDisabled bool     `json:"authorizationCodeDisabled,omitempty"`
+	ClientCredentialsDisabled bool     `json:"clientCredentialsDisabled,omitempty"`
+	RefreshTokenDisabled      bool     `json:"refreshTokenDisabled,omitempty"`
+	JWTBearerDisabled         bool     `json:"jwtBearerDisabled,omitempty"`
+	DeviceCodeDisabled        bool     `json:"deviceCodeDisabled,omitempty"`
 }
 
 type SAMLApplicationRequest struct {


### PR DESCRIPTION
## Summary

Adds management-API support for the new **dedicated-client configuration** on SSO OIDC applications, mirroring inbound (third-party) apps.

### `OIDCApplicationRequest` (new optional fields, backward compatible)
- `ClientType` (`""` | `confidential` | `public`)
- `ApprovedRedirectURLs`
- grant-type disable flags: `AuthorizationCodeDisabled`, `ClientCredentialsDisabled`, `RefreshTokenDisabled`, `JWTBearerDisabled`, `DeviceCodeDisabled`

### `SSOApplicationOIDCSettings` (response)
- `ClientID`, `ClientSecret` (secret returned only on create/rotate), `ClientType`, `ApprovedRedirectURLs`, grant-type flags

### New methods on the `SSOApplication` management interface
- `GetApplicationSecret(ctx, id)` → `GET mgmt/sso/idp/app/secret`
- `RotateApplicationSecret(ctx, id)` → `POST mgmt/sso/idp/app/rotate`

Mirrors the existing third-party-app SDK surface. Mock + tests included; existing SSO tests unchanged.

Backend: descope/backend#1119 · Tracking: descope/etc#15957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Force PKCE (descope/etc#15694)

Adds `ForcePkce` (default `false`) to `SSOApplicationOIDCSettings`, `OIDCApplicationRequest`, `ThirdPartyApplication` and `ThirdPartyApplicationRequest`, and wires it into the create/update request bodies (these are built as explicit maps, so the field is added there too). When enabled, the authorization-code flow requires PKCE in addition to client authentication.

Resolves descope/etc#15694.