### PR TITLE
feat(http): also retry on transient status code 520

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -1661,6 +1661,7 @@ type IHttpClient interface {
 // retryableStatusCodes are HTTP status codes that should trigger an automatic retry
 var retryableStatusCodes = map[int]bool{
 	503: true, // Service Unavailable
+	520: true, // Web Server Returned an Unknown Error (Cloudflare)
 	521: true, // Web Server Is Down (Cloudflare)
 	522: true, // Connection Timed Out (Cloudflare)
 	524: true, // A Timeout Occurred (Cloudflare)

--- a/descope/api/client_test.go
+++ b/descope/api/client_test.go
@@ -600,7 +600,7 @@ func TestRetryDelayConfig(t *testing.T) {
 }
 
 func TestRetryOnRetryableStatusCodes(t *testing.T) {
-	retryableCodes := []int{503, 521, 522, 524, 530}
+	retryableCodes := []int{503, 520, 521, 522, 524, 530}
 
 	for _, statusCode := range retryableCodes {
 		t.Run(fmt.Sprintf("status_%d", statusCode), func(t *testing.T) {


### PR DESCRIPTION
## Summary

Add Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the set of transient HTTP status codes that trigger an automatic retry, alongside the existing `503` / `521` / `522` / `524` / `530`.

Like the other Cloudflare 52x codes already in the list, `520` is a transient edge error returned when the origin is briefly unreachable (e.g. during pod replacement on deploy), so the request is safe to retry.

Follow-up to #717.

https://github.com/descope/etc/issues/14039

## Test plan

- [x] `TestRetryOnRetryableStatusCodes` updated to include `520` — passes
- [x] Full retry suite passes (`go test ./descope/api/ -run 'TestRetry|TestNoRetry'` → 20 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)