### PR TITLE
feat(outbound): add token/api-key upload, connection-status list, tenant fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1892,6 +1892,70 @@ app, err := descopeClient.Management.OutboundApplication().LoadApplication(conte
 apps, err := descopeClient.Management.OutboundApplication().LoadAllApplications(context.Background())
 ```
 
+You can fetch tokens for a user or a tenant, by scopes or the latest one:
+
+```go
+// Fetch a user token with specific scopes
+token, err := descopeClient.Management.OutboundApplication().FetchUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{
+    AppID:  "app-id",
+    UserID: "user-id",
+    Scopes: []string{"read", "write"},
+})
+
+// Fetch the latest user token (ignores scopes)
+token, err = descopeClient.Management.OutboundApplication().FetchLatestUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{
+    AppID:  "app-id",
+    UserID: "user-id",
+})
+
+// Fetch a tenant token with specific scopes / the latest tenant token
+token, err = descopeClient.Management.OutboundApplication().FetchTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{
+    AppID:    "app-id",
+    TenantID: "tenant-id",
+    Scopes:   []string{"read"},
+})
+token, err = descopeClient.Management.OutboundApplication().FetchLatestTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{
+    AppID:    "app-id",
+    TenantID: "tenant-id",
+})
+
+// List the IDs of the outbound apps a user currently holds a valid token for
+appIDs, err := descopeClient.Management.OutboundApplication().ListAppsWithUserToken(context.Background(), "user-id", "" /* optional tenantId */)
+```
+
+For apikey-type outbound apps you can store a static API key, and for oauth-type apps you can
+migrate (upload) existing tokens without requiring the user to re-run the OAuth flow:
+
+```go
+// Store a static API key for a user / tenant on an apikey-type app
+err := descopeClient.Management.OutboundApplication().UploadUserAPIKey(context.Background(), &descope.UploadOutboundAppUserAPIKeyRequest{
+    AppID:  "app-id",
+    UserID: "user-id",
+    APIKey: "the-users-api-key",
+})
+err = descopeClient.Management.OutboundApplication().UploadTenantAPIKey(context.Background(), &descope.UploadOutboundAppTenantAPIKeyRequest{
+    AppID:    "app-id",
+    TenantID: "tenant-id",
+    APIKey:   "the-tenants-api-key",
+})
+
+// Upload (migrate) an existing OAuth token for a user / tenant
+err = descopeClient.Management.OutboundApplication().UploadUserToken(context.Background(), &descope.UploadOutboundAppUserTokenRequest{
+    OutboundAppUserTokenToUpload: descope.OutboundAppUserTokenToUpload{
+        AppID:        "app-id",
+        UserID:       "user-id",
+        RefreshToken: "the-refresh-token",
+        Scopes:       []string{"read", "write"},
+    },
+})
+
+// Batch upload (all-or-nothing): inspect res.Failures to see which items were rejected
+res, err := descopeClient.Management.OutboundApplication().BatchUploadUserTokens(context.Background(), []*descope.OutboundAppUserTokenToUpload{
+    {AppID: "app-id", UserID: "user-1", AccessToken: "token-1"},
+    {AppID: "app-id", UserID: "user-2", AccessToken: "token-2"},
+})
+```
+
 ### Manage Lists
 
 You can create, update, delete, or load lists, as well as perform IP-specific operations:

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -249,44 +249,54 @@ var (
 			outboundApplicationDelete:                "mgmt/outbound/app/delete",
 			outboundApplicationLoad:                  "mgmt/outbound/app",
 			outboundApplicationLoadAll:               "mgmt/outbound/apps",
+			outboundApplicationListAppsWithUserToken: "mgmt/outbound/apps-with-user-token",
 			outboundApplicationFetchUserToken:        "mgmt/outbound/app/user/token",
-			outboundApplicationDeleteUserTokens:      "mgmt/outbound/user/tokens",
-			outboundApplicationDeleteTokenByID:       "mgmt/outbound/token",
-			thirdPartyApplicationCreate:              "mgmt/thirdparty/app/create",
-			thirdPartyApplicationUpdate:              "mgmt/thirdparty/app/update",
-			thirdPartyApplicationPatch:               "mgmt/thirdparty/app/patch",
-			thirdPartyApplicationDelete:              "mgmt/thirdparty/app/delete",
-			thirdPartyApplicationLoad:                "mgmt/thirdparty/app/load",
-			thirdPartyApplicationLoadAll:             "mgmt/thirdparty/apps/load",
-			thirdPartyApplicationSecret:              "mgmt/thirdparty/app/secret",
-			thirdPartyApplicationRotate:              "mgmt/thirdparty/app/rotate",
-			thirdPartyApplicationConsentDelete:       "mgmt/thirdparty/consents/delete",
-			thirdPartyApplicationTenantConsentDelete: "mgmt/thirdparty/consents/delete/tenant",
-			thirdPartyApplicationConsentsSearch:      "mgmt/thirdparty/consents/search",
-			mgmtKeyCreate:                            "mgmt/managementkey",
-			mgmtKeyUpdate:                            "mgmt/managementkey",
-			mgmtKeyGet:                               "mgmt/managementkey",
-			mgmtKeyDelete:                            "mgmt/managementkey/delete",
-			mgmtKeySearch:                            "mgmt/managementkey/search",
-			descoperCreate:                           "mgmt/descoper",
-			descoperUpdate:                           "mgmt/descoper",
-			descoperGet:                              "mgmt/descoper",
-			descoperDelete:                           "mgmt/descoper",
-			descoperSearch:                           "mgmt/descoper/list",
-			listCreate:                               "mgmt/list",
-			listUpdate:                               "mgmt/list/update",
-			listDelete:                               "mgmt/list/delete",
-			listLoad:                                 "mgmt/list",
-			listLoadByName:                           "mgmt/list/name",
-			listLoadAll:                              "mgmt/list/all",
-			listImport:                               "mgmt/list/import",
-			listAddIPs:                               "mgmt/list/ip/add",
-			listRemoveIPs:                            "mgmt/list/ip/remove",
-			listCheckIP:                              "mgmt/list/ip/check",
-			listAddTexts:                             "mgmt/list/text/add",
-			listRemoveTexts:                          "mgmt/list/text/remove",
-			listCheckText:                            "mgmt/list/text/check",
-			listClear:                                "mgmt/list/clear",
+			outboundApplicationFetchLatestUserToken:  "mgmt/outbound/app/user/token/latest",
+			outboundApplicationFetchTenantToken:      "mgmt/outbound/app/tenant/token",
+			outboundApplicationFetchLatestTenantToken:  "mgmt/outbound/app/tenant/token/latest",
+			outboundApplicationDeleteUserTokens:        "mgmt/outbound/user/tokens",
+			outboundApplicationDeleteTokenByID:         "mgmt/outbound/token",
+			outboundApplicationUploadUserAPIKey:        "mgmt/outbound/app/user/apikey/upload",
+			outboundApplicationUploadTenantAPIKey:      "mgmt/outbound/app/tenant/apikey/upload",
+			outboundApplicationUploadUserToken:         "mgmt/outbound/app/user/oauthtoken/upload",
+			outboundApplicationUploadTenantToken:       "mgmt/outbound/app/tenant/oauthtoken/upload",
+			outboundApplicationBatchUploadUserTokens:   "mgmt/outbound/app/user/oauthtoken/batch/upload",
+			outboundApplicationBatchUploadTenantTokens: "mgmt/outbound/app/tenant/oauthtoken/batch/upload",
+			thirdPartyApplicationCreate:                "mgmt/thirdparty/app/create",
+			thirdPartyApplicationUpdate:                "mgmt/thirdparty/app/update",
+			thirdPartyApplicationPatch:                 "mgmt/thirdparty/app/patch",
+			thirdPartyApplicationDelete:                "mgmt/thirdparty/app/delete",
+			thirdPartyApplicationLoad:                  "mgmt/thirdparty/app/load",
+			thirdPartyApplicationLoadAll:               "mgmt/thirdparty/apps/load",
+			thirdPartyApplicationSecret:                "mgmt/thirdparty/app/secret",
+			thirdPartyApplicationRotate:                "mgmt/thirdparty/app/rotate",
+			thirdPartyApplicationConsentDelete:         "mgmt/thirdparty/consents/delete",
+			thirdPartyApplicationTenantConsentDelete:   "mgmt/thirdparty/consents/delete/tenant",
+			thirdPartyApplicationConsentsSearch:        "mgmt/thirdparty/consents/search",
+			mgmtKeyCreate:                              "mgmt/managementkey",
+			mgmtKeyUpdate:                              "mgmt/managementkey",
+			mgmtKeyGet:                                 "mgmt/managementkey",
+			mgmtKeyDelete:                              "mgmt/managementkey/delete",
+			mgmtKeySearch:                              "mgmt/managementkey/search",
+			descoperCreate:                             "mgmt/descoper",
+			descoperUpdate:                             "mgmt/descoper",
+			descoperGet:                                "mgmt/descoper",
+			descoperDelete:                             "mgmt/descoper",
+			descoperSearch:                             "mgmt/descoper/list",
+			listCreate:                                 "mgmt/list",
+			listUpdate:                                 "mgmt/list/update",
+			listDelete:                                 "mgmt/list/delete",
+			listLoad:                                   "mgmt/list",
+			listLoadByName:                             "mgmt/list/name",
+			listLoadAll:                                "mgmt/list/all",
+			listImport:                                 "mgmt/list/import",
+			listAddIPs:                                 "mgmt/list/ip/add",
+			listRemoveIPs:                              "mgmt/list/ip/remove",
+			listCheckIP:                                "mgmt/list/ip/check",
+			listAddTexts:                               "mgmt/list/text/add",
+			listRemoveTexts:                            "mgmt/list/text/remove",
+			listCheckText:                              "mgmt/list/text/check",
+			listClear:                                  "mgmt/list/clear",
 		},
 		logout:       "auth/logout",
 		logoutAll:    "auth/logoutall",
@@ -545,14 +555,24 @@ type mgmtEndpoints struct {
 	fgaResourcesLoad           string
 	fgaResourcesSave           string
 
-	outboundApplicationCreate           string
-	outboundApplicationUpdate           string
-	outboundApplicationDelete           string
-	outboundApplicationLoad             string
-	outboundApplicationLoadAll          string
-	outboundApplicationFetchUserToken   string
-	outboundApplicationDeleteUserTokens string
-	outboundApplicationDeleteTokenByID  string
+	outboundApplicationCreate                  string
+	outboundApplicationUpdate                  string
+	outboundApplicationDelete                  string
+	outboundApplicationLoad                    string
+	outboundApplicationLoadAll                 string
+	outboundApplicationListAppsWithUserToken   string
+	outboundApplicationFetchUserToken          string
+	outboundApplicationFetchLatestUserToken    string
+	outboundApplicationFetchTenantToken        string
+	outboundApplicationFetchLatestTenantToken  string
+	outboundApplicationDeleteUserTokens        string
+	outboundApplicationDeleteTokenByID         string
+	outboundApplicationUploadUserAPIKey        string
+	outboundApplicationUploadTenantAPIKey      string
+	outboundApplicationUploadUserToken         string
+	outboundApplicationUploadTenantToken       string
+	outboundApplicationBatchUploadUserTokens   string
+	outboundApplicationBatchUploadTenantTokens string
 
 	thirdPartyApplicationCreate              string
 	thirdPartyApplicationUpdate              string
@@ -1475,6 +1495,46 @@ func (e *endpoints) ManagementOutboundApplicationDeleteUserTokens() string {
 
 func (e *endpoints) ManagementOutboundApplicationDeleteTokenByID() string {
 	return path.Join(e.version, e.mgmt.outboundApplicationDeleteTokenByID)
+}
+
+func (e *endpoints) ManagementOutboundApplicationListAppsWithUserToken() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationListAppsWithUserToken)
+}
+
+func (e *endpoints) ManagementOutboundApplicationFetchLatestUserToken() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationFetchLatestUserToken)
+}
+
+func (e *endpoints) ManagementOutboundApplicationFetchTenantToken() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationFetchTenantToken)
+}
+
+func (e *endpoints) ManagementOutboundApplicationFetchLatestTenantToken() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationFetchLatestTenantToken)
+}
+
+func (e *endpoints) ManagementOutboundApplicationUploadUserAPIKey() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationUploadUserAPIKey)
+}
+
+func (e *endpoints) ManagementOutboundApplicationUploadTenantAPIKey() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationUploadTenantAPIKey)
+}
+
+func (e *endpoints) ManagementOutboundApplicationUploadUserToken() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationUploadUserToken)
+}
+
+func (e *endpoints) ManagementOutboundApplicationUploadTenantToken() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationUploadTenantToken)
+}
+
+func (e *endpoints) ManagementOutboundApplicationBatchUploadUserTokens() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationBatchUploadUserTokens)
+}
+
+func (e *endpoints) ManagementOutboundApplicationBatchUploadTenantTokens() string {
+	return path.Join(e.version, e.mgmt.outboundApplicationBatchUploadTenantTokens)
 }
 
 func (e *endpoints) ManagementThirdPartyApplicationCreate() string {

--- a/descope/internal/mgmt/outbound_application.go
+++ b/descope/internal/mgmt/outbound_application.go
@@ -128,12 +128,193 @@ func (s *outboundApplication) FetchUserToken(ctx context.Context, request *desco
 	if err != nil {
 		return nil, err
 	}
+	return s.unmarshalTokenResponse(httpRes)
+}
 
-	var response descope.FetchOutboundAppUserTokenResponse
-	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &response); err != nil {
+func (s *outboundApplication) FetchLatestUserToken(ctx context.Context, request *descope.FetchOutboundAppUserTokenRequest) (*descope.OutboundAppUserToken, error) {
+	if request == nil {
+		return nil, utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return nil, utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.UserID == "" {
+		return nil, utils.NewInvalidArgumentError("request.UserID")
+	}
+
+	// The "latest" endpoint ignores scopes; send only the relevant fields so we never post a
+	// "scopes" key the target message doesn't define (the gateway rejects unknown fields).
+	body := map[string]any{"appId": request.AppID, "userId": request.UserID}
+	if request.TenantID != "" {
+		body["tenantId"] = request.TenantID
+	}
+	if request.Options != nil {
+		body["options"] = request.Options
+	}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationFetchLatestUserToken(), body, nil, "")
+	if err != nil {
 		return nil, err
 	}
-	return response.Token, nil
+	return s.unmarshalTokenResponse(httpRes)
+}
+
+func (s *outboundApplication) FetchTenantToken(ctx context.Context, request *descope.FetchOutboundAppTenantTokenRequest) (*descope.OutboundAppUserToken, error) {
+	if request == nil {
+		return nil, utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return nil, utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.TenantID == "" {
+		return nil, utils.NewInvalidArgumentError("request.TenantID")
+	}
+
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationFetchTenantToken(), request, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return s.unmarshalTokenResponse(httpRes)
+}
+
+func (s *outboundApplication) FetchLatestTenantToken(ctx context.Context, request *descope.FetchOutboundAppTenantTokenRequest) (*descope.OutboundAppUserToken, error) {
+	if request == nil {
+		return nil, utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return nil, utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.TenantID == "" {
+		return nil, utils.NewInvalidArgumentError("request.TenantID")
+	}
+
+	// The "latest" endpoint ignores scopes; send only the relevant fields (see FetchLatestUserToken).
+	body := map[string]any{"appId": request.AppID, "tenantId": request.TenantID}
+	if request.Options != nil {
+		body["options"] = request.Options
+	}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationFetchLatestTenantToken(), body, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return s.unmarshalTokenResponse(httpRes)
+}
+
+func (s *outboundApplication) ListAppsWithUserToken(ctx context.Context, userID, tenantID string) ([]string, error) {
+	if userID == "" {
+		return nil, utils.NewInvalidArgumentError("userID")
+	}
+
+	params := map[string]string{"userId": userID}
+	if tenantID != "" {
+		params["tenantId"] = tenantID
+	}
+	res, err := s.client.DoGetRequest(ctx, api.Routes.ManagementOutboundApplicationListAppsWithUserToken(), &api.HTTPRequest{QueryParams: params}, "")
+	if err != nil {
+		return nil, err
+	}
+	tmp := &struct {
+		AppIDs []string `json:"appIds"`
+	}{}
+	if err = utils.Unmarshal([]byte(res.BodyStr), tmp); err != nil {
+		return nil, err
+	}
+	return tmp.AppIDs, nil
+}
+
+func (s *outboundApplication) UploadUserAPIKey(ctx context.Context, request *descope.UploadOutboundAppUserAPIKeyRequest) error {
+	if request == nil {
+		return utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.UserID == "" {
+		return utils.NewInvalidArgumentError("request.UserID")
+	}
+	if request.APIKey == "" {
+		return utils.NewInvalidArgumentError("request.APIKey")
+	}
+
+	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationUploadUserAPIKey(), request, nil, "")
+	return err
+}
+
+func (s *outboundApplication) UploadTenantAPIKey(ctx context.Context, request *descope.UploadOutboundAppTenantAPIKeyRequest) error {
+	if request == nil {
+		return utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.TenantID == "" {
+		return utils.NewInvalidArgumentError("request.TenantID")
+	}
+	if request.APIKey == "" {
+		return utils.NewInvalidArgumentError("request.APIKey")
+	}
+
+	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationUploadTenantAPIKey(), request, nil, "")
+	return err
+}
+
+func (s *outboundApplication) UploadUserToken(ctx context.Context, request *descope.UploadOutboundAppUserTokenRequest) error {
+	if request == nil {
+		return utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.UserID == "" {
+		return utils.NewInvalidArgumentError("request.UserID")
+	}
+	if request.RefreshToken == "" && request.AccessToken == "" {
+		return utils.NewInvalidArgumentError("either request.RefreshToken or request.AccessToken must be provided")
+	}
+
+	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationUploadUserToken(), request, nil, "")
+	return err
+}
+
+func (s *outboundApplication) UploadTenantToken(ctx context.Context, request *descope.UploadOutboundAppTenantTokenRequest) error {
+	if request == nil {
+		return utils.NewInvalidArgumentError("request")
+	}
+	if request.AppID == "" {
+		return utils.NewInvalidArgumentError("request.AppID")
+	}
+	if request.TenantID == "" {
+		return utils.NewInvalidArgumentError("request.TenantID")
+	}
+	if request.RefreshToken == "" && request.AccessToken == "" {
+		return utils.NewInvalidArgumentError("either request.RefreshToken or request.AccessToken must be provided")
+	}
+
+	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationUploadTenantToken(), request, nil, "")
+	return err
+}
+
+func (s *outboundApplication) BatchUploadUserTokens(ctx context.Context, tokens []*descope.OutboundAppUserTokenToUpload) (*descope.BatchUploadOutboundAppTokensResponse, error) {
+	if len(tokens) == 0 {
+		return nil, utils.NewInvalidArgumentError("tokens")
+	}
+
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationBatchUploadUserTokens(), map[string]any{"tokens": tokens}, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalBatchUploadResponse(httpRes)
+}
+
+func (s *outboundApplication) BatchUploadTenantTokens(ctx context.Context, tokens []*descope.OutboundAppTenantTokenToUpload) (*descope.BatchUploadOutboundAppTokensResponse, error) {
+	if len(tokens) == 0 {
+		return nil, utils.NewInvalidArgumentError("tokens")
+	}
+
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementOutboundApplicationBatchUploadTenantTokens(), map[string]any{"tokens": tokens}, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalBatchUploadResponse(httpRes)
 }
 
 func (s *outboundApplication) DeleteUserTokens(ctx context.Context, appID, userID string) error {
@@ -183,4 +364,20 @@ func (s *outboundApplication) unmarshalAppResponse(httpRes *api.HTTPResponse) (*
 		return nil, err
 	}
 	return res.App, nil
+}
+
+func (s *outboundApplication) unmarshalTokenResponse(httpRes *api.HTTPResponse) (*descope.OutboundAppUserToken, error) {
+	var response descope.FetchOutboundAppUserTokenResponse
+	if err := utils.Unmarshal([]byte(httpRes.BodyStr), &response); err != nil {
+		return nil, err
+	}
+	return response.Token, nil
+}
+
+func unmarshalBatchUploadResponse(httpRes *api.HTTPResponse) (*descope.BatchUploadOutboundAppTokensResponse, error) {
+	var response descope.BatchUploadOutboundAppTokensResponse
+	if err := utils.Unmarshal([]byte(httpRes.BodyStr), &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
 }

--- a/descope/internal/mgmt/outbound_application_test.go
+++ b/descope/internal/mgmt/outbound_application_test.go
@@ -220,6 +220,321 @@ func TestOutboundApplicationFetchUserTokenError(t *testing.T) {
 	require.False(t, called)
 }
 
+func TestOutboundApplicationFetchLatestUserTokenSuccess(t *testing.T) {
+	response := map[string]any{"token": map[string]any{"id": "token-id", "appId": "app-id", "userId": "user-id"}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/user/token/latest", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "user-id", req["userId"])
+	}, response))
+
+	token, err := mgmt.OutboundApplication().FetchLatestUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{
+		AppID:  "app-id",
+		UserID: "user-id",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "token-id", token.ID)
+}
+
+func TestOutboundApplicationFetchLatestUserTokenError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	token, err := mgmt.OutboundApplication().FetchLatestUserToken(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, token)
+
+	token, err = mgmt.OutboundApplication().FetchLatestUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{AppID: "app-id"})
+	require.Error(t, err)
+	require.Nil(t, token)
+	require.False(t, called)
+}
+
+func TestOutboundApplicationFetchTenantTokenSuccess(t *testing.T) {
+	response := map[string]any{"token": map[string]any{"id": "token-id", "appId": "app-id", "tenantId": "tenant-id"}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/tenant/token", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "tenant-id", req["tenantId"])
+		assert.Equal(t, []any{"read"}, req["scopes"])
+	}, response))
+
+	token, err := mgmt.OutboundApplication().FetchTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{
+		AppID:    "app-id",
+		TenantID: "tenant-id",
+		Scopes:   []string{"read"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "token-id", token.ID)
+}
+
+func TestOutboundApplicationFetchTenantTokenError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	token, err := mgmt.OutboundApplication().FetchTenantToken(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, token)
+
+	token, err = mgmt.OutboundApplication().FetchTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{AppID: "app-id"})
+	require.Error(t, err)
+	require.Nil(t, token)
+	require.False(t, called)
+}
+
+func TestOutboundApplicationFetchLatestTenantTokenSuccess(t *testing.T) {
+	response := map[string]any{"token": map[string]any{"id": "token-id", "appId": "app-id", "tenantId": "tenant-id"}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/tenant/token/latest", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "tenant-id", req["tenantId"])
+	}, response))
+
+	token, err := mgmt.OutboundApplication().FetchLatestTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{
+		AppID:    "app-id",
+		TenantID: "tenant-id",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "token-id", token.ID)
+}
+
+func TestOutboundApplicationListAppsWithUserTokenSuccess(t *testing.T) {
+	response := map[string]any{"appIds": []string{"app1", "app2"}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/apps-with-user-token", r.URL.Path)
+		assert.Equal(t, "user-id", r.URL.Query().Get("userId"))
+		assert.Equal(t, "tenant-id", r.URL.Query().Get("tenantId"))
+	}, response))
+
+	appIDs, err := mgmt.OutboundApplication().ListAppsWithUserToken(context.Background(), "user-id", "tenant-id")
+	require.NoError(t, err)
+	require.Equal(t, []string{"app1", "app2"}, appIDs)
+}
+
+func TestOutboundApplicationListAppsWithUserTokenNoTenant(t *testing.T) {
+	response := map[string]any{"appIds": []string{"app1"}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "user-id", r.URL.Query().Get("userId"))
+		assert.Equal(t, "", r.URL.Query().Get("tenantId"))
+	}, response))
+
+	appIDs, err := mgmt.OutboundApplication().ListAppsWithUserToken(context.Background(), "user-id", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"app1"}, appIDs)
+}
+
+func TestOutboundApplicationListAppsWithUserTokenError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	appIDs, err := mgmt.OutboundApplication().ListAppsWithUserToken(context.Background(), "", "")
+	require.Error(t, err)
+	require.Nil(t, appIDs)
+	require.False(t, called)
+}
+
+func TestOutboundApplicationUploadUserAPIKeySuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/user/apikey/upload", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "user-id", req["userId"])
+		assert.Equal(t, "secret-key", req["apiKey"])
+		assert.Equal(t, "tenant-id", req["tenantId"])
+	}))
+
+	err := mgmt.OutboundApplication().UploadUserAPIKey(context.Background(), &descope.UploadOutboundAppUserAPIKeyRequest{
+		AppID:    "app-id",
+		UserID:   "user-id",
+		APIKey:   "secret-key",
+		TenantID: "tenant-id",
+	})
+	require.NoError(t, err)
+}
+
+func TestOutboundApplicationUploadUserAPIKeyError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	require.Error(t, mgmt.OutboundApplication().UploadUserAPIKey(context.Background(), nil))
+	require.Error(t, mgmt.OutboundApplication().UploadUserAPIKey(context.Background(), &descope.UploadOutboundAppUserAPIKeyRequest{UserID: "u", APIKey: "k"}))
+	require.Error(t, mgmt.OutboundApplication().UploadUserAPIKey(context.Background(), &descope.UploadOutboundAppUserAPIKeyRequest{AppID: "a", APIKey: "k"}))
+	require.Error(t, mgmt.OutboundApplication().UploadUserAPIKey(context.Background(), &descope.UploadOutboundAppUserAPIKeyRequest{AppID: "a", UserID: "u"}))
+	require.False(t, called)
+}
+
+func TestOutboundApplicationUploadTenantAPIKeySuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/tenant/apikey/upload", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "tenant-id", req["tenantId"])
+		assert.Equal(t, "secret-key", req["apiKey"])
+	}))
+
+	err := mgmt.OutboundApplication().UploadTenantAPIKey(context.Background(), &descope.UploadOutboundAppTenantAPIKeyRequest{
+		AppID:    "app-id",
+		TenantID: "tenant-id",
+		APIKey:   "secret-key",
+	})
+	require.NoError(t, err)
+}
+
+func TestOutboundApplicationUploadTenantAPIKeyError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	require.Error(t, mgmt.OutboundApplication().UploadTenantAPIKey(context.Background(), nil))
+	require.Error(t, mgmt.OutboundApplication().UploadTenantAPIKey(context.Background(), &descope.UploadOutboundAppTenantAPIKeyRequest{TenantID: "t", APIKey: "k"}))
+	require.Error(t, mgmt.OutboundApplication().UploadTenantAPIKey(context.Background(), &descope.UploadOutboundAppTenantAPIKeyRequest{AppID: "a", APIKey: "k"}))
+	require.Error(t, mgmt.OutboundApplication().UploadTenantAPIKey(context.Background(), &descope.UploadOutboundAppTenantAPIKeyRequest{AppID: "a", TenantID: "t"}))
+	require.False(t, called)
+}
+
+func TestOutboundApplicationUploadUserTokenSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/user/oauthtoken/upload", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "user-id", req["userId"])
+		assert.Equal(t, "refresh", req["refreshToken"])
+		assert.Equal(t, true, req["verifyRefresh"])
+	}))
+
+	err := mgmt.OutboundApplication().UploadUserToken(context.Background(), &descope.UploadOutboundAppUserTokenRequest{
+		OutboundAppUserTokenToUpload: descope.OutboundAppUserTokenToUpload{
+			AppID:        "app-id",
+			UserID:       "user-id",
+			RefreshToken: "refresh",
+			Scopes:       []string{"read"},
+		},
+		VerifyRefresh: true,
+	})
+	require.NoError(t, err)
+}
+
+func TestOutboundApplicationUploadUserTokenError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	require.Error(t, mgmt.OutboundApplication().UploadUserToken(context.Background(), nil))
+	// missing both refresh and access token
+	require.Error(t, mgmt.OutboundApplication().UploadUserToken(context.Background(), &descope.UploadOutboundAppUserTokenRequest{
+		OutboundAppUserTokenToUpload: descope.OutboundAppUserTokenToUpload{AppID: "a", UserID: "u"},
+	}))
+	require.False(t, called)
+}
+
+func TestOutboundApplicationUploadTenantTokenSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/tenant/oauthtoken/upload", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		assert.Equal(t, "app-id", req["appId"])
+		assert.Equal(t, "tenant-id", req["tenantId"])
+		assert.Equal(t, "access", req["accessToken"])
+	}))
+
+	err := mgmt.OutboundApplication().UploadTenantToken(context.Background(), &descope.UploadOutboundAppTenantTokenRequest{
+		OutboundAppTenantTokenToUpload: descope.OutboundAppTenantTokenToUpload{
+			AppID:       "app-id",
+			TenantID:    "tenant-id",
+			AccessToken: "access",
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestOutboundApplicationUploadTenantTokenError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	require.Error(t, mgmt.OutboundApplication().UploadTenantToken(context.Background(), nil))
+	require.Error(t, mgmt.OutboundApplication().UploadTenantToken(context.Background(), &descope.UploadOutboundAppTenantTokenRequest{
+		OutboundAppTenantTokenToUpload: descope.OutboundAppTenantTokenToUpload{AppID: "a"},
+	}))
+	require.False(t, called)
+}
+
+func TestOutboundApplicationBatchUploadUserTokensSuccess(t *testing.T) {
+	response := map[string]any{"failures": []map[string]any{
+		{"appId": "app-id", "userId": "user-2", "errorCode": "E152110", "reason": "bad token"},
+	}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/user/oauthtoken/batch/upload", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		tokens := req["tokens"].([]any)
+		require.Len(t, tokens, 2)
+		assert.Equal(t, "app-id", tokens[0].(map[string]any)["appId"])
+	}, response))
+
+	res, err := mgmt.OutboundApplication().BatchUploadUserTokens(context.Background(), []*descope.OutboundAppUserTokenToUpload{
+		{AppID: "app-id", UserID: "user-1", AccessToken: "a1"},
+		{AppID: "app-id", UserID: "user-2", AccessToken: "a2"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res.Failures, 1)
+	assert.Equal(t, "E152110", res.Failures[0].ErrorCode)
+	assert.Equal(t, "user-2", res.Failures[0].UserID)
+}
+
+func TestOutboundApplicationBatchUploadUserTokensError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	res, err := mgmt.OutboundApplication().BatchUploadUserTokens(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.False(t, called)
+}
+
+func TestOutboundApplicationBatchUploadTenantTokensSuccess(t *testing.T) {
+	response := map[string]any{"failures": []map[string]any{}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		assert.Equal(t, "/v1/mgmt/outbound/app/tenant/oauthtoken/batch/upload", r.URL.Path)
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Len(t, req["tokens"].([]any), 1)
+	}, response))
+
+	res, err := mgmt.OutboundApplication().BatchUploadTenantTokens(context.Background(), []*descope.OutboundAppTenantTokenToUpload{
+		{AppID: "app-id", TenantID: "tenant-1", AccessToken: "a1"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Empty(t, res.Failures)
+}
+
 func TestOutboundApplicationDeleteUserTokensSuccess(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		assert.Equal(t, "/v1/mgmt/outbound/user/tokens", r.URL.Path)

--- a/descope/internal/mgmt/outbound_application_test.go
+++ b/descope/internal/mgmt/outbound_application_test.go
@@ -228,11 +228,17 @@ func TestOutboundApplicationFetchLatestUserTokenSuccess(t *testing.T) {
 		require.NoError(t, helpers.ReadBody(r, &req))
 		assert.Equal(t, "app-id", req["appId"])
 		assert.Equal(t, "user-id", req["userId"])
+		assert.Equal(t, "tenant-id", req["tenantId"])
+		// scopes must NOT be sent to the latest endpoint
+		_, hasScopes := req["scopes"]
+		assert.False(t, hasScopes)
 	}, response))
 
 	token, err := mgmt.OutboundApplication().FetchLatestUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{
-		AppID:  "app-id",
-		UserID: "user-id",
+		AppID:    "app-id",
+		UserID:   "user-id",
+		TenantID: "tenant-id",
+		Options:  &descope.OutboundAppUserTokenOptions{ForceRefresh: true},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, token)
@@ -249,6 +255,12 @@ func TestOutboundApplicationFetchLatestUserTokenError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, token)
 
+	// empty AppID
+	token, err = mgmt.OutboundApplication().FetchLatestUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{UserID: "user-id"})
+	require.Error(t, err)
+	require.Nil(t, token)
+
+	// empty UserID
 	token, err = mgmt.OutboundApplication().FetchLatestUserToken(context.Background(), &descope.FetchOutboundAppUserTokenRequest{AppID: "app-id"})
 	require.Error(t, err)
 	require.Nil(t, token)
@@ -286,6 +298,12 @@ func TestOutboundApplicationFetchTenantTokenError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, token)
 
+	// empty AppID
+	token, err = mgmt.OutboundApplication().FetchTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{TenantID: "tenant-id"})
+	require.Error(t, err)
+	require.Nil(t, token)
+
+	// empty TenantID
 	token, err = mgmt.OutboundApplication().FetchTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{AppID: "app-id"})
 	require.Error(t, err)
 	require.Nil(t, token)
@@ -300,15 +318,40 @@ func TestOutboundApplicationFetchLatestTenantTokenSuccess(t *testing.T) {
 		require.NoError(t, helpers.ReadBody(r, &req))
 		assert.Equal(t, "app-id", req["appId"])
 		assert.Equal(t, "tenant-id", req["tenantId"])
+		_, hasScopes := req["scopes"]
+		assert.False(t, hasScopes)
 	}, response))
 
 	token, err := mgmt.OutboundApplication().FetchLatestTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{
 		AppID:    "app-id",
 		TenantID: "tenant-id",
+		Options:  &descope.OutboundAppUserTokenOptions{ForceRefresh: true},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, token)
 	assert.Equal(t, "token-id", token.ID)
+}
+
+func TestOutboundApplicationFetchLatestTenantTokenError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	token, err := mgmt.OutboundApplication().FetchLatestTenantToken(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, token)
+
+	// empty AppID
+	token, err = mgmt.OutboundApplication().FetchLatestTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{TenantID: "tenant-id"})
+	require.Error(t, err)
+	require.Nil(t, token)
+
+	// empty TenantID
+	token, err = mgmt.OutboundApplication().FetchLatestTenantToken(context.Background(), &descope.FetchOutboundAppTenantTokenRequest{AppID: "app-id"})
+	require.Error(t, err)
+	require.Nil(t, token)
+	require.False(t, called)
 }
 
 func TestOutboundApplicationListAppsWithUserTokenSuccess(t *testing.T) {
@@ -442,6 +485,14 @@ func TestOutboundApplicationUploadUserTokenError(t *testing.T) {
 	}))
 
 	require.Error(t, mgmt.OutboundApplication().UploadUserToken(context.Background(), nil))
+	// missing AppID
+	require.Error(t, mgmt.OutboundApplication().UploadUserToken(context.Background(), &descope.UploadOutboundAppUserTokenRequest{
+		OutboundAppUserTokenToUpload: descope.OutboundAppUserTokenToUpload{UserID: "u", AccessToken: "x"},
+	}))
+	// missing UserID
+	require.Error(t, mgmt.OutboundApplication().UploadUserToken(context.Background(), &descope.UploadOutboundAppUserTokenRequest{
+		OutboundAppUserTokenToUpload: descope.OutboundAppUserTokenToUpload{AppID: "a", AccessToken: "x"},
+	}))
 	// missing both refresh and access token
 	require.Error(t, mgmt.OutboundApplication().UploadUserToken(context.Background(), &descope.UploadOutboundAppUserTokenRequest{
 		OutboundAppUserTokenToUpload: descope.OutboundAppUserTokenToUpload{AppID: "a", UserID: "u"},
@@ -476,8 +527,17 @@ func TestOutboundApplicationUploadTenantTokenError(t *testing.T) {
 	}))
 
 	require.Error(t, mgmt.OutboundApplication().UploadTenantToken(context.Background(), nil))
+	// missing AppID
+	require.Error(t, mgmt.OutboundApplication().UploadTenantToken(context.Background(), &descope.UploadOutboundAppTenantTokenRequest{
+		OutboundAppTenantTokenToUpload: descope.OutboundAppTenantTokenToUpload{TenantID: "t", AccessToken: "x"},
+	}))
+	// missing TenantID
 	require.Error(t, mgmt.OutboundApplication().UploadTenantToken(context.Background(), &descope.UploadOutboundAppTenantTokenRequest{
 		OutboundAppTenantTokenToUpload: descope.OutboundAppTenantTokenToUpload{AppID: "a"},
+	}))
+	// missing both refresh and access token
+	require.Error(t, mgmt.OutboundApplication().UploadTenantToken(context.Background(), &descope.UploadOutboundAppTenantTokenRequest{
+		OutboundAppTenantTokenToUpload: descope.OutboundAppTenantTokenToUpload{AppID: "a", TenantID: "t"},
 	}))
 	require.False(t, called)
 }
@@ -533,6 +593,18 @@ func TestOutboundApplicationBatchUploadTenantTokensSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Empty(t, res.Failures)
+}
+
+func TestOutboundApplicationBatchUploadTenantTokensError(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+
+	res, err := mgmt.OutboundApplication().BatchUploadTenantTokens(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.False(t, called)
 }
 
 func TestOutboundApplicationDeleteUserTokensSuccess(t *testing.T) {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1134,6 +1134,43 @@ type OutboundApplication interface {
 	// The token can be used to access external resources on behalf of the user.
 	FetchUserToken(ctx context.Context, request *descope.FetchOutboundAppUserTokenRequest) (*descope.OutboundAppUserToken, error)
 
+	// Fetch the last created outbound application user token (ignores scopes).
+	// The token can be used to access external resources on behalf of the user.
+	FetchLatestUserToken(ctx context.Context, request *descope.FetchOutboundAppUserTokenRequest) (*descope.OutboundAppUserToken, error)
+
+	// Fetch an outbound application tenant token with the specified scopes.
+	// The token can be used to access external resources on behalf of the tenant.
+	FetchTenantToken(ctx context.Context, request *descope.FetchOutboundAppTenantTokenRequest) (*descope.OutboundAppUserToken, error)
+
+	// Fetch the last created outbound application tenant token (ignores scopes).
+	// The token can be used to access external resources on behalf of the tenant.
+	FetchLatestTenantToken(ctx context.Context, request *descope.FetchOutboundAppTenantTokenRequest) (*descope.OutboundAppUserToken, error)
+
+	// List the IDs of the outbound applications the given user currently holds a valid token for.
+	// An optional tenantID scopes the lookup to tokens associated with that tenant.
+	ListAppsWithUserToken(ctx context.Context, userID, tenantID string) ([]string, error)
+
+	// Upload (set) a static API key for a user on an apikey-type outbound application.
+	UploadUserAPIKey(ctx context.Context, request *descope.UploadOutboundAppUserAPIKeyRequest) error
+
+	// Upload (set) a static API key for a tenant on an apikey-type outbound application.
+	UploadTenantAPIKey(ctx context.Context, request *descope.UploadOutboundAppTenantAPIKeyRequest) error
+
+	// Upload (migrate) an existing OAuth token for a user on an oauth-type outbound application.
+	// Used to import tokens managed outside of Descope without requiring the user to re-run the OAuth flow.
+	UploadUserToken(ctx context.Context, request *descope.UploadOutboundAppUserTokenRequest) error
+
+	// Upload (migrate) an existing OAuth token for a tenant on an oauth-type outbound application.
+	UploadTenantToken(ctx context.Context, request *descope.UploadOutboundAppTenantTokenRequest) error
+
+	// Batch upload (migrate) existing OAuth tokens for users. All-or-nothing: if any item fails
+	// per-item validation, the returned failures are populated and no tokens are committed.
+	BatchUploadUserTokens(ctx context.Context, tokens []*descope.OutboundAppUserTokenToUpload) (*descope.BatchUploadOutboundAppTokensResponse, error)
+
+	// Batch upload (migrate) existing OAuth tokens for tenants. All-or-nothing: if any item fails
+	// per-item validation, the returned failures are populated and no tokens are committed.
+	BatchUploadTenantTokens(ctx context.Context, tokens []*descope.OutboundAppTenantTokenToUpload) (*descope.BatchUploadOutboundAppTokensResponse, error)
+
 	// Delete outbound application user tokens by appID or userID.
 	// At least one of appID or userID must be provided.
 	DeleteUserTokens(ctx context.Context, appID, userID string) error

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -2152,6 +2152,42 @@ type MockOutboundApplication struct {
 	FetchUserTokenResponse *descope.OutboundAppUserToken
 	FetchUserTokenError    error
 
+	FetchLatestUserTokenAssert   func(request *descope.FetchOutboundAppUserTokenRequest)
+	FetchLatestUserTokenResponse *descope.OutboundAppUserToken
+	FetchLatestUserTokenError    error
+
+	FetchTenantTokenAssert   func(request *descope.FetchOutboundAppTenantTokenRequest)
+	FetchTenantTokenResponse *descope.OutboundAppUserToken
+	FetchTenantTokenError    error
+
+	FetchLatestTenantTokenAssert   func(request *descope.FetchOutboundAppTenantTokenRequest)
+	FetchLatestTenantTokenResponse *descope.OutboundAppUserToken
+	FetchLatestTenantTokenError    error
+
+	ListAppsWithUserTokenAssert   func(userID, tenantID string)
+	ListAppsWithUserTokenResponse []string
+	ListAppsWithUserTokenError    error
+
+	UploadUserAPIKeyAssert func(request *descope.UploadOutboundAppUserAPIKeyRequest)
+	UploadUserAPIKeyError  error
+
+	UploadTenantAPIKeyAssert func(request *descope.UploadOutboundAppTenantAPIKeyRequest)
+	UploadTenantAPIKeyError  error
+
+	UploadUserTokenAssert func(request *descope.UploadOutboundAppUserTokenRequest)
+	UploadUserTokenError  error
+
+	UploadTenantTokenAssert func(request *descope.UploadOutboundAppTenantTokenRequest)
+	UploadTenantTokenError  error
+
+	BatchUploadUserTokensAssert   func(tokens []*descope.OutboundAppUserTokenToUpload)
+	BatchUploadUserTokensResponse *descope.BatchUploadOutboundAppTokensResponse
+	BatchUploadUserTokensError    error
+
+	BatchUploadTenantTokensAssert   func(tokens []*descope.OutboundAppTenantTokenToUpload)
+	BatchUploadTenantTokensResponse *descope.BatchUploadOutboundAppTokensResponse
+	BatchUploadTenantTokensError    error
+
 	DeleteUserTokensAssert func(appID, userID string)
 	DeleteUserTokensError  error
 
@@ -2196,6 +2232,76 @@ func (m *MockOutboundApplication) FetchUserToken(_ context.Context, request *des
 		m.FetchUserTokenAssert(request)
 	}
 	return m.FetchUserTokenResponse, m.FetchUserTokenError
+}
+
+func (m *MockOutboundApplication) FetchLatestUserToken(_ context.Context, request *descope.FetchOutboundAppUserTokenRequest) (*descope.OutboundAppUserToken, error) {
+	if m.FetchLatestUserTokenAssert != nil {
+		m.FetchLatestUserTokenAssert(request)
+	}
+	return m.FetchLatestUserTokenResponse, m.FetchLatestUserTokenError
+}
+
+func (m *MockOutboundApplication) FetchTenantToken(_ context.Context, request *descope.FetchOutboundAppTenantTokenRequest) (*descope.OutboundAppUserToken, error) {
+	if m.FetchTenantTokenAssert != nil {
+		m.FetchTenantTokenAssert(request)
+	}
+	return m.FetchTenantTokenResponse, m.FetchTenantTokenError
+}
+
+func (m *MockOutboundApplication) FetchLatestTenantToken(_ context.Context, request *descope.FetchOutboundAppTenantTokenRequest) (*descope.OutboundAppUserToken, error) {
+	if m.FetchLatestTenantTokenAssert != nil {
+		m.FetchLatestTenantTokenAssert(request)
+	}
+	return m.FetchLatestTenantTokenResponse, m.FetchLatestTenantTokenError
+}
+
+func (m *MockOutboundApplication) ListAppsWithUserToken(_ context.Context, userID, tenantID string) ([]string, error) {
+	if m.ListAppsWithUserTokenAssert != nil {
+		m.ListAppsWithUserTokenAssert(userID, tenantID)
+	}
+	return m.ListAppsWithUserTokenResponse, m.ListAppsWithUserTokenError
+}
+
+func (m *MockOutboundApplication) UploadUserAPIKey(_ context.Context, request *descope.UploadOutboundAppUserAPIKeyRequest) error {
+	if m.UploadUserAPIKeyAssert != nil {
+		m.UploadUserAPIKeyAssert(request)
+	}
+	return m.UploadUserAPIKeyError
+}
+
+func (m *MockOutboundApplication) UploadTenantAPIKey(_ context.Context, request *descope.UploadOutboundAppTenantAPIKeyRequest) error {
+	if m.UploadTenantAPIKeyAssert != nil {
+		m.UploadTenantAPIKeyAssert(request)
+	}
+	return m.UploadTenantAPIKeyError
+}
+
+func (m *MockOutboundApplication) UploadUserToken(_ context.Context, request *descope.UploadOutboundAppUserTokenRequest) error {
+	if m.UploadUserTokenAssert != nil {
+		m.UploadUserTokenAssert(request)
+	}
+	return m.UploadUserTokenError
+}
+
+func (m *MockOutboundApplication) UploadTenantToken(_ context.Context, request *descope.UploadOutboundAppTenantTokenRequest) error {
+	if m.UploadTenantTokenAssert != nil {
+		m.UploadTenantTokenAssert(request)
+	}
+	return m.UploadTenantTokenError
+}
+
+func (m *MockOutboundApplication) BatchUploadUserTokens(_ context.Context, tokens []*descope.OutboundAppUserTokenToUpload) (*descope.BatchUploadOutboundAppTokensResponse, error) {
+	if m.BatchUploadUserTokensAssert != nil {
+		m.BatchUploadUserTokensAssert(tokens)
+	}
+	return m.BatchUploadUserTokensResponse, m.BatchUploadUserTokensError
+}
+
+func (m *MockOutboundApplication) BatchUploadTenantTokens(_ context.Context, tokens []*descope.OutboundAppTenantTokenToUpload) (*descope.BatchUploadOutboundAppTokensResponse, error) {
+	if m.BatchUploadTenantTokensAssert != nil {
+		m.BatchUploadTenantTokensAssert(tokens)
+	}
+	return m.BatchUploadTenantTokensResponse, m.BatchUploadTenantTokensError
 }
 
 func (m *MockOutboundApplication) DeleteUserTokens(_ context.Context, appID, userID string) error {

--- a/descope/types.go
+++ b/descope/types.go
@@ -1448,6 +1448,96 @@ type FetchOutboundAppUserTokenResponse struct {
 	Token *OutboundAppUserToken `json:"token"`
 }
 
+// FetchOutboundAppTenantTokenRequest represents a request to fetch an outbound app tenant token
+type FetchOutboundAppTenantTokenRequest struct {
+	AppID    string                       `json:"appId"`
+	TenantID string                       `json:"tenantId"`
+	Scopes   []string                     `json:"scopes,omitempty"`
+	Options  *OutboundAppUserTokenOptions `json:"options,omitempty"`
+}
+
+// UploadOutboundAppUserAPIKeyRequest represents a request to upload/set a static API key for a user
+// on an apikey-type outbound application.
+type UploadOutboundAppUserAPIKeyRequest struct {
+	AppID    string `json:"appId"`
+	UserID   string `json:"userId"`
+	APIKey   string `json:"apiKey"`
+	TenantID string `json:"tenantId,omitempty"`
+}
+
+// UploadOutboundAppTenantAPIKeyRequest represents a request to upload/set a static API key for a tenant
+// on an apikey-type outbound application.
+type UploadOutboundAppTenantAPIKeyRequest struct {
+	AppID    string `json:"appId"`
+	TenantID string `json:"tenantId"`
+	APIKey   string `json:"apiKey"`
+}
+
+// OutboundAppUserTokenToUpload is a single OAuth token to migrate for a user. At least one of
+// RefreshToken or AccessToken must be set. AccessTokenExpiry is in epoch seconds (0 means unknown).
+// Used as a batch item and embedded into UploadOutboundAppUserTokenRequest.
+type OutboundAppUserTokenToUpload struct {
+	AppID              string   `json:"appId"`
+	UserID             string   `json:"userId"`
+	TenantID           string   `json:"tenantId,omitempty"`
+	RefreshToken       string   `json:"refreshToken,omitempty"`
+	AccessToken        string   `json:"accessToken,omitempty"`
+	AccessTokenExpiry  int32    `json:"accessTokenExpiry,omitempty"`
+	AccessTokenType    string   `json:"accessTokenType,omitempty"`
+	Scopes             []string `json:"scopes,omitempty"`
+	ExternalIdentifier string   `json:"externalIdentifier,omitempty"`
+	IDToken            string   `json:"idToken,omitempty"`
+	GrantedBy          string   `json:"grantedBy,omitempty"`
+}
+
+// OutboundAppTenantTokenToUpload is a single OAuth token to migrate for a tenant. At least one of
+// RefreshToken or AccessToken must be set. AccessTokenExpiry is in epoch seconds (0 means unknown).
+// Used as a batch item and embedded into UploadOutboundAppTenantTokenRequest.
+type OutboundAppTenantTokenToUpload struct {
+	AppID              string   `json:"appId"`
+	TenantID           string   `json:"tenantId"`
+	RefreshToken       string   `json:"refreshToken,omitempty"`
+	AccessToken        string   `json:"accessToken,omitempty"`
+	AccessTokenExpiry  int32    `json:"accessTokenExpiry,omitempty"`
+	AccessTokenType    string   `json:"accessTokenType,omitempty"`
+	Scopes             []string `json:"scopes,omitempty"`
+	ExternalIdentifier string   `json:"externalIdentifier,omitempty"`
+	IDToken            string   `json:"idToken,omitempty"`
+	GrantedBy          string   `json:"grantedBy,omitempty"`
+}
+
+// UploadOutboundAppUserTokenRequest uploads a single OAuth token for a user. When VerifyRefresh is
+// true, the refresh token is verified against the provider before persisting; nothing is written if
+// the verification fails.
+type UploadOutboundAppUserTokenRequest struct {
+	OutboundAppUserTokenToUpload
+	VerifyRefresh bool `json:"verifyRefresh,omitempty"`
+}
+
+// UploadOutboundAppTenantTokenRequest uploads a single OAuth token for a tenant. When VerifyRefresh is
+// true, the refresh token is verified against the provider before persisting; nothing is written if
+// the verification fails.
+type UploadOutboundAppTenantTokenRequest struct {
+	OutboundAppTenantTokenToUpload
+	VerifyRefresh bool `json:"verifyRefresh,omitempty"`
+}
+
+// OutboundAppTokenUploadFailure describes a single per-item failure from a batch upload. Only the
+// identifier relevant to the variant is populated (UserID for the user batch, TenantID for the tenant batch).
+type OutboundAppTokenUploadFailure struct {
+	AppID     string `json:"appId"`
+	UserID    string `json:"userId,omitempty"`
+	TenantID  string `json:"tenantId,omitempty"`
+	ErrorCode string `json:"errorCode"`
+	Reason    string `json:"reason"`
+}
+
+// BatchUploadOutboundAppTokensResponse is returned by the batch upload endpoints. Batch upload is
+// all-or-nothing: a non-empty Failures slice means no tokens were committed.
+type BatchUploadOutboundAppTokensResponse struct {
+	Failures []*OutboundAppTokenUploadFailure `json:"failures"`
+}
+
 type ThirdPartyApplicationScope struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`


