### PR TITLE
feat: expose lastSuccessTestTime on SSO settings load response

### DIFF
--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -442,6 +442,7 @@ func TestLoadSettingsSuccess(t *testing.T) {
 			},
 			"configFGATenantIDResourcePrefix": "tenant_prefix_",
 			"configFGATenantIDResourceSuffix": "_tenant_suffix",
+			"lastSuccessTestTime":             777,
 		},
 		"oidc": map[string]any{
 			"name":        "myName",
@@ -452,6 +453,7 @@ func TestLoadSettingsSuccess(t *testing.T) {
 			"userAttrMapping": map[string]any{
 				"givenName": "myGivenName",
 			},
+			"lastSuccessTestTime": 888,
 		},
 	}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
@@ -499,6 +501,7 @@ func TestLoadSettingsSuccess(t *testing.T) {
 	assert.EqualValues(t, "ns3", res.Saml.FgaMappings["group2"].Relations[0].Namespace)
 	assert.EqualValues(t, "tenant_prefix_", res.Saml.ConfigFGATenantIDResourcePrefix)
 	assert.EqualValues(t, "_tenant_suffix", res.Saml.ConfigFGATenantIDResourceSuffix)
+	assert.EqualValues(t, 777, res.Saml.LastSuccessTestTime)
 
 	require.NotNil(t, res.Oidc)
 	assert.EqualValues(t, "myName", res.Oidc.Name)
@@ -508,6 +511,7 @@ func TestLoadSettingsSuccess(t *testing.T) {
 	assert.EqualValues(t, "http://dummy.com", res.Oidc.UserDataURL)
 	require.NotNil(t, res.Oidc.AttributeMapping)
 	assert.EqualValues(t, "myGivenName", res.Oidc.AttributeMapping.GivenName)
+	assert.EqualValues(t, 888, res.Oidc.LastSuccessTestTime)
 	require.Empty(t, res.SSOID)
 }
 

--- a/descope/types.go
+++ b/descope/types.go
@@ -149,6 +149,7 @@ type SSOSAMLSettingsResponse struct {
 	FgaMappings                     map[string]*FGAGroupMapping `json:"fgaMappings,omitempty"`
 	ConfigFGATenantIDResourcePrefix string                      `json:"configFGATenantIDResourcePrefix,omitempty"`
 	ConfigFGATenantIDResourceSuffix string                      `json:"configFGATenantIDResourceSuffix,omitempty"`
+	LastSuccessTestTime             int32                       `json:"lastSuccessTestTime,omitempty"` // epoch seconds of the last successful SSO test login on this configuration (read-only)
 }
 
 type SSOSAMLSettings struct {
@@ -218,6 +219,7 @@ type SSOOIDCSettings struct {
 	DefaultSSORoles      []string                    `json:"defaultSSORoles,omitempty"`
 	GroupsPriority       []string                    `json:"groupsPriority,omitempty"` // list of group names in priority order (first = highest priority)
 	FgaMappings          map[string]*FGAGroupMapping `json:"fgaMappings,omitempty"`
+	LastSuccessTestTime  int32                       `json:"lastSuccessTestTime,omitempty"` // epoch seconds of the last successful SSO test login on this configuration (read-only, ignored on configure)
 }
 
 type SSOTenantSettingsResponse struct {


### PR DESCRIPTION
## Description
The management API now returns `lastSuccessTestTime` (epoch seconds of the last successful SSO test login) on tenant SSO settings load for both SAML and OIDC configurations (descope/backend#1772). Surface it on `SSOSAMLSettingsResponse` and `SSOOIDCSettings` so callers can programmatically verify a tenant's SSO configuration was tested successfully and is active.

Related: https://github.com/descope/etc/issues/16911

🤖 Generated with [Claude Code](https://claude.com/claude-code)