### PR TITLE
feat(sso): add IdP entityId to ConfigureSAMLSettingsByMetadata

### DIFF
--- a/descope/internal/mgmt/sso.go
+++ b/descope/internal/mgmt/sso.go
@@ -136,6 +136,7 @@ func (s *sso) ConfigureSAMLSettingsByMetadata(ctx context.Context, tenantID stri
 		"tenantId": tenantID,
 		"settings": map[string]any{
 			"idpMetadataUrl":   settings.IdpMetadataURL,
+			"entityId":         settings.IdpEntityID,
 			"roleMappings":     mappings,
 			"attributeMapping": settings.AttributeMapping,
 			"spACSUrl":         settings.SpACSUrl,

--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -966,6 +966,7 @@ func TestSSOConfigureSAMLSettingsError(t *testing.T) {
 func TestSSOConfigureSAMLSettingsByMetadataSuccess(t *testing.T) {
 	settings := &descope.SSOSAMLSettingsByMetadata{
 		IdpMetadataURL: "http://idpURL",
+		IdpEntityID:    "https://idp.example.com/entity",
 		AttributeMapping: &descope.AttributeMapping{
 			GivenName: "myGivenName",
 			CustomAttributes: map[string]string{
@@ -1011,6 +1012,7 @@ func TestSSOConfigureSAMLSettingsByMetadataSuccess(t *testing.T) {
 		sett, ok := settings.(map[string]any)
 		require.True(t, ok)
 		require.Equal(t, "http://idpURL", sett["idpMetadataUrl"])
+		require.Equal(t, "https://idp.example.com/entity", sett["entityId"])
 
 		require.Equal(t, "https://spacsurl.com", sett["spACSUrl"])
 		require.Equal(t, "spentityid", sett["spEntityId"])

--- a/descope/types.go
+++ b/descope/types.go
@@ -170,6 +170,7 @@ type SSOSAMLSettings struct {
 
 type SSOSAMLSettingsByMetadata struct {
 	IdpMetadataURL                  string                      `json:"idpMetadataUrl,omitempty"`
+	IdpEntityID                     string                      `json:"entityId,omitempty"` // IdP entity ID - set so IdP-initiated login can resolve the tenant by the SAML response issuer
 	AttributeMapping                *AttributeMapping           `json:"attributeMapping,omitempty"`
 	RoleMappings                    []*RoleMapping              `json:"roleMappings,omitempty"`
 	DefaultSSORoles                 []string                    `json:"defaultSSORoles,omitempty"` // roles names


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/16175

## Description

Adds an optional `IdpEntityID` field to `SSOSAMLSettingsByMetadata`, sent as `entityId` in the request to `ConfigureSAMLSettingsByMetadata`.

This lets callers persist the IdP entity ID alongside a metadata URL so **IdP-initiated SAML login can resolve the tenant by the SAML response issuer**. Without it, metadata-configured tenants had no stored entity ID and the issuer lookup failed (reported by Navan during SSO migration).

Backend PR: descope/backend#1280

## Must
- [x] Tests
- [x] Documentation (if applicable)