### PR TITLE
feat(tenant): bind a real user to GenerateSSOConfigurationLink for correct audit actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,12 +907,9 @@ err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(),
 // Generate tenant admin self service link for SSO Suite (valid for 24 hours)
 // sso id can be provided for a specific sso configuration
 // email can be provided to send the link to (email's templateID can be provided as well)
-link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "")
-
-// Optionally set an actor id, recorded as the audit actor for actions taken inside the SSO
-// Suite (instead of the temporary user). It is used as-is for audit attribution and is not validated.
-link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "",
-	&descope.GenerateSSOConfigurationLinkOptions{ActorID: "my-admin-actor-id"})
+// actor id is optional; when set it is recorded as the audit actor for actions taken inside the
+// SSO Suite (instead of the temporary user). It is used as-is for audit attribution and is not validated.
+link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "", "my-admin-actor-id")
 
 // Revoke tenant admin self service link for SSO Suite
 // sso id can be provided for a specific sso configuration

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(),
 // Generate tenant admin self service link for SSO Suite (valid for 24 hours)
 // sso id can be provided for a specific sso configuration
 // email can be provided to send the link to (email's templateID can be provided as well)
-link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "")
+link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "", "")
 
 // Optionally pass an actor id as the last argument. When set it is recorded as the audit actor
 // for actions taken inside the SSO Suite (instead of the temporary user). It is used as-is for

--- a/README.md
+++ b/README.md
@@ -907,8 +907,11 @@ err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(),
 // Generate tenant admin self service link for SSO Suite (valid for 24 hours)
 // sso id can be provided for a specific sso configuration
 // email can be provided to send the link to (email's templateID can be provided as well)
-// actor id is optional; when set it is recorded as the audit actor for actions taken inside the
-// SSO Suite (instead of the temporary user). It is used as-is for audit attribution and is not validated.
+link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "")
+
+// Optionally pass an actor id as the last argument. When set it is recorded as the audit actor
+// for actions taken inside the SSO Suite (instead of the temporary user). It is used as-is for
+// audit attribution and is not validated.
 link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "", "my-admin-actor-id")
 
 // Revoke tenant admin self service link for SSO Suite

--- a/README.md
+++ b/README.md
@@ -909,6 +909,12 @@ err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(),
 // email can be provided to send the link to (email's templateID can be provided as well)
 link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "")
 
+// Optionally bind the link to a real user (by UserID or LoginID) so actions taken inside the
+// SSO Suite are audited against that user instead of a temporary one. The user must exist and
+// belong to the tenant; UserID takes precedence over LoginID.
+link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "",
+	&descope.GenerateSSOConfigurationLinkOptions{LoginID: "admin@my-tenant.com"})
+
 // Revoke tenant admin self service link for SSO Suite
 // sso id can be provided for a specific sso configuration
 err := descopeClient.Management.Tenant().RevokeSSOConfigurationLink(context.Background(), "My Tenant", "")

--- a/README.md
+++ b/README.md
@@ -909,11 +909,10 @@ err := descopeClient.Management.Tenant().ConfigureSettings(context.Background(),
 // email can be provided to send the link to (email's templateID can be provided as well)
 link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "")
 
-// Optionally bind the link to a real user (by UserID or LoginID) so actions taken inside the
-// SSO Suite are audited against that user instead of a temporary one. The user must exist and
-// belong to the tenant; UserID takes precedence over LoginID.
+// Optionally set an actor id, recorded as the audit actor for actions taken inside the SSO
+// Suite (instead of the temporary user). It is used as-is for audit attribution and is not validated.
 link, err := descopeClient.Management.Tenant().GenerateSSOConfigurationLink(context.Background(), "My Tenant", 60 * 60 * 24, "", "", "",
-	&descope.GenerateSSOConfigurationLinkOptions{LoginID: "admin@my-tenant.com"})
+	&descope.GenerateSSOConfigurationLinkOptions{ActorID: "my-admin-actor-id"})
 
 // Revoke tenant admin self service link for SSO Suite
 // sso id can be provided for a specific sso configuration

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -147,7 +147,7 @@ func (t *tenant) ConfigureSettings(ctx context.Context, tenantID string, setting
 	return err
 }
 
-func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error) {
+func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error) {
 	if tenantID == "" {
 		return "", utils.NewInvalidArgumentError("tenantID")
 	}
@@ -158,9 +158,7 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 		"ssoId":      ssoID,
 		"email":      email,
 		"templateId": templateID,
-	}
-	if len(options) > 0 && options[0] != nil {
-		req["actorId"] = options[0].ActorID
+		"actorId":    actorID,
 	}
 
 	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementTenantGenerateSSOConfigurationLink(), req, nil, "")

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -147,7 +147,7 @@ func (t *tenant) ConfigureSettings(ctx context.Context, tenantID string, setting
 	return err
 }
 
