### PR TITLE
fix(mgmt): send templateId and templateOptions in InviteBatch request

### DIFF
--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -1076,6 +1076,12 @@ func makeCreateUsersBatchRequest(users []*descope.BatchUser, options *descope.In
 		if options.SendSMS != nil {
 			req["sendSMS"] = *options.SendSMS
 		}
+		if options.TemplateOptions != nil {
+			req["templateOptions"] = options.TemplateOptions
+		}
+		if len(options.TemplateID) > 0 {
+			req["templateId"] = options.TemplateID
+		}
 		if len(options.Locale) > 0 {
 			req["locale"] = options.Locale
 		}

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -170,6 +170,8 @@ func TestUsersInviteBatchSuccess(t *testing.T) {
 				assert.Nil(t, req["sendMail"])
 				assert.EqualValues(t, true, req["sendSMS"])
 				assert.EqualValues(t, "fr-FR", req["locale"])
+				assert.EqualValues(t, "tmpl-1", req["templateId"])
+				assert.EqualValues(t, map[string]any{"k1": "v1"}, req["templateOptions"])
 			} else if sendMail {
 				assert.EqualValues(t, true, req["invite"])
 				assert.EqualValues(t, "https://some.domain.com", req["inviteUrl"])
@@ -212,9 +214,11 @@ func TestUsersInviteBatchSuccess(t *testing.T) {
 	}, response))
 
 	res, err := m.User().InviteBatch(context.Background(), users, &descope.InviteOptions{
-		InviteURL: "https://some.domain.com",
-		SendSMS:   &sendSMS,
-		Locale:    "fr-FR",
+		InviteURL:       "https://some.domain.com",
+		SendSMS:         &sendSMS,
+		Locale:          "fr-FR",
+		TemplateID:      "tmpl-1",
+		TemplateOptions: map[string]string{"k1": "v1"},
 	})
 	require.True(t, called)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`InviteOptions.TemplateID` and `InviteOptions.TemplateOptions` were silently dropped when building the batch create request body (`makeCreateUsersBatchRequest`), so `InviteBatch` always sent invitations with the default template.

- `TemplateID` is tagged `json:"-"` on `InviteOptions`, so it relies on each call site adding it to the request map explicitly - the single-user path (`makeCreateUserRequest`) does this, the batch path did not
- `TemplateOptions` was likewise only added on the single-user path

The backend batch endpoint (`POST /v1/mgmt/user/create/batch`) already supports both fields, so this is purely an SDK serialization gap.

## Changes

- `makeCreateUsersBatchRequest`: pass `templateOptions` and `templateId` in the request body, matching the single-user create path
- Extend `TestUsersInviteBatchSuccess` to assert both fields are sent

## Testing

- `go test ./descope/internal/mgmt/` - 650 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)