### PR TITLE
feat: expose source on external Group (scim vs jit)

### DIFF
--- a/descope/types.go
+++ b/descope/types.go
@@ -1153,6 +1153,8 @@ type Group struct {
 	ID      string        `json:"id"`
 	Display string        `json:"display,omitempty"`
 	Members []GroupMember `json:"members,omitempty"`
+	// Source is the origin of the group: "scim" or "jit" (SSO SAML/OIDC assertion groups).
+	Source string `json:"source,omitempty"`
 }
 
 type FlowList struct {


### PR DESCRIPTION
Adds a `Source` field to `descope.Group` so callers can tell SCIM groups apart from SSO/JIT (SAML/OIDC assertion) groups, matching the new backend `external_groups.source` field.

Part of the JIT-idpGroups-on-refresh work (descope/etc#16923, backend descope/backend#1776).