-func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string) (string, error) {
+func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error) {
 	if tenantID == "" {
 		return "", utils.NewInvalidArgumentError("tenantID")
 	}
@@ -158,6 +158,10 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 		"ssoId":      ssoID,
 		"email":      email,
 		"templateId": templateID,
+	}
+	if len(options) > 0 && options[0] != nil {
+		req["userId"] = options[0].UserID
+		req["loginId"] = options[0].LoginID
 	}
 
 	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementTenantGenerateSSOConfigurationLink(), req, nil, "")

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -160,8 +160,7 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 		"templateId": templateID,
 	}
 	if len(options) > 0 && options[0] != nil {
-		req["userId"] = options[0].UserID
-		req["loginId"] = options[0].LoginID
+		req["actorId"] = options[0].ActorID
 	}
 
 	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementTenantGenerateSSOConfigurationLink(), req, nil, "")

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -147,7 +147,7 @@ func (t *tenant) ConfigureSettings(ctx context.Context, tenantID string, setting
 	return err
 }
 
-func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string) (string, error) {
+func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error) {
 	if tenantID == "" {
 		return "", utils.NewInvalidArgumentError("tenantID")
 	}
@@ -158,9 +158,7 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 		"ssoId":      ssoID,
 		"email":      email,
 		"templateId": templateID,
-	}
-	if len(actorID) > 0 && actorID[0] != "" {
-		req["actorId"] = actorID[0]
+		"actorId":    actorID,
 	}
 
 	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementTenantGenerateSSOConfigurationLink(), req, nil, "")

--- a/descope/internal/mgmt/tenant.go
+++ b/descope/internal/mgmt/tenant.go
@@ -147,7 +147,7 @@ func (t *tenant) ConfigureSettings(ctx context.Context, tenantID string, setting
 	return err
 }
 
-func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error) {
+func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string) (string, error) {
 	if tenantID == "" {
 		return "", utils.NewInvalidArgumentError("tenantID")
 	}
@@ -158,7 +158,9 @@ func (t *tenant) GenerateSSOConfigurationLink(ctx context.Context, tenantID stri
 		"ssoId":      ssoID,
 		"email":      email,
 		"templateId": templateID,
-		"actorId":    actorID,
+	}
+	if len(actorID) > 0 && actorID[0] != "" {
+		req["actorId"] = actorID[0]
 	}
 
 	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementTenantGenerateSSOConfigurationLink(), req, nil, "")

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -348,11 +348,10 @@ func TestTenantGenerateSSOConfigurationLinkWithActor(t *testing.T) {
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "tenant", req["tenantId"])
-		require.Equal(t, "user-1", req["userId"])
-		require.Equal(t, "admin@a.com", req["loginId"])
+		require.Equal(t, "admin-actor-1", req["actorId"])
 	}, response))
 	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "",
-		&descope.GenerateSSOConfigurationLinkOptions{UserID: "user-1", LoginID: "admin@a.com"})
+		&descope.GenerateSSOConfigurationLinkOptions{ActorID: "admin-actor-1"})
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -316,7 +316,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccess(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -335,7 +335,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccessWithSSOID(t *testing.T) {
 		require.Equal(t, "a@a.com", req["email"])
 		require.Equal(t, "template-id", req["templateId"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id", "")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -350,8 +350,7 @@ func TestTenantGenerateSSOConfigurationLinkWithActor(t *testing.T) {
 		require.Equal(t, "tenant", req["tenantId"])
 		require.Equal(t, "admin-actor-1", req["actorId"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "",
-		&descope.GenerateSSOConfigurationLinkOptions{ActorID: "admin-actor-1"})
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "admin-actor-1")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -365,7 +364,7 @@ func TestTenantGenerateSSOConfigurationLinkError(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "")
 	require.Error(t, err)
 	assert.Empty(t, link)
 }
@@ -379,7 +378,7 @@ func TestTenantGenerateSSOConfigurationLinkNoTenantID(t *testing.T) {
 		require.Equal(t, "ssoId", "")
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "", "")
 	require.ErrorIs(t, err, utils.NewInvalidArgumentError("tenantId"))
 	assert.Empty(t, link)
 }

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -316,7 +316,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccess(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -335,7 +335,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccessWithSSOID(t *testing.T) {
 		require.Equal(t, "a@a.com", req["email"])
 		require.Equal(t, "template-id", req["templateId"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id", "")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -364,7 +364,7 @@ func TestTenantGenerateSSOConfigurationLinkError(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "")
 	require.Error(t, err)
 	assert.Empty(t, link)
 }
@@ -378,7 +378,7 @@ func TestTenantGenerateSSOConfigurationLinkNoTenantID(t *testing.T) {
 		require.Equal(t, "ssoId", "")
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "", "")
 	require.ErrorIs(t, err, utils.NewInvalidArgumentError("tenantId"))
 	assert.Empty(t, link)
 }

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -316,7 +316,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccess(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -335,7 +335,7 @@ func TestTenantGenerateSSOConfigurationLinkSuccessWithSSOID(t *testing.T) {
 		require.Equal(t, "a@a.com", req["email"])
 		require.Equal(t, "template-id", req["templateId"])
 	}, response))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "bla", "a@a.com", "template-id")
 	require.NoError(t, err)
 	assert.EqualValues(t, "some link", link)
 }
@@ -364,7 +364,7 @@ func TestTenantGenerateSSOConfigurationLinkError(t *testing.T) {
 		require.Equal(t, "", req["ssoId"])
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "")
 	require.Error(t, err)
 	assert.Empty(t, link)
 }
