### PR TITLE
docs: fix boundary wording for time-filter params

### DIFF
--- a/descope/types.go
+++ b/descope/types.go
@@ -1115,9 +1115,9 @@ type CustomAttributeOption struct {
 // CustomAttributes map is an optional filter for custom attributes:
 // where the keys are the attribute names and the values are either a value we are searching for or list of these values in a slice.
 // We currently support string, int and bool values
-// FromCreatedTime - only include users created on or after this time (Unix epoch milliseconds). Leave at 0 to disable.
+// FromCreatedTime - only include users created after this time (Unix epoch milliseconds). Leave at 0 to disable.
 // ToCreatedTime - only include users created on or before this time (Unix epoch milliseconds). Leave at 0 to disable.
-// FromModifiedTime - only include users modified on or after this time (Unix epoch milliseconds). Leave at 0 to disable.
+// FromModifiedTime - only include users modified after this time (Unix epoch milliseconds). Leave at 0 to disable.
 // ToModifiedTime - only include users modified on or before this time (Unix epoch milliseconds). Leave at 0 to disable.
 type UserSearchOptions struct {
 	Page              int32


### PR DESCRIPTION
Fixes wording in FromCreatedTime/FromModifiedTime doc comments to
correctly reflect that these bounds are exclusive (strictly after),
not inclusive (on or before), matching the backend's actual SQL
comparison operators. Same fix already applied to descope-php,
descope-ruby-sdk, and node-sdk in this PR series. This is a
comment-only change with no functional/behavioral modification.

Merging into feature/9538-search-user-time-params directly is blocked
by branch protection requiring PR-mediated changes, hence this small
PR targeting the feature branch rather than main.