### PR DESCRIPTION
## Description

The outbound-application **management REST API** already ships these endpoints, but the Go SDK didn't wrap them. This adds them to `Management.OutboundApplication()`:

**Upload / migrate credentials** (descope/etc#16568)
- `UploadUserAPIKey` / `UploadTenantAPIKey` — store a static API key on an apikey-type app
- `UploadUserToken` / `UploadTenantToken` — migrate an existing OAuth token without re-running the flow
- `BatchUploadUserTokens` / `BatchUploadTenantTokens` — all-or-nothing batch (returns per-item `failures`)

**Connection-status read** (descope/etc#16569)
- `ListAppsWithUserToken(userID, tenantID)` — the app IDs a user holds a valid token for; replaces calling `FetchUserToken` once per app and sniffing a not-found error code

**Parity with node/python SDKs** (the Go surface was behind)
- `FetchLatestUserToken`, `FetchTenantToken`, `FetchLatestTenantToken`

Request bodies were verified field-for-field against the backend proto messages. The `*Latest*` fetches deliberately omit `scopes` (the target messages have no such field, and the gateway rejects unknown fields).

## Must
- [x] Tests — added cases for every new method (`outbound_application_test.go`); full suite passes (1010 tests)
- [x] Documentation — README "Manage Outbound Applications" section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)