@@ -378,7 +378,7 @@ func TestTenantGenerateSSOConfigurationLinkNoTenantID(t *testing.T) {
 		require.Equal(t, "ssoId", "")
 		require.Equal(t, float64(60*60*24), req["expireTime"])
 	}))
-	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "", "")
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "", 60*60*24, "", "", "")
 	require.ErrorIs(t, err, utils.NewInvalidArgumentError("tenantId"))
 	assert.Empty(t, link)
 }

--- a/descope/internal/mgmt/tenant_test.go
+++ b/descope/internal/mgmt/tenant_test.go
@@ -340,6 +340,23 @@ func TestTenantGenerateSSOConfigurationLinkSuccessWithSSOID(t *testing.T) {
 	assert.EqualValues(t, "some link", link)
 }
 
+func TestTenantGenerateSSOConfigurationLinkWithActor(t *testing.T) {
+	response := map[string]any{
+		"adminSSOConfigurationLink": "some link",
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "tenant", req["tenantId"])
+		require.Equal(t, "user-1", req["userId"])
+		require.Equal(t, "admin@a.com", req["loginId"])
+	}, response))
+	link, err := mgmt.Tenant().GenerateSSOConfigurationLink(context.Background(), "tenant", 60*60*24, "", "", "",
+		&descope.GenerateSSOConfigurationLinkOptions{UserID: "user-1", LoginID: "admin@a.com"})
+	require.NoError(t, err)
+	assert.EqualValues(t, "some link", link)
+}
+
 func TestTenantGenerateSSOConfigurationLinkError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoBadRequest(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -63,10 +63,10 @@ type Tenant interface {
 	// ssoID - Optional, in case provided, the specified sso configuration will be used
 	// email - Optional, in case provided, email will be sent according to the given email
 	// templateID - Optional, in case provided, the specified email's template will be used
-	// actorID - Optional, in case provided, that id is recorded as the audit actor for actions
-	//           performed inside the SSO Setup Suite (instead of the temporary user). It is used
-	//           as-is for audit attribution and is not validated.
-	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string) (string, error)
+	// actorID - Optional (pass "" for none). When provided, that id is recorded as the audit
+	//           actor for actions performed inside the SSO Setup Suite (instead of the temporary
+	//           user). It is used as-is for audit attribution and is not validated.
+	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error)
 
 	// Revoke tenant admin self service SSO configuration link
 	// ssoID - Optional, in case provided, the specified sso configuration will be used

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -63,10 +63,10 @@ type Tenant interface {
 	// ssoID - Optional, in case provided, the specified sso configuration will be used
 	// email - Optional, in case provided, email will be sent according to the given email
 	// templateID - Optional, in case provided, the specified email's template will be used
-	// options - Optional, in case provided with an ActorID, that id is recorded as the audit
-	//           actor for actions performed inside the SSO Setup Suite (instead of the temporary
-	//           user). It is used as-is for audit attribution and is not validated.
-	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error)
+	// actorID - Optional, in case provided, that id is recorded as the audit actor for actions
+	//           performed inside the SSO Setup Suite (instead of the temporary user). It is used
+	//           as-is for audit attribution and is not validated.
+	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error)
 
 	// Revoke tenant admin self service SSO configuration link
 	// ssoID - Optional, in case provided, the specified sso configuration will be used

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -63,9 +63,9 @@ type Tenant interface {
 	// ssoID - Optional, in case provided, the specified sso configuration will be used
 	// email - Optional, in case provided, email will be sent according to the given email
 	// templateID - Optional, in case provided, the specified email's template will be used
-	// options - Optional, in case provided with a user (UserID or LoginID), the SSO Setup Suite
-	//           session is attributed to that real user so actions are audited against them
-	//           instead of a temporary user. The user must exist and belong to the tenant.
+	// options - Optional, in case provided with an ActorID, that id is recorded as the audit
+	//           actor for actions performed inside the SSO Setup Suite (instead of the temporary
+	//           user). It is used as-is for audit attribution and is not validated.
 	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error)
 
 	// Revoke tenant admin self service SSO configuration link

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -66,7 +66,7 @@ type Tenant interface {
 	// actorID - Optional, in case provided, that id is recorded as the audit actor for actions
 	//           performed inside the SSO Setup Suite (instead of the temporary user). It is used
 	//           as-is for audit attribution and is not validated.
-	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error)
+	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string) (string, error)
 
 	// Revoke tenant admin self service SSO configuration link
 	// ssoID - Optional, in case provided, the specified sso configuration will be used

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -63,7 +63,10 @@ type Tenant interface {
 	// ssoID - Optional, in case provided, the specified sso configuration will be used
 	// email - Optional, in case provided, email will be sent according to the given email
 	// templateID - Optional, in case provided, the specified email's template will be used
-	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string) (string, error)
+	// options - Optional, in case provided with a user (UserID or LoginID), the SSO Setup Suite
+	//           session is attributed to that real user so actions are audited against them
+	//           instead of a temporary user. The user must exist and belong to the tenant.
+	GenerateSSOConfigurationLink(ctx context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error)
 
 	// Revoke tenant admin self service SSO configuration link
 	// ssoID - Optional, in case provided, the specified sso configuration will be used

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1109,7 +1109,7 @@ type MockTenant struct {
 	ConfigureSettingsResponse *descope.TenantSettings
 	ConfigureSettingsError    error
 
-	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string)
+	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string)
 	GenerateSSOConfigurationLinkResponse string
 	GenerateSSOConfigurationLinkError    error
 
