### PR TITLE
feat(types): add roleIds to user response

### DIFF
--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -1031,6 +1031,26 @@ func TestUserLoadParsesRoleIds(t *testing.T) {
 	require.EqualValues(t, []string{"rid1"}, res.UserTenants[0].RoleIDs)
 }
 
+func TestSearchAllUsersParsesRoleIds(t *testing.T) {
+	response := map[string]any{
+		"users": []map[string]any{{
+			"email":   "a@b.c",
+			"roleIds": []string{"gid1"},
+			"userTenants": []map[string]any{
+				{"tenantId": "t1", "roleNames": []string{"role1"}, "roleIds": []string{"rid1"}},
+			},
+		}},
+		"total": 1,
+	}
+	m := newTestMgmt(nil, helpers.DoOkWithBody(func(_ *http.Request) {}, response))
+	res, _, err := m.User().SearchAll(context.Background(), &descope.UserSearchOptions{})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.EqualValues(t, []string{"gid1"}, res[0].RoleIDs)
+	require.Len(t, res[0].UserTenants, 1)
+	require.EqualValues(t, []string{"rid1"}, res[0].UserTenants[0].RoleIDs)
+}
+
 func TestUsersLoad(t *testing.T) {
 	response := map[string]any{
 		"users": []map[string]any{{

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -1013,6 +1013,24 @@ func TestUserLoadSuccess(t *testing.T) {
 	require.Equal(t, "a@b.c", res.Email)
 }
 
+func TestUserLoadParsesRoleIds(t *testing.T) {
+	response := map[string]any{
+		"user": map[string]any{
+			"email":   "a@b.c",
+			"roleIds": []string{"gid1"},
+			"userTenants": []map[string]any{
+				{"tenantId": "t1", "roleNames": []string{"role1"}, "roleIds": []string{"rid1"}},
+			},
+		}}
+	m := newTestMgmt(nil, helpers.DoOkWithBody(func(_ *http.Request) {}, response))
+	res, err := m.User().Load(context.Background(), "abc")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.EqualValues(t, []string{"gid1"}, res.RoleIDs)
+	require.Len(t, res.UserTenants, 1)
+	require.EqualValues(t, []string{"rid1"}, res.UserTenants[0].RoleIDs)
+}
+
 func TestUsersLoad(t *testing.T) {
 	response := map[string]any{
 		"users": []map[string]any{{

--- a/descope/types.go
+++ b/descope/types.go
@@ -619,6 +619,7 @@ type UserResponse struct {
 	VerifiedEmail    bool                            `json:"verifiedEmail,omitempty"`
 	VerifiedPhone    bool                            `json:"verifiedPhone,omitempty"`
 	RoleNames        []string                        `json:"roleNames,omitempty"`
+	RoleIDs          []string                        `json:"roleIds,omitempty"`
 	UserTenants      []*UserResponseAssociatedTenant `json:"userTenants,omitempty"`
 	Status           string                          `json:"status,omitempty"`
 	Picture          string                          `json:"picture,omitempty"`
@@ -741,6 +742,7 @@ type AssociatedTenant struct {
 type UserResponseAssociatedTenant struct {
 	AssociatedTenant `json:",inline"`
 	Permissions      []string `json:"permissions,omitempty"`
+	RoleIDs          []string `json:"roleIds,omitempty"`
 }
 
 // Represents a mapping between a set of groups of users and a role that will be assigned to them.


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/16542

## Related PRs
### Downstream PRs
- descope/integrationtests#14404

### Related PRs
- descope/backend#1599

## In a Nutshell
- Parse new `roleIds` on user-load responses
- Top-level on `UserResponse`, per-tenant on `UserResponseAssociatedTenant`
- Additive, backwards compatible
- Covers both `Load` and `SearchAll` responses (same `UserResponse` struct)

## Description
The backend now returns a `roleIds` field alongside `roleNames` on user-load responses (top-level and per-tenant). This adds matching `RoleIDs []string` fields to the SDK response structs so consumers can parse them. Order is not guaranteed to match `roleNames` — consume one field or the other.

## Must
- [x] Tests
- [ ] Documentation (if applicable)


