### PR TITLE
feat(mgmt): add jwt template management api

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ These sections show how to use the SDK to perform API management functions. Befo
 17. [Manage Management Keys](#manage-management-keys)
 18. [Manage Descopers](#manage-descopers)
 19. [Manage Engines](#manage-engines)
+20. [Manage JWT Templates](#manage-jwt-templates)
 
 If you wish to run any of our code samples and play with them, check out our [Code Examples](#code-examples) section.
 
@@ -2276,6 +2277,48 @@ newSecret, err := descopeClient.Management.Engine().RotateSecret(context.Backgro
 
 // Delete an engine by ID.
 err = descopeClient.Management.Engine().Delete(context.Background(), "engine-id")
+```
+
+### Manage JWT Templates
+
+You can create, update, delete, load, list and validate JWT templates, as well as
+apply Descope's read-only library templates:
+
+```go
+// Create a new JWT template. The returned template includes its generated ID.
+tmpl, err := descopeClient.Management.JWTTemplate().Create(context.Background(), &descope.JWTTemplate{
+    Name:     "my-template",
+    Template: map[string]any{"customClaim": "{{user.email}}"},
+})
+
+// Update an existing template (identified by its ID). All fields are overridden.
+tmpl, err = descopeClient.Management.JWTTemplate().Update(context.Background(), &descope.JWTTemplate{
+    ID:   "template-id",
+    Name: "renamed-template",
+})
+
+// Load a template by ID, or list all templates in the project.
+tmpl, err = descopeClient.Management.JWTTemplate().Load(context.Background(), "template-id")
+templates, err := descopeClient.Management.JWTTemplate().List(context.Background())
+
+// Validate a template by ID and/or an inline template before saving.
+result, err := descopeClient.Management.JWTTemplate().Validate(context.Background(), "template-id", nil)
+if err == nil && !result.Valid {
+    for _, issue := range result.Issues {
+        fmt.Println(issue.Field, issue.Code, issue.Message)
+    }
+}
+
+// Browse the read-only starter templates shipped by Descope and apply one as a new template.
+entries, err := descopeClient.Management.JWTTemplate().ListLibrary(context.Background())
+entry, err := descopeClient.Management.JWTTemplate().LoadLibraryEntry(context.Background(), "library-entry-id")
+tmpl, err = descopeClient.Management.JWTTemplate().ApplyFromLibrary(context.Background(), &descope.ApplyJWTTemplateFromLibraryRequest{
+    LibraryEntryID: "library-entry-id",
+    NameOverride:   "my-template-from-library",
+})
+
+// Delete a template by ID.
+err = descopeClient.Management.JWTTemplate().Delete(context.Background(), "template-id")
 ```
 
 ## Code Examples

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -319,6 +319,15 @@ var (
 			engineLoad:                                 "mgmt/engine/load",
 			engineLoadAll:                              "mgmt/engines/load",
 			engineRotateSecret:                         "mgmt/engine/rotate",
+			jwtTemplateCreate:                          "mgmt/jwt/templates/create",
+			jwtTemplateUpdate:                          "mgmt/jwt/templates/update",
+			jwtTemplateDelete:                          "mgmt/jwt/templates/delete",
+			jwtTemplateList:                            "mgmt/jwt/templates/list",
+			jwtTemplateLoad:                            "mgmt/jwt/templates/load",
+			jwtTemplateValidate:                        "mgmt/jwt/templates/validate",
+			jwtTemplateLibraryList:                     "mgmt/jwt/templates/library/list",
+			jwtTemplateLibraryLoad:                     "mgmt/jwt/templates/library/load",
+			jwtTemplateLibraryApply:                    "mgmt/jwt/templates/library/apply",
 			scopeClaimMappingGet:                       "mgmt/scopeClaimMapping/get",
 			scopeClaimMappingSet:                       "mgmt/scopeClaimMapping/set",
 			scopeClaimMappingDelete:                    "mgmt/scopeClaimMapping/delete",
@@ -660,6 +669,16 @@ type mgmtEndpoints struct {
 	engineLoad         string
 	engineLoadAll      string
 	engineRotateSecret string
+
+	jwtTemplateCreate       string
+	jwtTemplateUpdate       string
+	jwtTemplateDelete       string
+	jwtTemplateList         string
+	jwtTemplateLoad         string
+	jwtTemplateValidate     string
+	jwtTemplateLibraryList  string
+	jwtTemplateLibraryLoad  string
+	jwtTemplateLibraryApply string
 
 	scopeClaimMappingGet    string
 	scopeClaimMappingSet    string
@@ -1815,6 +1834,42 @@ func (e *endpoints) ManagementEngineLoadAll() string {
 
 func (e *endpoints) ManagementEngineRotateSecret() string {
 	return path.Join(e.version, e.mgmt.engineRotateSecret)
+}
+
+func (e *endpoints) ManagementJWTTemplateCreate() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateCreate)
+}
+
+func (e *endpoints) ManagementJWTTemplateUpdate() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateUpdate)
+}
+
+func (e *endpoints) ManagementJWTTemplateDelete() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateDelete)
+}
+
+func (e *endpoints) ManagementJWTTemplateList() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateList)
+}
+
+func (e *endpoints) ManagementJWTTemplateLoad() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateLoad)
+}
+
+func (e *endpoints) ManagementJWTTemplateValidate() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateValidate)
+}
+
+func (e *endpoints) ManagementJWTTemplateLibraryList() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateLibraryList)
+}
+
+func (e *endpoints) ManagementJWTTemplateLibraryLoad() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateLibraryLoad)
+}
+
+func (e *endpoints) ManagementJWTTemplateLibraryApply() string {
+	return path.Join(e.version, e.mgmt.jwtTemplateLibraryApply)
 }
 
 func (e *endpoints) ManagementScopeClaimMappingGet() string {

--- a/descope/internal/mgmt/jwttemplate.go
+++ b/descope/internal/mgmt/jwttemplate.go
@@ -1,0 +1,150 @@
+package mgmt
+
+import (
+	"context"
+
+	"github.com/descope/go-sdk/descope"
+	"github.com/descope/go-sdk/descope/api"
+	"github.com/descope/go-sdk/descope/internal/utils"
+	"github.com/descope/go-sdk/descope/sdk"
+)
+
+type jwtTemplate struct {
+	managementBase
+}
+
+var _ sdk.JWTTemplate = &jwtTemplate{}
+
+func (t *jwtTemplate) Create(ctx context.Context, template *descope.JWTTemplate) (*descope.JWTTemplate, error) {
+	if template == nil {
+		return nil, utils.NewInvalidArgumentError("template")
+	}
+	body := map[string]any{"template": template}
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateCreate(), body, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalJWTTemplateResponse(res)
+}
+
+func (t *jwtTemplate) Update(ctx context.Context, template *descope.JWTTemplate) (*descope.JWTTemplate, error) {
+	if template == nil {
+		return nil, utils.NewInvalidArgumentError("template")
+	}
+	if template.ID == "" {
+		return nil, utils.NewInvalidArgumentError("template.ID")
+	}
+	body := map[string]any{"template": template}
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateUpdate(), body, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalJWTTemplateResponse(res)
+}
+
+func (t *jwtTemplate) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return utils.NewInvalidArgumentError("id")
+	}
+	body := map[string]any{"id": id}
+	_, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateDelete(), body, nil, "")
+	return err
+}
+
+func (t *jwtTemplate) List(ctx context.Context) ([]*descope.JWTTemplate, error) {
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateList(), map[string]any{}, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	lres := struct {
+		Templates []*descope.JWTTemplate
+	}{}
+	if err := utils.Unmarshal([]byte(res.BodyStr), &lres); err != nil {
+		return nil, err
+	}
+	return lres.Templates, nil
+}
+
+func (t *jwtTemplate) Load(ctx context.Context, id string) (*descope.JWTTemplate, error) {
+	if id == "" {
+		return nil, utils.NewInvalidArgumentError("id")
+	}
+	body := map[string]any{"id": id}
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateLoad(), body, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalJWTTemplateResponse(res)
+}
+
+func (t *jwtTemplate) Validate(ctx context.Context, id string, template *descope.JWTTemplate) (*descope.JWTTemplateValidationResult, error) {
+	if id == "" && template == nil {
+		return nil, utils.NewInvalidArgumentError("template")
+	}
+	body := map[string]any{"id": id, "template": template}
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateValidate(), body, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	result := &descope.JWTTemplateValidationResult{}
+	if err := utils.Unmarshal([]byte(res.BodyStr), result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (t *jwtTemplate) ListLibrary(ctx context.Context) ([]*descope.JWTTemplateLibraryEntry, error) {
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateLibraryList(), map[string]any{}, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	lres := struct {
+		Entries []*descope.JWTTemplateLibraryEntry
+	}{}
+	if err := utils.Unmarshal([]byte(res.BodyStr), &lres); err != nil {
+		return nil, err
+	}
+	return lres.Entries, nil
+}
+
+func (t *jwtTemplate) LoadLibraryEntry(ctx context.Context, id string) (*descope.JWTTemplateLibraryEntry, error) {
+	if id == "" {
+		return nil, utils.NewInvalidArgumentError("id")
+	}
+	body := map[string]any{"id": id}
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateLibraryLoad(), body, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	eres := struct {
+		Entry *descope.JWTTemplateLibraryEntry
+	}{}
+	if err := utils.Unmarshal([]byte(res.BodyStr), &eres); err != nil {
+		return nil, err
+	}
+	return eres.Entry, nil
+}
+
+func (t *jwtTemplate) ApplyFromLibrary(ctx context.Context, request *descope.ApplyJWTTemplateFromLibraryRequest) (*descope.JWTTemplate, error) {
+	if request == nil {
+		return nil, utils.NewInvalidArgumentError("request")
+	}
+	if request.LibraryEntryID == "" {
+		return nil, utils.NewInvalidArgumentError("request.LibraryEntryID")
+	}
+	res, err := t.client.DoPostRequest(ctx, api.Routes.ManagementJWTTemplateLibraryApply(), request, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalJWTTemplateResponse(res)
+}
+
+func unmarshalJWTTemplateResponse(res *api.HTTPResponse) (*descope.JWTTemplate, error) {
+	tres := struct {
+		Template *descope.JWTTemplate
+	}{}
+	if err := utils.Unmarshal([]byte(res.BodyStr), &tres); err != nil {
+		return nil, err
+	}
+	return tres.Template, nil
+}

--- a/descope/internal/mgmt/jwttemplate_test.go
+++ b/descope/internal/mgmt/jwttemplate_test.go
@@ -1,0 +1,180 @@
+package mgmt
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/descope/go-sdk/descope"
+	"github.com/descope/go-sdk/descope/tests/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJWTTemplateCreateSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		tmpl, ok := req["template"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "my-template", tmpl["name"])
+	}, map[string]any{"template": map[string]any{"id": "T1", "name": "my-template"}}))
+	res, err := mgmt.JWTTemplate().Create(context.Background(), &descope.JWTTemplate{Name: "my-template"})
+	require.NoError(t, err)
+	require.Equal(t, "T1", res.ID)
+	require.Equal(t, "my-template", res.Name)
+}
+
+func TestJWTTemplateCreateError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := mgmt.JWTTemplate().Create(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestJWTTemplateUpdateSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		tmpl, ok := req["template"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "T1", tmpl["id"])
+	}, map[string]any{"template": map[string]any{"id": "T1", "name": "updated"}}))
+	res, err := mgmt.JWTTemplate().Update(context.Background(), &descope.JWTTemplate{ID: "T1", Name: "updated"})
+	require.NoError(t, err)
+	require.Equal(t, "updated", res.Name)
+}
+
+func TestJWTTemplateUpdateError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := mgmt.JWTTemplate().Update(context.Background(), nil)
+	require.Error(t, err)
+	_, err = mgmt.JWTTemplate().Update(context.Background(), &descope.JWTTemplate{Name: "no-id"})
+	require.Error(t, err)
+}
+
+func TestJWTTemplateDeleteSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "T1", req["id"])
+	}))
+	err := mgmt.JWTTemplate().Delete(context.Background(), "T1")
+	require.NoError(t, err)
+}
+
+func TestJWTTemplateDeleteError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	err := mgmt.JWTTemplate().Delete(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestJWTTemplateListSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+	}, map[string]any{"templates": []map[string]any{
+		{"id": "T1", "name": "a"},
+		{"id": "T2", "name": "b"},
+	}}))
+	res, err := mgmt.JWTTemplate().List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	require.Equal(t, "a", res[0].Name)
+}
+
+func TestJWTTemplateListError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	res, err := mgmt.JWTTemplate().List(context.Background())
+	require.Error(t, err)
+	require.Nil(t, res)
+}
+
+func TestJWTTemplateLoadSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "T1", req["id"])
+	}, map[string]any{"template": map[string]any{"id": "T1", "name": "a"}}))
+	res, err := mgmt.JWTTemplate().Load(context.Background(), "T1")
+	require.NoError(t, err)
+	require.Equal(t, "T1", res.ID)
+}
+
+func TestJWTTemplateLoadError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := mgmt.JWTTemplate().Load(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestJWTTemplateValidateSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "T1", req["id"])
+	}, map[string]any{"valid": false, "issues": []map[string]any{
+		{"field": "name", "code": "required", "message": "name is required"},
+	}}))
+	res, err := mgmt.JWTTemplate().Validate(context.Background(), "T1", nil)
+	require.NoError(t, err)
+	require.False(t, res.Valid)
+	require.Len(t, res.Issues, 1)
+	require.Equal(t, "required", res.Issues[0].Code)
+}
+
+func TestJWTTemplateValidateError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := mgmt.JWTTemplate().Validate(context.Background(), "", nil)
+	require.Error(t, err)
+}
+
+func TestJWTTemplateListLibrarySuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+	}, map[string]any{"entries": []map[string]any{
+		{"id": "L1", "name": "starter", "experimental": true},
+	}}))
+	res, err := mgmt.JWTTemplate().ListLibrary(context.Background())
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, "starter", res[0].Name)
+	require.True(t, res[0].Experimental)
+}
+
+func TestJWTTemplateLoadLibraryEntrySuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "L1", req["id"])
+	}, map[string]any{"entry": map[string]any{"id": "L1", "name": "starter"}}))
+	res, err := mgmt.JWTTemplate().LoadLibraryEntry(context.Background(), "L1")
+	require.NoError(t, err)
+	require.Equal(t, "L1", res.ID)
+}
+
+func TestJWTTemplateLoadLibraryEntryError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := mgmt.JWTTemplate().LoadLibraryEntry(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestJWTTemplateApplyFromLibrarySuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "L1", req["libraryEntryId"])
+		require.Equal(t, "renamed", req["nameOverride"])
+	}, map[string]any{"template": map[string]any{"id": "T9", "name": "renamed"}}))
+	res, err := mgmt.JWTTemplate().ApplyFromLibrary(context.Background(), &descope.ApplyJWTTemplateFromLibraryRequest{
+		LibraryEntryID: "L1",
+		NameOverride:   "renamed",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "T9", res.ID)
+}
+
+func TestJWTTemplateApplyFromLibraryError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	_, err := mgmt.JWTTemplate().ApplyFromLibrary(context.Background(), nil)
+	require.Error(t, err)
+	_, err = mgmt.JWTTemplate().ApplyFromLibrary(context.Background(), &descope.ApplyJWTTemplateFromLibraryRequest{})
+	require.Error(t, err)
+}

--- a/descope/internal/mgmt/mgmt.go
+++ b/descope/internal/mgmt/mgmt.go
@@ -44,6 +44,7 @@ type managementService struct {
 	list                  sdk.List
 	engine                sdk.Engine
 	scopeClaimMapping     sdk.ScopeClaimMapping
+	jwtTemplate           sdk.JWTTemplate
 }
 
 func NewManagement(conf ManagementParams, provider *auth.Provider, c *api.Client) *managementService {
@@ -72,6 +73,7 @@ func NewManagement(conf ManagementParams, provider *auth.Provider, c *api.Client
 	service.list = &lists{managementBase: base}
 	service.engine = &engine{managementBase: base}
 	service.scopeClaimMapping = &scopeClaimMapping{managementBase: base}
+	service.jwtTemplate = &jwtTemplate{managementBase: base}
 	return service
 }
 
@@ -188,6 +190,11 @@ func (mgmt *managementService) Engine() sdk.Engine {
 func (mgmt *managementService) ScopeClaimMapping() sdk.ScopeClaimMapping {
 	mgmt.ensureManagementKey()
 	return mgmt.scopeClaimMapping
+}
+
+func (mgmt *managementService) JWTTemplate() sdk.JWTTemplate {
+	mgmt.ensureManagementKey()
+	return mgmt.jwtTemplate
 }
 
 func (mgmt *managementService) ensureManagementKey() {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1495,6 +1495,46 @@ type Management interface {
 
 	// Provides functions for managing the project-wide OIDC scope-to-claim mapping.
 	ScopeClaimMapping() ScopeClaimMapping
+
+	// Provides functions for managing JWT templates in a project.
+	JWTTemplate() JWTTemplate
+}
+
+// JWTTemplate provides functions for managing JWT templates in a project.
+type JWTTemplate interface {
+	// Create a new JWT template and return the created template.
+	Create(ctx context.Context, template *descope.JWTTemplate) (*descope.JWTTemplate, error)
+
+	// Update an existing JWT template (identified by its ID) and return the updated template.
+	//
+	// IMPORTANT: All fields will override whatever values are currently set
+	// in the existing template. Use carefully.
+	Update(ctx context.Context, template *descope.JWTTemplate) (*descope.JWTTemplate, error)
+
+	// Delete an existing JWT template by id.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	Delete(ctx context.Context, id string) error
+
+	// List all JWT templates in the project.
+	List(ctx context.Context) ([]*descope.JWTTemplate, error)
+
+	// Load a JWT template by id.
+	Load(ctx context.Context, id string) (*descope.JWTTemplate, error)
+
+	// Validate a JWT template. Either an existing template id or an inline template
+	// (or both) may be provided. Returns the validation result and any issues found.
+	Validate(ctx context.Context, id string, template *descope.JWTTemplate) (*descope.JWTTemplateValidationResult, error)
+
+	// ListLibrary lists the read-only starter JWT templates shipped by Descope.
+	ListLibrary(ctx context.Context) ([]*descope.JWTTemplateLibraryEntry, error)
+
+	// LoadLibraryEntry loads a single library entry by id.
+	LoadLibraryEntry(ctx context.Context, id string) (*descope.JWTTemplateLibraryEntry, error)
+
+	// ApplyFromLibrary creates a new JWT template from a library entry, applying any
+	// provided overrides, and returns the created template.
+	ApplyFromLibrary(ctx context.Context, request *descope.ApplyJWTTemplateFromLibraryRequest) (*descope.JWTTemplate, error)
 }
 
 // ScopeClaimMapping provides functions for managing the project-wide mapping of

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -32,6 +32,7 @@ type MockManagement struct {
 	*MockList
 	*MockEngine
 	*MockScopeClaimMapping
+	*MockJWTTemplate
 }
 
 func (m *MockManagement) JWT() sdk.JWT {
@@ -124,6 +125,10 @@ func (m *MockManagement) Engine() sdk.Engine {
 
 func (m *MockManagement) ScopeClaimMapping() sdk.ScopeClaimMapping {
 	return m.MockScopeClaimMapping
+}
+
+func (m *MockManagement) JWTTemplate() sdk.JWTTemplate {
+	return m.MockJWTTemplate
 }
 
 // Mock JWT
@@ -2848,4 +2853,98 @@ func (m *MockScopeClaimMapping) Set(_ context.Context, mappings []*descope.Scope
 
 func (m *MockScopeClaimMapping) Delete(_ context.Context) error {
 	return m.DeleteError
+}
+
+// Mock JWT Template
+
+type MockJWTTemplate struct {
+	CreateAssert   func(template *descope.JWTTemplate)
+	CreateResponse *descope.JWTTemplate
+	CreateError    error
+
+	UpdateAssert   func(template *descope.JWTTemplate)
+	UpdateResponse *descope.JWTTemplate
+	UpdateError    error
+
+	DeleteAssert func(id string)
+	DeleteError  error
+
+	ListResponse []*descope.JWTTemplate
+	ListError    error
+
+	LoadAssert   func(id string)
+	LoadResponse *descope.JWTTemplate
+	LoadError    error
+
+	ValidateAssert   func(id string, template *descope.JWTTemplate)
+	ValidateResponse *descope.JWTTemplateValidationResult
+	ValidateError    error
+
+	ListLibraryResponse []*descope.JWTTemplateLibraryEntry
+	ListLibraryError    error
+
+	LoadLibraryEntryAssert   func(id string)
+	LoadLibraryEntryResponse *descope.JWTTemplateLibraryEntry
+	LoadLibraryEntryError    error
+
+	ApplyFromLibraryAssert   func(request *descope.ApplyJWTTemplateFromLibraryRequest)
+	ApplyFromLibraryResponse *descope.JWTTemplate
+	ApplyFromLibraryError    error
+}
+
+func (m *MockJWTTemplate) Create(_ context.Context, template *descope.JWTTemplate) (*descope.JWTTemplate, error) {
+	if m.CreateAssert != nil {
+		m.CreateAssert(template)
+	}
+	return m.CreateResponse, m.CreateError
+}
+
+func (m *MockJWTTemplate) Update(_ context.Context, template *descope.JWTTemplate) (*descope.JWTTemplate, error) {
+	if m.UpdateAssert != nil {
+		m.UpdateAssert(template)
+	}
+	return m.UpdateResponse, m.UpdateError
+}
+
+func (m *MockJWTTemplate) Delete(_ context.Context, id string) error {
+	if m.DeleteAssert != nil {
+		m.DeleteAssert(id)
+	}
+	return m.DeleteError
+}
+
+func (m *MockJWTTemplate) List(_ context.Context) ([]*descope.JWTTemplate, error) {
+	return m.ListResponse, m.ListError
+}
+
+func (m *MockJWTTemplate) Load(_ context.Context, id string) (*descope.JWTTemplate, error) {
+	if m.LoadAssert != nil {
+		m.LoadAssert(id)
+	}
+	return m.LoadResponse, m.LoadError
+}
+
+func (m *MockJWTTemplate) Validate(_ context.Context, id string, template *descope.JWTTemplate) (*descope.JWTTemplateValidationResult, error) {
+	if m.ValidateAssert != nil {
+		m.ValidateAssert(id, template)
+	}
+	return m.ValidateResponse, m.ValidateError
+}
+
+func (m *MockJWTTemplate) ListLibrary(_ context.Context) ([]*descope.JWTTemplateLibraryEntry, error) {
+	return m.ListLibraryResponse, m.ListLibraryError
+}
+
+func (m *MockJWTTemplate) LoadLibraryEntry(_ context.Context, id string) (*descope.JWTTemplateLibraryEntry, error) {
+	if m.LoadLibraryEntryAssert != nil {
+		m.LoadLibraryEntryAssert(id)
+	}
+	return m.LoadLibraryEntryResponse, m.LoadLibraryEntryError
+}
+
+func (m *MockJWTTemplate) ApplyFromLibrary(_ context.Context, request *descope.ApplyJWTTemplateFromLibraryRequest) (*descope.JWTTemplate, error) {
+	if m.ApplyFromLibraryAssert != nil {
+		m.ApplyFromLibraryAssert(request)
+	}
+	return m.ApplyFromLibraryResponse, m.ApplyFromLibraryError
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -1910,3 +1910,70 @@ type ListCheckTextRequest struct {
 	ID   string `json:"id"`
 	Text string `json:"text"`
 }
+
+// JWTTemplate is a JWT template definition in a project.
+type JWTTemplate struct {
+	ID                      string         `json:"id,omitempty"`
+	Name                    string         `json:"name,omitempty"`
+	Description             string         `json:"description,omitempty"`
+	Template                map[string]any `json:"template,omitempty"`
+	Source                  string         `json:"source,omitempty"`
+	Tags                    []string       `json:"tags,omitempty"`
+	AuthSchema              string         `json:"authSchema,omitempty"`
+	Type                    string         `json:"type,omitempty"`
+	ConformanceIssuer       bool           `json:"conformanceIssuer,omitempty"`
+	AutoDCT                 bool           `json:"autoDCT,omitempty"`
+	EnforceIssuer           bool           `json:"enforceIssuer,omitempty"`
+	EmptyClaimPolicy        string         `json:"emptyClaimPolicy,omitempty"`
+	OverrideSubject         bool           `json:"overrideSubject,omitempty"`
+	IssuerType              string         `json:"issuerType,omitempty"`
+	OmitCustomClaimsFromDSR bool           `json:"omitCustomClaimsFromDSR,omitempty"`
+	AddJti                  bool           `json:"addJti,omitempty"`
+	ExcludePermissions      bool           `json:"excludePermissions,omitempty"`
+}
+
+// JWTTemplateLibraryEntry is a read-only starter JWT template shipped by Descope.
+type JWTTemplateLibraryEntry struct {
+	ID                      string         `json:"id,omitempty"`
+	Name                    string         `json:"name,omitempty"`
+	Description             string         `json:"description,omitempty"`
+	Template                map[string]any `json:"template,omitempty"`
+	Tags                    []string       `json:"tags,omitempty"`
+	AuthSchema              string         `json:"authSchema,omitempty"`
+	Type                    string         `json:"type,omitempty"`
+	ConformanceIssuer       bool           `json:"conformanceIssuer,omitempty"`
+	AutoDCT                 bool           `json:"autoDCT,omitempty"`
+	EnforceIssuer           bool           `json:"enforceIssuer,omitempty"`
+	EmptyClaimPolicy        string         `json:"emptyClaimPolicy,omitempty"`
+	OverrideSubject         bool           `json:"overrideSubject,omitempty"`
+	IssuerType              string         `json:"issuerType,omitempty"`
+	OmitCustomClaimsFromDSR bool           `json:"omitCustomClaimsFromDSR,omitempty"`
+	AddJti                  bool           `json:"addJti,omitempty"`
+	ExcludePermissions      bool           `json:"excludePermissions,omitempty"`
+	Experimental            bool           `json:"experimental,omitempty"`
+	LogoLight               string         `json:"logoLight,omitempty"`
+	LogoDark                string         `json:"logoDark,omitempty"`
+}
+
+// JWTTemplateValidationIssue is a single validation failure produced when validating a JWT template.
+type JWTTemplateValidationIssue struct {
+	Field   string `json:"field,omitempty"`
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+// JWTTemplateValidationResult is the result of validating a JWT template.
+type JWTTemplateValidationResult struct {
+	Valid  bool                          `json:"valid"`
+	Issues []*JWTTemplateValidationIssue `json:"issues,omitempty"`
+}
+
+// ApplyJWTTemplateFromLibraryRequest applies a library entry as a new template, with optional overrides.
+type ApplyJWTTemplateFromLibraryRequest struct {
+	LibraryEntryID      string         `json:"libraryEntryId,omitempty"`
+	NameOverride        string         `json:"nameOverride,omitempty"`
+	DescriptionOverride string         `json:"descriptionOverride,omitempty"`
+	TagsOverride        []string       `json:"tagsOverride,omitempty"`
+	TemplateOverride    map[string]any `json:"templateOverride,omitempty"`
+}


### PR DESCRIPTION
Fixes descope/etc#16608

[View workflow run](https://github.com/descope/shuni/actions/runs/28372890296)

Done. Committed `feat(mgmt): add JWT template management API` (5860180) on this fresh branch.

## Larger slice — new JWTTemplate manager (9 endpoints)

Re-diffed the live spec against the current SDK (prior PRs #789/#790 now merged → **87** still missing) and implemented a complete, self-contained new feature area: the **JWT Templates** management API.

| Method | Endpoint |
|---|---|
| `Create` / `Update` / `Delete` | `mgmt/jwt/templates/{create,update,delete}` |
| `List` / `Load` / `Validate` | `mgmt/jwt/templates/{list,load,validate}` |
| `ListLibrary` / `LoadLibraryEntry` / `ApplyFromLibrary` | `mgmt/jwt/templates/library/{list,load,apply}` |

This was a deeper slice than the prior two because it's a brand-new manager, not just extensions of existing ones — so it touches the full wiring stack:

- **`types.go`** — `JWTTemplate`, `JWTTemplateLibraryEntry`, `JWTTemplateValidationIssue`, `JWTTemplateValidationResult`, `ApplyJWTTemplateFromLibraryRequest`
- **`api/client.go`** — 9 endpoint fields + init + route methods
- **`sdk/mgmt.go`** — new `JWTTemplate` interface + `Management.JWTTemplate()` accessor
- **`internal/mgmt/jwttemplate.go`** — new manager implementation
- **`internal/mgmt/mgmt.go`** — manager registration + accessor
- **`tests/mocks/mgmt/managementmock.go`** — `MockJWTTemplate` + embedding
- **`jwttemplate_test.go`** — 17 new tests
- **`README.md`** — new "Manage JWT Templates" section + TOC entry

All 4 quality checks pass; `go.mod`/`go.sum` unchanged.

## Scope note
Remaining ~78 gaps are other net-new areas, each best as its own PR: MCP servers (15), resource + resourcepolicy (19), FGA backups/AuthZEN (9), policies/rule (5), localization (4), project export/import + async clone (4), SSO custom-attributes/provider-ids (4), tenant admin-links (4), plus singletons like `accesskey/import` and `user/passkeys/import`. A couple of listed paths remain false positives (`mgmt/list/{id}`, `mgmt/outbound/app/{id}` are path-param GET variants already covered via query params).

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*