@@ -1177,9 +1177,9 @@ func (m *MockTenant) ConfigureSettings(_ context.Context, tenantID string, setti
 	return m.ConfigureSettingsError
 }
 
-func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string) (string, error) {
+func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error) {
 	if m.GenerateSSOConfigurationLinkAssert != nil {
-		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, actorID...)
+		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, actorID)
 	}
 	return m.GenerateSSOConfigurationLinkResponse, m.GenerateSSOConfigurationLinkError
 }

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1109,7 +1109,7 @@ type MockTenant struct {
 	ConfigureSettingsResponse *descope.TenantSettings
 	ConfigureSettingsError    error
 
-	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions)
+	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string)
 	GenerateSSOConfigurationLinkResponse string
 	GenerateSSOConfigurationLinkError    error
 
@@ -1177,9 +1177,9 @@ func (m *MockTenant) ConfigureSettings(_ context.Context, tenantID string, setti
 	return m.ConfigureSettingsError
 }
 
-func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error) {
+func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error) {
 	if m.GenerateSSOConfigurationLinkAssert != nil {
-		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, options...)
+		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, actorID)
 	}
 	return m.GenerateSSOConfigurationLinkResponse, m.GenerateSSOConfigurationLinkError
 }

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1109,7 +1109,7 @@ type MockTenant struct {
 	ConfigureSettingsResponse *descope.TenantSettings
 	ConfigureSettingsError    error
 
-	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string)
+	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions)
 	GenerateSSOConfigurationLinkResponse string
 	GenerateSSOConfigurationLinkError    error
 
@@ -1177,9 +1177,9 @@ func (m *MockTenant) ConfigureSettings(_ context.Context, tenantID string, setti
 	return m.ConfigureSettingsError
 }
 
-func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string) (string, error) {
+func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, options ...*descope.GenerateSSOConfigurationLinkOptions) (string, error) {
 	if m.GenerateSSOConfigurationLinkAssert != nil {
-		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID)
+		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, options...)
 	}
 	return m.GenerateSSOConfigurationLinkResponse, m.GenerateSSOConfigurationLinkError
 }

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1109,7 +1109,7 @@ type MockTenant struct {
 	ConfigureSettingsResponse *descope.TenantSettings
 	ConfigureSettingsError    error
 
-	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string)
+	GenerateSSOConfigurationLinkAssert   func(tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string)
 	GenerateSSOConfigurationLinkResponse string
 	GenerateSSOConfigurationLinkError    error
 
