### PR TITLE
fix(management): add missing management api endpoints for sdk parity

### DIFF
--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -328,6 +328,20 @@ var (
 			jwtTemplateLibraryList:                     "mgmt/jwt/templates/library/list",
 			jwtTemplateLibraryLoad:                     "mgmt/jwt/templates/library/load",
 			jwtTemplateLibraryApply:                    "mgmt/jwt/templates/library/apply",
+			mcpServerCreate:                            "mgmt/mcp/server/create",
+			mcpServerUpdate:                            "mgmt/mcp/server/update",
+			mcpServerDelete:                            "mgmt/mcp/server/delete",
+			mcpServerLoad:                              "mgmt/mcp/server/load",
+			mcpServersLoadAll:                          "mgmt/mcp/servers/all",
+			mcpServersDelete:                           "mgmt/mcp/servers/delete",
+			mcpServerClientCreate:                      "mgmt/mcp/server/client/create",
+			mcpServerClientUpdate:                      "mgmt/mcp/server/client/update",
+			mcpServerClientDelete:                      "mgmt/mcp/server/client/delete",
+			mcpServerClientLoad:                        "mgmt/mcp/server/client/load",
+			mcpServerClientSecret:                      "mgmt/mcp/server/client/secret",
+			mcpServerClientSecretRotate:                "mgmt/mcp/server/client/secret/rotate",
+			mcpServerClientsDelete:                     "mgmt/mcp/server/clients/delete",
+			mcpServerClientsSearch:                     "mgmt/mcp/server/clients/search",
 			scopeClaimMappingGet:                       "mgmt/scopeClaimMapping/get",
 			scopeClaimMappingSet:                       "mgmt/scopeClaimMapping/set",
 			scopeClaimMappingDelete:                    "mgmt/scopeClaimMapping/delete",
@@ -679,6 +693,21 @@ type mgmtEndpoints struct {
 	jwtTemplateLibraryList  string
 	jwtTemplateLibraryLoad  string
 	jwtTemplateLibraryApply string
+
+	mcpServerCreate             string
+	mcpServerUpdate             string
+	mcpServerDelete             string
+	mcpServerLoad               string
+	mcpServersLoadAll           string
+	mcpServersDelete            string
+	mcpServerClientCreate       string
+	mcpServerClientUpdate       string
+	mcpServerClientDelete       string
+	mcpServerClientLoad         string
+	mcpServerClientSecret       string
+	mcpServerClientSecretRotate string
+	mcpServerClientsDelete      string
+	mcpServerClientsSearch      string
 
 	scopeClaimMappingGet    string
 	scopeClaimMappingSet    string
@@ -1870,6 +1899,62 @@ func (e *endpoints) ManagementJWTTemplateLibraryLoad() string {
 
 func (e *endpoints) ManagementJWTTemplateLibraryApply() string {
 	return path.Join(e.version, e.mgmt.jwtTemplateLibraryApply)
+}
+
+func (e *endpoints) ManagementMCPServerCreate() string {
+	return path.Join(e.version, e.mgmt.mcpServerCreate)
+}
+
+func (e *endpoints) ManagementMCPServerUpdate() string {
+	return path.Join(e.version, e.mgmt.mcpServerUpdate)
+}
+
+func (e *endpoints) ManagementMCPServerDelete() string {
+	return path.Join(e.version, e.mgmt.mcpServerDelete)
+}
+
+func (e *endpoints) ManagementMCPServerLoad() string {
+	return path.Join(e.version, e.mgmt.mcpServerLoad)
+}
+
+func (e *endpoints) ManagementMCPServersLoadAll() string {
+	return path.Join(e.version, e.mgmt.mcpServersLoadAll)
+}
+
+func (e *endpoints) ManagementMCPServersDelete() string {
+	return path.Join(e.version, e.mgmt.mcpServersDelete)
+}
+
+func (e *endpoints) ManagementMCPServerClientCreate() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientCreate)
+}
+
+func (e *endpoints) ManagementMCPServerClientUpdate() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientUpdate)
+}
+
+func (e *endpoints) ManagementMCPServerClientDelete() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientDelete)
+}
+
+func (e *endpoints) ManagementMCPServerClientLoad() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientLoad)
+}
+
+func (e *endpoints) ManagementMCPServerClientSecret() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientSecret)
+}
+
+func (e *endpoints) ManagementMCPServerClientSecretRotate() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientSecretRotate)
+}
+
+func (e *endpoints) ManagementMCPServerClientsDelete() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientsDelete)
+}
+
+func (e *endpoints) ManagementMCPServerClientsSearch() string {
+	return path.Join(e.version, e.mgmt.mcpServerClientsSearch)
 }
 
 func (e *endpoints) ManagementScopeClaimMappingGet() string {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1498,6 +1498,67 @@ type Management interface {
 
 	// Provides functions for managing JWT templates in a project.
 	JWTTemplate() JWTTemplate
+
+	// Provides functions for managing MCP servers and their clients in a project.
+	MCPServer() MCPServer
+}
+
+// MCPServer provides functions for managing MCP servers and their clients in a project.
+type MCPServer interface {
+	// Create a new MCP server and return the created server.
+	Create(ctx context.Context, server *descope.MCPServer) (*descope.MCPServer, error)
+
+	// Update an existing MCP server (identified by its ID) and return the updated server.
+	//
+	// IMPORTANT: All fields will override whatever values are currently set
+	// in the existing server. Use carefully.
+	Update(ctx context.Context, server *descope.MCPServer) (*descope.MCPServer, error)
+
+	// Delete an existing MCP server by id.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	Delete(ctx context.Context, id string) error
+
+	// DeleteBatch deletes multiple MCP servers by id in a single request.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	DeleteBatch(ctx context.Context, ids []string) error
+
+	// Load an MCP server by id.
+	Load(ctx context.Context, id string) (*descope.MCPServer, error)
+
+	// LoadAll loads all MCP servers in the project.
+	LoadAll(ctx context.Context) ([]*descope.MCPServer, error)
+
+	// CreateClient creates a new client for an MCP server. The returned response includes
+	// the generated client secret (Cleartext), which is only available at creation time.
+	CreateClient(ctx context.Context, client *descope.MCPServerClientRequest) (*descope.MCPServerClientCreateResponse, error)
+
+	// UpdateClient updates an existing MCP server client and returns the updated client.
+	UpdateClient(ctx context.Context, client *descope.MCPServerClientRequest) (*descope.MCPServerClient, error)
+
+	// DeleteClient deletes an MCP server client by id within the given MCP server.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	DeleteClient(ctx context.Context, mcpServerID, id string) error
+
+	// DeleteClients deletes multiple MCP server clients by id within the given MCP server.
+	//
+	// IMPORTANT: This action is irreversible. Use carefully.
+	DeleteClients(ctx context.Context, mcpServerID string, ids []string) error
+
+	// LoadClient loads an MCP server client by its id or client id within the given MCP server.
+	LoadClient(ctx context.Context, mcpServerID, id, clientID string) (*descope.MCPServerClient, error)
+
+	// GetClientSecret returns the cleartext secret of an MCP server client.
+	GetClientSecret(ctx context.Context, mcpServerID, id string) (string, error)
+
+	// RotateClientSecret rotates the secret of an MCP server client and returns the new
+	// cleartext secret. The previous secret is immediately invalidated.
+	RotateClientSecret(ctx context.Context, mcpServerID, id string) (string, error)
+
+	// SearchClients searches MCP server clients and returns the matching clients and the total count.
+	SearchClients(ctx context.Context, options *descope.MCPServerClientSearchOptions) ([]*descope.MCPServerClient, int, error)
 }
 
 // JWTTemplate provides functions for managing JWT templates in a project.

--- a/descope/types.go
+++ b/descope/types.go
@@ -1977,3 +1977,134 @@ type ApplyJWTTemplateFromLibraryRequest struct {
 	TagsOverride        []string       `json:"tagsOverride,omitempty"`
 	TemplateOverride    map[string]any `json:"templateOverride,omitempty"`
 }
+
+// MCPServerDynamicClientRegistration configures dynamic client registration for an MCP server.
+type MCPServerDynamicClientRegistration struct {
+	Enabled                        bool   `json:"enabled,omitempty"`
+	DisableApprovedScopesAsDefault bool   `json:"disableApprovedScopesAsDefault,omitempty"`
+	FlowID                         string `json:"flowId,omitempty"`
+}
+
+// MCPApplicationScope is a single scope offered by an MCP server.
+type MCPApplicationScope struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Optional    bool     `json:"optional,omitempty"`
+	Values      []string `json:"values,omitempty"`
+}
+
+// MCPApprovedScopes groups the scopes approved for dynamically registered MCP clients.
+type MCPApprovedScopes struct {
+	PermissionsScopes []*MCPApplicationScope `json:"permissionsScopes,omitempty"`
+	AttributesScopes  []*MCPApplicationScope `json:"attributesScopes,omitempty"`
+	ConnectionsScopes []*MCPApplicationScope `json:"connectionsScopes,omitempty"`
+}
+
+// MCPSessionSettings configures session/token behavior for an MCP server.
+type MCPSessionSettings struct {
+	Enabled                       bool   `json:"enabled,omitempty"`
+	RefreshTokenExpiration        int32  `json:"refreshTokenExpiration,omitempty"`
+	RefreshTokenExpirationUnit    string `json:"refreshTokenExpirationUnit,omitempty"`
+	SessionTokenExpiration        int32  `json:"sessionTokenExpiration,omitempty"`
+	SessionTokenExpirationUnit    string `json:"sessionTokenExpirationUnit,omitempty"`
+	UserTemplateID                string `json:"userTemplateId,omitempty"`
+	KeyTemplateID                 string `json:"keyTemplateId,omitempty"`
+	KeySessionTokenExpiration     int32  `json:"keySessionTokenExpiration,omitempty"`
+	KeySessionTokenExpirationUnit string `json:"keySessionTokenExpirationUnit,omitempty"`
+}
+
+// MCPCIMDDomainPolicy is a single client-identity-managed-domain policy entry.
+type MCPCIMDDomainPolicy struct {
+	DomainPattern string `json:"domainPattern,omitempty"`
+	Enabled       bool   `json:"enabled,omitempty"`
+}
+
+// MCPCIMDDomainPolicies groups CIMD domain policies.
+type MCPCIMDDomainPolicies struct {
+	Policies []*MCPCIMDDomainPolicy `json:"policies,omitempty"`
+}
+
+// MCPCIMDSettings configures client-identity-managed-domain behavior for an MCP server.
+type MCPCIMDSettings struct {
+	Enabled        bool                   `json:"enabled,omitempty"`
+	DomainPolicies *MCPCIMDDomainPolicies `json:"domainPolicies,omitempty"`
+}
+
+// MCPServer is an MCP server definition in a project. It is used both as input to
+// Create/Update and as the value returned by Load/LoadAll.
+type MCPServer struct {
+	ID                           string                              `json:"id,omitempty"`
+	Name                         string                              `json:"name,omitempty"`
+	Description                  string                              `json:"description,omitempty"`
+	DynamicRegistration          *MCPServerDynamicClientRegistration `json:"dynamicRegistration,omitempty"`
+	AudienceWhitelist            []string                            `json:"audienceWhitelist,omitempty"`
+	ApprovedScopes               *MCPApprovedScopes                  `json:"approvedScopes,omitempty"`
+	ApprovedCallbackUrls         []string                            `json:"approvedCallbackUrls,omitempty"`
+	LoginPageURL                 string                              `json:"loginPageURL,omitempty"`
+	SessionSettings              *MCPSessionSettings                 `json:"sessionSettings,omitempty"`
+	Tags                         []string                            `json:"tags,omitempty"`
+	Logo                         string                              `json:"logo,omitempty"`
+	CIMDSettings                 *MCPCIMDSettings                    `json:"cimdSettings,omitempty"`
+	SkipConsentScreen            bool                                `json:"skipConsentScreen,omitempty"`
+	ConsentFlowID                string                              `json:"consentFlowId,omitempty"`
+	ConsentFlowHostingURL        string                              `json:"consentFlowHostingURL,omitempty"`
+	ForceAddAllAuthorizationInfo bool                                `json:"forceAddAllAuthorizationInfo,omitempty"`
+}
+
+// MCPServerClient is a client registered against an MCP server.
+type MCPServerClient struct {
+	ID                           string   `json:"id,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	ClientID                     string   `json:"clientId,omitempty"`
+	MCPServerID                  string   `json:"mcpServerId,omitempty"`
+	ApprovedCallbackUrls         []string `json:"approvedCallbackUrls,omitempty"`
+	Scopes                       []string `json:"scopes,omitempty"`
+	Tags                         []string `json:"tags,omitempty"`
+	Logo                         string   `json:"logo,omitempty"`
+	RegistrationType             string   `json:"registrationType,omitempty"`
+	Status                       string   `json:"status,omitempty"`
+	ForceAddAllAuthorizationInfo bool     `json:"forceAddAllAuthorizationInfo,omitempty"`
+	AllowedTenants               []string `json:"allowedTenants,omitempty"`
+}
+
+// MCPServerClientRequest is the input for creating or updating an MCP server client.
+// ID is required for updates and ignored on create.
+type MCPServerClientRequest struct {
+	ID                           string   `json:"id,omitempty"`
+	MCPServerID                  string   `json:"mcpServerId,omitempty"`
+	Name                         string   `json:"name,omitempty"`
+	ApprovedCallbackUrls         []string `json:"approvedCallbackUrls,omitempty"`
+	Scopes                       []string `json:"scopes,omitempty"`
+	Tags                         []string `json:"tags,omitempty"`
+	Logo                         string   `json:"logo,omitempty"`
+	ForceAddAllAuthorizationInfo bool     `json:"forceAddAllAuthorizationInfo,omitempty"`
+	AllowedTenants               []string `json:"allowedTenants,omitempty"`
+}
+
+// MCPServerClientCreateResponse is returned when creating an MCP server client.
+// Cleartext is the generated client secret and is only returned on create.
+type MCPServerClientCreateResponse struct {
+	ID        string `json:"id,omitempty"`
+	ClientID  string `json:"clientId,omitempty"`
+	Cleartext string `json:"cleartext,omitempty"`
+}
+
+// MCPSortField specifies a sort field and direction for MCP client searches.
+type MCPSortField struct {
+	Field string `json:"field,omitempty"`
+	Desc  bool   `json:"desc,omitempty"`
+}
+
+// MCPServerClientSearchOptions are the filters for searching MCP server clients.
+type MCPServerClientSearchOptions struct {
+	MCPServerID        string          `json:"mcpServerId,omitempty"`
+	Page               int32           `json:"page,omitempty"`
+	Limit              int32           `json:"limit,omitempty"`
+	Text               string          `json:"text,omitempty"`
+	Name               string          `json:"name,omitempty"`
+	ClientID           string          `json:"clientId,omitempty"`
+	Status             string          `json:"status,omitempty"`
+	RegistrationMethod string          `json:"registrationMethod,omitempty"`
+	Tag                string          `json:"tag,omitempty"`
+	Sort               []*MCPSortField `json:"sort,omitempty"`
+}


### PR DESCRIPTION
Fixes descope/etc#16608

[View workflow run](https://github.com/descope/shuni/actions/runs/28373609705)

API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*