### PR TITLE
docs(mgmt): accept login ID or user ID in RemoveRecoveryCodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ totpResponse, err := descopeClient.Management.User().RemoveTOTPSeed(context.Back
 
 #### Removing Recovery Codes
 
-Pass the loginId to the function to remove all of the user's recovery codes.
+Pass a login ID or user ID to the function to remove all of the user's recovery codes.
 
 ```go
 err := descopeClient.Management.User().RemoveRecoveryCodes(context.Background(), loginID)

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -752,12 +752,12 @@ func (u *user) RemoveTOTPSeed(ctx context.Context, loginID string) error {
 	return err
 }
 
-func (u *user) RemoveRecoveryCodes(ctx context.Context, loginID string) error {
-	if loginID == "" {
-		return utils.NewInvalidArgumentError("loginID")
+func (u *user) RemoveRecoveryCodes(ctx context.Context, loginIDOrUserID string) error {
+	if loginIDOrUserID == "" {
+		return utils.NewInvalidArgumentError("loginIDOrUserID")
 	}
 
-	req := map[string]any{"loginId": loginID}
+	req := map[string]any{"loginId": loginIDOrUserID}
 	_, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserRemoveRecoveryCodes(), req, nil, "")
 	return err
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -482,8 +482,8 @@ type User interface {
 	// methods or a verified email/phone.
 	RemoveTOTPSeed(ctx context.Context, loginID string) error
 
-	// Removes all recovery codes for the user with the given login ID.
-	RemoveRecoveryCodes(ctx context.Context, loginID string) error
+	// Removes all recovery codes for the user with the given login ID or user ID.
+	RemoveRecoveryCodes(ctx context.Context, loginIDOrUserID string) error
 
 	// Get the provider token for the given login ID.
 	// Only users that sign-in using social providers will have token.

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -569,7 +569,7 @@ type MockUser struct {
 	RemoveTOTPSeedAssert func(loginID string)
 	RemoveTOTPSeedError  error
 
-	RemoveRecoveryCodesAssert func(loginID string)
+	RemoveRecoveryCodesAssert func(loginIDOrUserID string)
 	RemoveRecoveryCodesError  error
 
 	ListTrustedDevicesAssert   func(loginIDsOrUserIDs []string)
@@ -985,9 +985,9 @@ func (m *MockUser) RemoveTOTPSeed(_ context.Context, loginID string) error {
 	return m.RemoveTOTPSeedError
 }
 
-func (m *MockUser) RemoveRecoveryCodes(_ context.Context, loginID string) error {
+func (m *MockUser) RemoveRecoveryCodes(_ context.Context, loginIDOrUserID string) error {
 	if m.RemoveRecoveryCodesAssert != nil {
-		m.RemoveRecoveryCodesAssert(loginID)
+		m.RemoveRecoveryCodesAssert(loginIDOrUserID)
 	}
 	return m.RemoveRecoveryCodesError
 }


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17502

## Related PRs
### Related PRs
- https://github.com/descope/backend/pull/2092
- https://github.com/descope/go-sdk/pull/818

## In a Nutshell
- `RemoveRecoveryCodes` accepts a login ID or user ID

## Description
Follow-up to #818: the backend resolves the identifier as either a login ID or a user ID (descope/backend#2092), and the public API field is named `identifier` like the other user endpoints. Rename the parameter to `loginIDOrUserID` and update docs to match the SDK's dual-ID convention (`Update`, `Delete`, `UpdateEmail`). No wire change.

## Must
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
