### PR TITLE
feat(otp): add MFA option to OTP update phone/email

### DIFF
--- a/descope/internal/auth/otp_test.go
+++ b/descope/internal/auth/otp_test.go
@@ -540,6 +540,54 @@ func TestUpdateEmailOTP(t *testing.T) {
 	require.EqualValues(t, maskedEmail, me)
 }
 
+func TestUpdateEmailOTPWithMFA(t *testing.T) {
+	loginID := "943248329844"
+	email := "test@test.com"
+	maskedEmail := "t***@test.com"
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		assert.EqualValues(t, composeUpdateUserEmailOTP(), r.URL.RequestURI())
+		body, err := readBodyMap(r)
+		require.NoError(t, err)
+		assert.EqualValues(t, loginID, body["loginId"])
+		assert.EqualValues(t, email, body["email"])
+		assert.EqualValues(t, true, body["mfa"])
+		resp := MaskedEmailRes{MaskedEmail: maskedEmail}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	r := &http.Request{Header: http.Header{}}
+	r.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtTokenValid})
+	me, err := a.OTP().UpdateUserEmail(context.Background(), loginID, email, &descope.UpdateOptions{MFA: true}, r)
+	require.NoError(t, err)
+	require.EqualValues(t, maskedEmail, me)
+}
+
+func TestUpdatePhoneOTPWithMFA(t *testing.T) {
+	loginID := "943248329844"
+	phone := "+111111111111"
+	maskedPhone := "+*******111"
+	a, err := newTestAuth(nil, func(r *http.Request) (*http.Response, error) {
+		assert.EqualValues(t, composeUpdateUserPhoneOTP(descope.MethodSMS), r.URL.RequestURI())
+		body, err := readBodyMap(r)
+		require.NoError(t, err)
+		assert.EqualValues(t, loginID, body["loginId"])
+		assert.EqualValues(t, phone, body["phone"])
+		assert.EqualValues(t, true, body["mfa"])
+		resp := MaskedPhoneRes{MaskedPhone: maskedPhone}
+		respBytes, err := utils.Marshal(resp)
+		require.NoError(t, err)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBuffer(respBytes))}, nil
+	})
+	require.NoError(t, err)
+	r := &http.Request{Header: http.Header{}}
+	r.AddCookie(&http.Cookie{Name: descope.RefreshCookieName, Value: jwtTokenValid})
+	mp, err := a.OTP().UpdateUserPhone(context.Background(), descope.MethodSMS, loginID, phone, &descope.UpdateOptions{MFA: true}, r)
+	require.NoError(t, err)
+	require.EqualValues(t, maskedPhone, mp)
+}
+
 func TestUpdateEmailOTPWithTemplateOptions(t *testing.T) {
 	loginID := "943248329844"
 	email := "test@test.com"

--- a/descope/types.go
+++ b/descope/types.go
@@ -690,6 +690,11 @@ type UpdateOptions struct {
 	TemplateOptions    map[string]string `json:"templateOptions,omitempty"` // for providing messaging template options (templates that are being sent via email / text message)
 	TemplateID         string            `json:"templateId,omitempty"`
 	ProviderID         string            `json:"providerId,omitempty"`
+	// MFA, when true, preserves the auth methods already on the refresh token and adds the
+	// updated factor to them (so the resulting amr keeps the previously-passed factors)
+	// instead of replacing it with a single factor. Requires a valid refresh token on the
+	// request. Currently applies to the OTP update phone / email flows.
+	MFA bool `json:"mfa,omitempty"`
 }
 
 type NOTPTemplates struct {


### PR DESCRIPTION
## What

Adds an `MFA` flag to `UpdateOptions`, used by the OTP **update phone / email** flows (`OTP().UpdateUserPhone` / `OTP().UpdateUserEmail`).

```go
_, err := descopeClient.Auth.OTP().UpdateUserPhone(ctx, descope.MethodSMS, loginID, phone,
    &descope.UpdateOptions{MFA: true}, request)
```

## Why

When an already-authenticated user enrolls or updates a phone/email via the OTP update flow, the verification mints a fresh **single-factor** session token, dropping the auth methods already on the refresh token (e.g. `pwd`). This forced a double-confirmation UX (one round to enroll the factor, a second `mfa` sign-in just to re-grab a token with a correct merged `amr`).

With `MFA: true` (and a valid refresh token on the request), the resulting session token preserves the prior factors and adds the updated one, e.g. `['pwd', 'phone', 'mfa']`.

Reported by PerciHealth (descope/etc#16372). Pairs with the backend change adding `mfa` to `UpdateUserPhoneOTPRequest` / `UpdateUserEmailOTPRequest`.

## Notes

- `MFA` is `omitempty` and defaults to `false`, so existing callers are unaffected.
- The field rides the existing inline `*UpdateOptions` in the OTP update request bodies — no transport changes.
- It currently takes effect on the OTP update flows only (matching backend support).

## Test

`TestUpdatePhoneOTPWithMFA` / `TestUpdateEmailOTPWithMFA` assert the request body carries `mfa: true`. Full `internal/auth` package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)