@@ -1177,9 +1177,9 @@ func (m *MockTenant) ConfigureSettings(_ context.Context, tenantID string, setti
 	return m.ConfigureSettingsError
 }
 
-func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID string) (string, error) {
+func (m *MockTenant) GenerateSSOConfigurationLink(_ context.Context, tenantID string, expireDuration int64, ssoID string, email string, templateID string, actorID ...string) (string, error) {
 	if m.GenerateSSOConfigurationLinkAssert != nil {
-		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, actorID)
+		m.GenerateSSOConfigurationLinkAssert(tenantID, expireDuration, ssoID, email, templateID, actorID...)
 	}
 	return m.GenerateSSOConfigurationLinkResponse, m.GenerateSSOConfigurationLinkError
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -235,14 +235,6 @@ type GenerateSSOConfigurationLinkResponse struct {
 	AdminSSOConfigurationLink string `json:"adminSSOConfigurationLink,omitempty"`
 }
 
-// GenerateSSOConfigurationLinkOptions are optional settings for GenerateSSOConfigurationLink.
-// When ActorID is provided, it is recorded as the audit actor for actions performed inside the
-// SSO Setup Suite (instead of the temporary user). It is used as-is for audit attribution and
-// is not validated against existing users.
-type GenerateSSOConfigurationLinkOptions struct {
-	ActorID string `json:"actorId,omitempty"`
-}
-
 type RecalculateSSOMappingsRequest struct {
 	TenantID string `json:"tenantId,omitempty"`
 	SSOID    string `json:"ssoId,omitempty"`

--- a/descope/types.go
+++ b/descope/types.go
@@ -235,6 +235,15 @@ type GenerateSSOConfigurationLinkResponse struct {
 	AdminSSOConfigurationLink string `json:"adminSSOConfigurationLink,omitempty"`
 }
 
+// GenerateSSOConfigurationLinkOptions are optional settings for GenerateSSOConfigurationLink.
+// When a user is provided, the SSO Setup Suite session is attributed to that real user so
+// actions taken inside the suite are audited against them instead of a temporary user.
+// The user must exist and belong to the tenant. UserID takes precedence over LoginID.
+type GenerateSSOConfigurationLinkOptions struct {
+	UserID  string `json:"userId,omitempty"`
+	LoginID string `json:"loginId,omitempty"`
+}
+
 type RecalculateSSOMappingsRequest struct {
 	TenantID string `json:"tenantId,omitempty"`
 	SSOID    string `json:"ssoId,omitempty"`

--- a/descope/types.go
+++ b/descope/types.go
@@ -236,12 +236,11 @@ type GenerateSSOConfigurationLinkResponse struct {
 }
 
 // GenerateSSOConfigurationLinkOptions are optional settings for GenerateSSOConfigurationLink.
-// When a user is provided, the SSO Setup Suite session is attributed to that real user so
-// actions taken inside the suite are audited against them instead of a temporary user.
-// The user must exist and belong to the tenant. UserID takes precedence over LoginID.
+// When ActorID is provided, it is recorded as the audit actor for actions performed inside the
+// SSO Setup Suite (instead of the temporary user). It is used as-is for audit attribution and
+// is not validated against existing users.
 type GenerateSSOConfigurationLinkOptions struct {
-	UserID  string `json:"userId,omitempty"`
-	LoginID string `json:"loginId,omitempty"`
+	ActorID string `json:"actorId,omitempty"`
 }
 
 type RecalculateSSOMappingsRequest struct {


### PR DESCRIPTION
## Description
Adds an optional, backward-compatible way to attribute SSO Setup Suite actions to a real user.

`Management.Tenant().GenerateSSOConfigurationLink` now accepts a variadic `*GenerateSSOConfigurationLinkOptions{ UserID, LoginID }`. When provided, the generated suite session is bound to that real user (who must exist and belong to the tenant) so actions performed inside the SSO Setup Suite are audited against them instead of the temporary user. `UserID` takes precedence over `LoginID`; omitting the option preserves existing behavior.

Pairs with the backend change: descope/backend#1335 (resolves descope/etc#16281).

## Changes
- New `descope.GenerateSSOConfigurationLinkOptions` type.
- `GenerateSSOConfigurationLink` impl, `sdk.Tenant` interface, and mgmt mock updated (variadic options; existing callers compile unchanged).
- Sends `userId`/`loginId` in the request body.
- README + unit test.