### PR TITLE
feat(mgmt): add RemoveRecoveryCodes user management method

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,14 @@ Pass the loginId to the function to remove the user's TOTP seed.
 totpResponse, err := descopeClient.Management.User().RemoveTOTPSeed(context.Background(), loginID)
 ```
 
+#### Removing Recovery Codes
+
+Pass the loginId to the function to remove all of the user's recovery codes.
+
+```go
+err := descopeClient.Management.User().RemoveRecoveryCodes(context.Background(), loginID)
+```
+
 ### Passwords
 
 The user can also authenticate with a password, though it's recommended to

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -155,6 +155,7 @@ var (
 			userRemovePasskey:                          "mgmt/user/passkey/delete",
 			userListPasskeys:                           "mgmt/user/passkeys/list",
 			userRemoveTOTPSeed:                         "mgmt/user/totp/delete",
+			userRemoveRecoveryCodes:                    "mgmt/user/recovery-codes/delete",
 			userListTrustedDevices:                     "mgmt/user/trusteddevices/list",
 			userRemoveTrustedDevices:                   "mgmt/user/trusteddevices/remove",
 			userGetProviderToken:                       "mgmt/user/provider/token",
@@ -484,6 +485,7 @@ type mgmtEndpoints struct {
 	userRemovePasskey         string
 	userListPasskeys          string
 	userRemoveTOTPSeed        string
+	userRemoveRecoveryCodes   string
 	userGetProviderToken      string
 	userLogoutAllDevices      string
 	userAddSsoApps            string
@@ -1184,6 +1186,10 @@ func (e *endpoints) ManagementUserListPasskeys() string {
 
 func (e *endpoints) ManagementUserRemoveTOTPSeed() string {
 	return path.Join(e.version, e.mgmt.userRemoveTOTPSeed)
+}
+
+func (e *endpoints) ManagementUserRemoveRecoveryCodes() string {
+	return path.Join(e.version, e.mgmt.userRemoveRecoveryCodes)
 }
 
 func (e *endpoints) ManagementUserListTrustedDevices() string {

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -752,6 +752,16 @@ func (u *user) RemoveTOTPSeed(ctx context.Context, loginID string) error {
 	return err
 }
 
+func (u *user) RemoveRecoveryCodes(ctx context.Context, loginID string) error {
+	if loginID == "" {
+		return utils.NewInvalidArgumentError("loginID")
+	}
+
+	req := map[string]any{"loginId": loginID}
+	_, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserRemoveRecoveryCodes(), req, nil, "")
+	return err
+}
+
 type userTrustedDeviceRaw struct {
 	ID                    string `json:"id,omitempty"`
 	Name                  string `json:"name,omitempty"`

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -2158,6 +2158,30 @@ func TestUserTOTPSeedError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUserRemoveRecoveryCodesSuccess(t *testing.T) {
+	response := map[string]any{}
+	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "abc", req["loginId"])
+	}, response))
+	err := m.User().RemoveRecoveryCodes(context.Background(), "abc")
+	require.NoError(t, err)
+}
+
+func TestUserRemoveRecoveryCodesBadInput(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoOk(nil))
+	err := m.User().RemoveRecoveryCodes(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestUserRemoveRecoveryCodesError(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	err := m.User().RemoveRecoveryCodes(context.Background(), "abc")
+	require.Error(t, err)
+}
+
 func TestUserProviderTokenSuccess(t *testing.T) {
 	response := map[string]any{
 		"provider":    "pro",

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -482,6 +482,9 @@ type User interface {
 	// methods or a verified email/phone.
 	RemoveTOTPSeed(ctx context.Context, loginID string) error
 
+	// Removes all recovery codes for the user with the given login ID.
+	RemoveRecoveryCodes(ctx context.Context, loginID string) error
+
 	// Get the provider token for the given login ID.
 	// Only users that sign-in using social providers will have token.
 	// Note: The 'Manage tokens from provider' setting must be enabled.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -569,6 +569,9 @@ type MockUser struct {
 	RemoveTOTPSeedAssert func(loginID string)
 	RemoveTOTPSeedError  error
 
+	RemoveRecoveryCodesAssert func(loginID string)
+	RemoveRecoveryCodesError  error
+
 	ListTrustedDevicesAssert   func(loginIDsOrUserIDs []string)
 	ListTrustedDevicesResponse []*descope.UserTrustedDevice
 	ListTrustedDevicesError    error
@@ -980,6 +983,13 @@ func (m *MockUser) RemoveTOTPSeed(_ context.Context, loginID string) error {
 		m.RemoveTOTPSeedAssert(loginID)
 	}
 	return m.RemoveTOTPSeedError
+}
+
+func (m *MockUser) RemoveRecoveryCodes(_ context.Context, loginID string) error {
+	if m.RemoveRecoveryCodesAssert != nil {
+		m.RemoveRecoveryCodesAssert(loginID)
+	}
+	return m.RemoveRecoveryCodesError
 }
 
 func (m *MockUser) ListTrustedDevices(_ context.Context, loginIDsOrUserIDs []string) ([]*descope.UserTrustedDevice, error) {


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17502

## Related PRs
### Related PRs
- https://github.com/descope/backend/pull/2092
- https://github.com/descope/python-sdk/pull/1643
- https://github.com/descope/node-sdk/pull/784

## In a Nutshell
- Add `RemoveRecoveryCodes` user management method

## Description
Adds the SDK wrapper for the new backend endpoint `POST /v1/mgmt/user/recovery-codes/delete` (descope/backend#2092), which revokes all of a user's recovery codes. Mirrors the existing `RemoveTOTPSeed` method.

## Must
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
