### PR TITLE
docs: fix boundary wording for time-filter params and sync with main

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       env:
         # to handle cache overwrite errors
         TAR_OPTIONS: --skip-old-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     needs: semantic-pr
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build
         uses: ./.github/actions/build
 
@@ -53,7 +53,7 @@ jobs:
     needs: semantic-pr
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Lint and more checks
         uses: ./.github/actions/lint
 
@@ -67,7 +67,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Tests
         uses: ./.github/actions/tests
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.29.0](https://github.com/descope/go-sdk/compare/v1.28.0...v1.29.0) (2026-08-07)
+
+
+### Features
+
+* **auth:** expose tenantSSOID on SSO exchange and rotated refresh JWT on refresh ([#815](https://github.com/descope/go-sdk/issues/815)) ([0d01fd0](https://github.com/descope/go-sdk/commit/0d01fd008c9490592e5a02c9328336eca53f8736))
+* **mgmt:** add RemoveRecoveryCodes user management method ([#818](https://github.com/descope/go-sdk/issues/818)) ([71d73ef](https://github.com/descope/go-sdk/commit/71d73ef9ecf46fab6ef5b28ed694148031190d14))
+* **mgmt:** load external groups scoped to a specific SSO config ([#816](https://github.com/descope/go-sdk/issues/816)) ([82c7cb3](https://github.com/descope/go-sdk/commit/82c7cb3da59e998c3212cfa4f04c535deaebe47b))
+
+
+### Bug Fixes
+
+* **deps:** update module github.com/descope/go-sdk to v1.28.0 ([#808](https://github.com/descope/go-sdk/issues/808)) ([474437b](https://github.com/descope/go-sdk/commit/474437bc6540cf81d2147250952bf1d65f228609))
+
 ## [1.28.0](https://github.com/descope/go-sdk/compare/v1.27.0...v1.28.0) (2026-07-21)
 
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,10 @@ authInfo, err := descopeClient.Auth.SSO().ExchangeToken(context.Background(), co
 if err != nil {
     // handle error
 }
+
+// When a tenant has multiple SSO configurations, authInfo.TenantSSOID holds the id
+// of the SSO configuration that performed the authentication
+ssoID := authInfo.TenantSSOID
 ```
 
 ```go
@@ -606,6 +610,13 @@ if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionWithToken(
 
 // If ValidateSessionWithRequest raises an exception, you will need to refresh the session using
 if authorized, sessionToken, err := descopeClient.Auth.RefreshSessionWithToken(context.Background(), refreshToken); !authorized {
+    // unauthorized error
+}
+
+// If refresh token rotation is enabled for the project, use RefreshSessionInfoWithToken to
+// receive the full authentication info: the rotated refresh token is returned in
+// authInfo.RefreshToken and must be used for subsequent refreshes
+if authorized, authInfo, err := descopeClient.Auth.RefreshSessionInfoWithToken(context.Background(), refreshToken); !authorized {
     // unauthorized error
 }
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,14 @@ Pass the loginId to the function to remove the user's TOTP seed.
 totpResponse, err := descopeClient.Management.User().RemoveTOTPSeed(context.Background(), loginID)
 ```
 
+#### Removing Recovery Codes
+
+Pass the loginId to the function to remove all of the user's recovery codes.
+
+```go
+err := descopeClient.Management.User().RemoveRecoveryCodes(context.Background(), loginID)
+```
+
 ### Passwords
 
 The user can also authenticate with a password, though it's recommended to

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ totpResponse, err := descopeClient.Management.User().RemoveTOTPSeed(context.Back
 
 #### Removing Recovery Codes
 
-Pass the loginId to the function to remove all of the user's recovery codes.
+Pass a login ID or user ID to the function to remove all of the user's recovery codes.
 
 ```go
 err := descopeClient.Management.User().RemoveRecoveryCodes(context.Background(), loginID)

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -109,6 +109,8 @@ var (
 			ssoApplicationLoad:                         "mgmt/sso/idp/app/load",
 			ssoApplicationLoadAll:                      "mgmt/sso/idp/apps/load",
 			ssoApplicationSecret:                       "mgmt/sso/idp/app/secret",
+			ssoApplicationSecretAdd:                    "mgmt/sso/idp/app/secret/add",
+			ssoApplicationSecretRevoke:                 "mgmt/sso/idp/app/secret/revoke",
 			ssoApplicationRotate:                       "mgmt/sso/idp/app/rotate",
 			ssoApplicationCreateCustomAttributes:       "mgmt/sso/idp/app/customattribute/create",
 			ssoApplicationDeleteCustomAttributes:       "mgmt/sso/idp/app/customattribute/delete",
@@ -289,6 +291,8 @@ var (
 			thirdPartyApplicationLoad:                  "mgmt/thirdparty/app/load",
 			thirdPartyApplicationLoadAll:               "mgmt/thirdparty/apps/load",
 			thirdPartyApplicationSecret:                "mgmt/thirdparty/app/secret",
+			thirdPartyApplicationSecretAdd:             "mgmt/thirdparty/app/secret/add",
+			thirdPartyApplicationSecretRevoke:          "mgmt/thirdparty/app/secret/revoke",
 			thirdPartyApplicationRotate:                "mgmt/thirdparty/app/rotate",
 			thirdPartyApplicationConsentDelete:         "mgmt/thirdparty/consents/delete",
 			thirdPartyApplicationTenantConsentDelete:   "mgmt/thirdparty/consents/delete/tenant",
@@ -430,17 +434,19 @@ type mgmtEndpoints struct {
 	tenantGenerateSSOConfigurationLink string
 	tenantRevokeSSOConfigurationLink   string
 
-	ssoApplicationOIDCCreate  string
-	ssoApplicationSAMLCreate  string
-	ssoApplicationWSFedCreate string
-	ssoApplicationOIDCUpdate  string
-	ssoApplicationSAMLUpdate  string
-	ssoApplicationWSFedUpdate string
-	ssoApplicationDelete      string
-	ssoApplicationLoad        string
-	ssoApplicationLoadAll     string
-	ssoApplicationSecret      string
-	ssoApplicationRotate      string
+	ssoApplicationOIDCCreate   string
+	ssoApplicationSAMLCreate   string
+	ssoApplicationWSFedCreate  string
+	ssoApplicationOIDCUpdate   string
+	ssoApplicationSAMLUpdate   string
+	ssoApplicationWSFedUpdate  string
+	ssoApplicationDelete       string
+	ssoApplicationLoad         string
+	ssoApplicationLoadAll      string
+	ssoApplicationSecret       string
+	ssoApplicationSecretAdd    string
+	ssoApplicationSecretRevoke string
+	ssoApplicationRotate       string
 
 	ssoApplicationCreateCustomAttributes string
 	ssoApplicationDeleteCustomAttributes string
@@ -640,6 +646,8 @@ type mgmtEndpoints struct {
 	thirdPartyApplicationLoad                string
 	thirdPartyApplicationLoadAll             string
 	thirdPartyApplicationSecret              string
+	thirdPartyApplicationSecretAdd           string
+	thirdPartyApplicationSecretRevoke        string
 	thirdPartyApplicationRotate              string
 	thirdPartyApplicationConsentDelete       string
 	thirdPartyApplicationTenantConsentDelete string
@@ -1002,6 +1010,14 @@ func (e *endpoints) ManagementSSOApplicationLoadAll() string {
 
 func (e *endpoints) ManagementSSOApplicationSecret() string {
 	return path.Join(e.version, e.mgmt.ssoApplicationSecret)
+}
+
+func (e *endpoints) ManagementSSOApplicationSecretAdd() string {
+	return path.Join(e.version, e.mgmt.ssoApplicationSecretAdd)
+}
+
+func (e *endpoints) ManagementSSOApplicationSecretRevoke() string {
+	return path.Join(e.version, e.mgmt.ssoApplicationSecretRevoke)
 }
 
 func (e *endpoints) ManagementSSOApplicationRotate() string {
@@ -1723,6 +1739,14 @@ func (e *endpoints) ManagementThirdPartyApplicationPatch() string {
 
 func (e *endpoints) ManagementThirdPartyApplicationSecret() string {
 	return path.Join(e.version, e.mgmt.thirdPartyApplicationSecret)
+}
+
+func (e *endpoints) ManagementThirdPartyApplicationSecretAdd() string {
+	return path.Join(e.version, e.mgmt.thirdPartyApplicationSecretAdd)
+}
+
+func (e *endpoints) ManagementThirdPartyApplicationSecretRevoke() string {
+	return path.Join(e.version, e.mgmt.thirdPartyApplicationSecretRevoke)
 }
 
 func (e *endpoints) ManagementThirdPartyApplicationRotate() string {

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -155,6 +155,7 @@ var (
 			userRemovePasskey:                          "mgmt/user/passkey/delete",
 			userListPasskeys:                           "mgmt/user/passkeys/list",
 			userRemoveTOTPSeed:                         "mgmt/user/totp/delete",
+			userRemoveRecoveryCodes:                    "mgmt/user/recovery-codes/delete",
 			userListTrustedDevices:                     "mgmt/user/trusteddevices/list",
 			userRemoveTrustedDevices:                   "mgmt/user/trusteddevices/remove",
 			userGetProviderToken:                       "mgmt/user/provider/token",
@@ -484,6 +485,7 @@ type mgmtEndpoints struct {
 	userRemovePasskey         string
 	userListPasskeys          string
 	userRemoveTOTPSeed        string
+	userRemoveRecoveryCodes   string
 	userGetProviderToken      string
 	userLogoutAllDevices      string
 	userAddSsoApps            string
@@ -1184,6 +1186,10 @@ func (e *endpoints) ManagementUserListPasskeys() string {
 
 func (e *endpoints) ManagementUserRemoveTOTPSeed() string {
 	return path.Join(e.version, e.mgmt.userRemoveTOTPSeed)
+}
+
+func (e *endpoints) ManagementUserRemoveRecoveryCodes() string {
+	return path.Join(e.version, e.mgmt.userRemoveRecoveryCodes)
 }
 
 func (e *endpoints) ManagementUserListTrustedDevices() string {

--- a/descope/gin/go.mod
+++ b/descope/gin/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/descope/go-sdk => ../../
 
 require (
-	github.com/descope/go-sdk v1.28.0
+	github.com/descope/go-sdk v1.29.0
 	github.com/gin-gonic/gin v1.12.0
 )
 

--- a/descope/internal/auth/auth.go
+++ b/descope/internal/auth/auth.go
@@ -518,27 +518,48 @@ func (auth *authenticationService) RefreshSessionWithTokenAndWriter(ctx context.
 	return auth.refreshSession(ctx, refreshToken, w)
 }
 
-func (auth *authenticationService) refreshSession(ctx context.Context, refreshToken string, w http.ResponseWriter) (bool, *descope.Token, error) {
-	token, err := auth.validateJWT(refreshToken)
+func (auth *authenticationService) RefreshSessionInfoWithToken(ctx context.Context, refreshToken string) (bool, *descope.AuthenticationInfo, error) {
+	if refreshToken == "" {
+		return false, nil, utils.NewInvalidArgumentError("refreshToken")
+	}
+	info, err := auth.refreshSessionInfo(ctx, refreshToken, nil)
 	if err != nil {
 		return false, nil, err
+	}
+	return true, info, nil
+}
+
+func (auth *authenticationService) refreshSession(ctx context.Context, refreshToken string, w http.ResponseWriter) (bool, *descope.Token, error) {
+	info, err := auth.refreshSessionInfo(ctx, refreshToken, w)
+	if err != nil {
+		return false, nil, err
+	}
+	return true, info.SessionToken, nil
+}
+
+func (auth *authenticationService) refreshSessionInfo(ctx context.Context, refreshToken string, w http.ResponseWriter) (*descope.AuthenticationInfo, error) {
+	token, err := auth.validateJWT(refreshToken)
+	if err != nil {
+		return nil, err
 	}
 
 	httpResponse, err := auth.client.DoPostRequest(ctx, api.Routes.RefreshToken(), nil, &api.HTTPRequest{}, refreshToken)
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
+	// the rotated refresh token, when refresh token rotation is enabled for the
+	// project, is extracted from the response into info.RefreshToken
 	info, err := auth.generateAuthenticationInfoWithRefreshToken(httpResponse, token, w)
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
 
 	if info.SessionToken == nil { // notest
-		return false, nil, descope.ErrUnexpectedResponse.WithMessage("Missing session token in refresh response")
+		return nil, descope.ErrUnexpectedResponse.WithMessage("Missing session token in refresh response")
 	}
 
 	info.SessionToken.RefreshExpiration = token.Expiration
-	return true, info.SessionToken, nil
+	return info, nil
 }
 
 // Validate & Refresh Session

--- a/descope/internal/auth/auth_test.go
+++ b/descope/internal/auth/auth_test.go
@@ -406,6 +406,46 @@ func TestRefreshSessionWithTokenAndWriterInvalidInput(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestRefreshSessionInfoWithToken(t *testing.T) {
+	a, err := newTestAuth(nil, DoOk(nil))
+	require.NoError(t, err)
+	// the provided token differs from the body's refreshJwt so the assertion below
+	// proves the returned refresh token was taken from the response body (rotation)
+	// and not from the fallback to the provided token
+	ok, info, err := a.RefreshSessionInfoWithToken(context.Background(), jwtTokenValid)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, info)
+	require.NotNil(t, info.SessionToken)
+	assert.EqualValues(t, jwtTokenValid, info.SessionToken.JWT)
+	require.NotNil(t, info.RefreshToken)
+	assert.EqualValues(t, jwtRTokenValid, info.RefreshToken.JWT)
+	assert.NotZero(t, info.SessionToken.RefreshExpiration)
+}
+
+func TestRefreshSessionInfoWithTokenNoBodyRefreshJwt(t *testing.T) {
+	a, err := newTestAuth(nil, func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(mockAuthSessionBodyNoRefreshJwt))}, nil
+	})
+	require.NoError(t, err)
+	ok, info, err := a.RefreshSessionInfoWithToken(context.Background(), jwtRTokenValid)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, info)
+	// without a rotated refresh token in the response, the provided refresh token is returned
+	require.NotNil(t, info.RefreshToken)
+	assert.EqualValues(t, jwtRTokenValid, info.RefreshToken.JWT)
+}
+
+func TestRefreshSessionInfoWithTokenInvalidInput(t *testing.T) {
+	a, err := newTestAuth(nil, DoOk(nil))
+	require.NoError(t, err)
+	ok, info, err := a.RefreshSessionInfoWithToken(context.Background(), "")
+	require.ErrorIs(t, err, descope.ErrInvalidArguments)
+	require.False(t, ok)
+	require.Nil(t, info)
+}
+
 func TestRefreshSessionWithTokenNoPublicKey(t *testing.T) {
 	a, err := newTestAuthConf(&AuthParams{ProjectID: "a"}, nil, DoOk(nil))
 	require.NoError(t, err)

--- a/descope/internal/auth/sso_test.go
+++ b/descope/internal/auth/sso_test.go
@@ -120,7 +120,8 @@ func TestExchangeTokenSSO(t *testing.T) {
 					Name: "name",
 				},
 			},
-			FirstSeen: true,
+			FirstSeen:   true,
+			TenantSSOID: "sso-config-id",
 		}
 		respBytes, err := utils.Marshal(resp)
 		require.NoError(t, err)
@@ -133,6 +134,7 @@ func TestExchangeTokenSSO(t *testing.T) {
 	require.NotNil(t, authInfo)
 	assert.EqualValues(t, "name", authInfo.User.Name)
 	assert.True(t, authInfo.FirstSeen)
+	assert.EqualValues(t, "sso-config-id", authInfo.TenantSSOID)
 }
 
 func TestExchangeTokenSSOWithIDPResponse(t *testing.T) {

--- a/descope/internal/mgmt/group.go
+++ b/descope/internal/mgmt/group.go
@@ -16,12 +16,17 @@ type group struct {
 var _ sdk.Group = &group{}
 
 func (r *group) LoadAllGroups(ctx context.Context, tenantID string) ([]*descope.Group, error) {
+	return r.LoadAllGroupsWithSSOID(ctx, tenantID, "")
+}
+
+func (r *group) LoadAllGroupsWithSSOID(ctx context.Context, tenantID, ssoID string) ([]*descope.Group, error) {
 	if tenantID == "" {
 		return nil, utils.NewInvalidArgumentError("tenantID")
 	}
 	body := map[string]any{
 		"tenantId": tenantID,
 	}
+	addSSOIDToGroupRequest(body, ssoID)
 	res, err := r.client.DoPostRequest(ctx, api.Routes.ManagementGroupLoadAllGroups(), body, nil, "")
 	if err != nil {
 		return nil, err
@@ -30,6 +35,10 @@ func (r *group) LoadAllGroups(ctx context.Context, tenantID string) ([]*descope.
 }
 
 func (r *group) LoadAllGroupsForMembers(ctx context.Context, tenantID string, userIDs, loginIDs []string) ([]*descope.Group, error) {
+	return r.LoadAllGroupsForMembersWithSSOID(ctx, tenantID, userIDs, loginIDs, "")
+}
+
+func (r *group) LoadAllGroupsForMembersWithSSOID(ctx context.Context, tenantID string, userIDs, loginIDs []string, ssoID string) ([]*descope.Group, error) {
 	if tenantID == "" {
 		return nil, utils.NewInvalidArgumentError("tenantID")
 	}
@@ -41,6 +50,7 @@ func (r *group) LoadAllGroupsForMembers(ctx context.Context, tenantID string, us
 		"loginIds": loginIDs,
 		"userIds":  userIDs,
 	}
+	addSSOIDToGroupRequest(body, ssoID)
 	res, err := r.client.DoPostRequest(ctx, api.Routes.ManagementGroupLoadAllGroupsForMember(), body, nil, "")
 	if err != nil {
 		return nil, err
@@ -49,6 +59,10 @@ func (r *group) LoadAllGroupsForMembers(ctx context.Context, tenantID string, us
 }
 
 func (r *group) LoadAllGroupMembers(ctx context.Context, tenantID, groupID string) ([]*descope.Group, error) {
+	return r.LoadAllGroupMembersWithSSOID(ctx, tenantID, groupID, "")
+}
+
+func (r *group) LoadAllGroupMembersWithSSOID(ctx context.Context, tenantID, groupID, ssoID string) ([]*descope.Group, error) {
 	if tenantID == "" {
 		return nil, utils.NewInvalidArgumentError("tenantID")
 	}
@@ -59,11 +73,21 @@ func (r *group) LoadAllGroupMembers(ctx context.Context, tenantID, groupID strin
 		"tenantId": tenantID,
 		"groupId":  groupID,
 	}
+	addSSOIDToGroupRequest(body, ssoID)
 	res, err := r.client.DoPostRequest(ctx, api.Routes.ManagementGroupLoadAllGroupMembers(), body, nil, "")
 	if err != nil {
 		return nil, err
 	}
 	return unmarshalGroupsResponse(res)
+}
+
+// addSSOIDToGroupRequest sets the ssoId filter only when one was given: the management gateway
+// rejects unknown request fields, so omitting it keeps the unfiltered methods compatible with
+// backends that predate the ssoId filter.
+func addSSOIDToGroupRequest(body map[string]any, ssoID string) {
+	if ssoID != "" {
+		body["ssoId"] = ssoID
+	}
 }
 
 func unmarshalGroupsResponse(res *api.HTTPResponse) ([]*descope.Group, error) {

--- a/descope/internal/mgmt/group_test.go
+++ b/descope/internal/mgmt/group_test.go
@@ -32,10 +32,44 @@ func TestLoadAllGroupsSuccess(t *testing.T) {
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, tenantID, req["tenantId"])
+		// no ssoId filter given: the field must be absent so the request stays compatible with
+		// backends that reject unknown fields
+		_, found := req["ssoId"]
+		require.False(t, found)
 	}, response))
 	res, err := mgmt.Group().LoadAllGroups(context.Background(), tenantID)
 	require.NoError(t, err)
 	assert.EqualValues(t, response, res)
+}
+
+func TestLoadAllGroupsWithSSOIDSuccess(t *testing.T) {
+	tenantID := "abc"
+	ssoID := "sso-config-1"
+	response := []*descope.Group{
+		{
+			ID:      "some-id",
+			Display: "some-display",
+			Source:  "scim",
+			SSOID:   ssoID,
+		},
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, tenantID, req["tenantId"])
+		require.Equal(t, ssoID, req["ssoId"])
+	}, response))
+	res, err := mgmt.Group().LoadAllGroupsWithSSOID(context.Background(), tenantID, ssoID)
+	require.NoError(t, err)
+	assert.EqualValues(t, response, res)
+}
+
+func TestLoadAllGroupsWithSSOIDMissingArgument(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	res, err := mgmt.Group().LoadAllGroupsWithSSOID(context.Background(), "", "sso-config-1")
+	require.ErrorContains(t, err, utils.NewInvalidArgumentError("tenantID").Message)
+	assert.Nil(t, res)
 }
 
 func TestLoadAllGroupsMissingArgument(t *testing.T) {
@@ -79,6 +113,25 @@ func TestLoadAllGroupsForMembersSuccess(t *testing.T) {
 		require.Equal(t, []any{"three", "four"}, req["loginIds"])
 	}, response))
 	res, err := mgmt.Group().LoadAllGroupsForMembers(context.Background(), tenantID, userIDs, loginIDs)
+	require.NoError(t, err)
+	assert.EqualValues(t, response, res)
+}
+
+func TestLoadAllGroupsForMembersWithSSOIDSuccess(t *testing.T) {
+	tenantID := "abc"
+	ssoID := "sso-config-1"
+	userIDs := []string{"one", "two"}
+	loginIDs := []string{"three", "four"}
+	response := []*descope.Group{{ID: "some-id", Display: "some-display", SSOID: ssoID}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, []any{"one", "two"}, req["userIds"])
+		require.Equal(t, []any{"three", "four"}, req["loginIds"])
+		require.Equal(t, ssoID, req["ssoId"])
+	}, response))
+	res, err := mgmt.Group().LoadAllGroupsForMembersWithSSOID(context.Background(), tenantID, userIDs, loginIDs, ssoID)
 	require.NoError(t, err)
 	assert.EqualValues(t, response, res)
 }
@@ -136,6 +189,23 @@ func TestLoadAllGroupMembersSuccess(t *testing.T) {
 		require.Equal(t, groupID, req["groupId"])
 	}, response))
 	res, err := mgmt.Group().LoadAllGroupMembers(context.Background(), tenantID, groupID)
+	require.NoError(t, err)
+	assert.EqualValues(t, response, res)
+}
+
+func TestLoadAllGroupMembersWithSSOIDSuccess(t *testing.T) {
+	tenantID := "abc"
+	groupID := "abc"
+	ssoID := "sso-config-1"
+	response := []*descope.Group{{ID: "some-id", Display: "some-display", SSOID: ssoID}}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, groupID, req["groupId"])
+		require.Equal(t, ssoID, req["ssoId"])
+	}, response))
+	res, err := mgmt.Group().LoadAllGroupMembersWithSSOID(context.Background(), tenantID, groupID, ssoID)
 	require.NoError(t, err)
 	assert.EqualValues(t, response, res)
 }

--- a/descope/internal/mgmt/ssoapplication.go
+++ b/descope/internal/mgmt/ssoapplication.go
@@ -211,6 +211,77 @@ func (s *ssoApplication) GetApplicationSecret(ctx context.Context, id string) (s
 	return res.Cleartext, nil
 }
 
+func (s *ssoApplication) AddApplicationSecret(ctx context.Context, id string, name string, expireTime int32) (*descope.ClientSecretMeta, string, error) {
+	if id == "" {
+		return nil, "", utils.NewInvalidArgumentError("id")
+	}
+	if name == "" {
+		return nil, "", utils.NewInvalidArgumentError("name")
+	}
+	req := map[string]any{
+		"appId":      id,
+		"name":       name,
+		"expireTime": expireTime,
+	}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOApplicationSecretAdd(), req, nil, "")
+	if err != nil {
+		return nil, "", err
+	}
+	res := struct {
+		Meta      *descope.ClientSecretMeta `json:"meta"`
+		Cleartext string                    `json:"cleartext"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return nil, "", err
+	}
+	return res.Meta, res.Cleartext, nil
+}
+
+func (s *ssoApplication) RevealApplicationSecret(ctx context.Context, id string, secretName string) (string, error) {
+	if id == "" {
+		return "", utils.NewInvalidArgumentError("id")
+	}
+	queryParams := map[string]string{"id": id}
+	if secretName != "" {
+		queryParams["secretName"] = secretName
+	}
+	req := &api.HTTPRequest{
+		QueryParams: queryParams,
+	}
+	httpRes, err := s.client.DoGetRequest(ctx, api.Routes.ManagementSSOApplicationSecret(), req, "")
+	if err != nil {
+		return "", err
+	}
+	res := struct {
+		Cleartext string `json:"cleartext"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return "", err
+	}
+	return res.Cleartext, nil
+}
+
+func (s *ssoApplication) RevokeApplicationSecret(ctx context.Context, id string, name string) ([]*descope.ClientSecretMeta, error) {
+	if id == "" {
+		return nil, utils.NewInvalidArgumentError("id")
+	}
+	req := map[string]any{
+		"appId": id,
+		"name":  name,
+	}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOApplicationSecretRevoke(), req, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	res := struct {
+		Secrets []*descope.ClientSecretMeta `json:"secrets"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return nil, err
+	}
+	return res.Secrets, nil
+}
+
 func (s *ssoApplication) RotateApplicationSecret(ctx context.Context, id string) (string, error) {
 	if id == "" {
 		return "", utils.NewInvalidArgumentError("id")

--- a/descope/internal/mgmt/ssoapplication_test.go
+++ b/descope/internal/mgmt/ssoapplication_test.go
@@ -657,6 +657,131 @@ func TestSSOApplicationRotateSecretError(t *testing.T) {
 	require.Empty(t, res)
 }
 
+func TestSSOApplicationAddSecretSuccess(t *testing.T) {
+	response := map[string]any{
+		"meta": map[string]any{
+			"id":          "secret-id",
+			"name":        "my-secret",
+			"status":      "active",
+			"expireTime":  1234,
+			"createdTime": 5678,
+		},
+		"cleartext": "secret-123",
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "id1", req["appId"])
+		require.Equal(t, "my-secret", req["name"])
+		require.EqualValues(t, 1234, req["expireTime"])
+	}, response))
+	meta, cleartext, err := mgmt.SSOApplication().AddApplicationSecret(context.Background(), "id1", "my-secret", 1234)
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", cleartext)
+	require.NotNil(t, meta)
+	require.Equal(t, "secret-id", meta.ID)
+	require.Equal(t, "my-secret", meta.Name)
+	require.Equal(t, "active", meta.Status)
+	require.EqualValues(t, 1234, meta.ExpireTime)
+	require.EqualValues(t, 5678, meta.CreatedTime)
+}
+
+func TestSSOApplicationAddSecretErrorEmptyID(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	meta, cleartext, err := mgmt.SSOApplication().AddApplicationSecret(context.Background(), "", "my-secret", 0)
+	require.Error(t, err)
+	require.Nil(t, meta)
+	require.Empty(t, cleartext)
+}
+
+func TestSSOApplicationAddSecretErrorEmptyName(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	meta, cleartext, err := mgmt.SSOApplication().AddApplicationSecret(context.Background(), "id1", "", 0)
+	require.Error(t, err)
+	require.Nil(t, meta)
+	require.Empty(t, cleartext)
+}
+
+func TestSSOApplicationAddSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	meta, cleartext, err := mgmt.SSOApplication().AddApplicationSecret(context.Background(), "id1", "my-secret", 0)
+	require.Error(t, err)
+	require.Nil(t, meta)
+	require.Empty(t, cleartext)
+}
+
+func TestSSOApplicationRevealSecretSuccess(t *testing.T) {
+	response := map[string]any{"cleartext": "secret-123"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		require.Equal(t, "id1", r.URL.Query().Get("id"))
+		require.Equal(t, "my-secret", r.URL.Query().Get("secretName"))
+	}, response))
+	res, err := mgmt.SSOApplication().RevealApplicationSecret(context.Background(), "id1", "my-secret")
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", res)
+}
+
+func TestSSOApplicationRevealSecretEmptyName(t *testing.T) {
+	response := map[string]any{"cleartext": "secret-123"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, "id1", r.URL.Query().Get("id"))
+		require.Empty(t, r.URL.Query().Get("secretName"))
+	}, response))
+	res, err := mgmt.SSOApplication().RevealApplicationSecret(context.Background(), "id1", "")
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", res)
+}
+
+func TestSSOApplicationRevealSecretErrorEmptyID(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	res, err := mgmt.SSOApplication().RevealApplicationSecret(context.Background(), "", "my-secret")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestSSOApplicationRevealSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	res, err := mgmt.SSOApplication().RevealApplicationSecret(context.Background(), "test", "my-secret")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestSSOApplicationRevokeSecretSuccess(t *testing.T) {
+	response := map[string]any{
+		"secrets": []map[string]any{
+			{"id": "secret-id", "name": "remaining", "status": "active", "expireTime": 0, "createdTime": 5678},
+		},
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "id1", req["appId"])
+		require.Equal(t, "my-secret", req["name"])
+	}, response))
+	secrets, err := mgmt.SSOApplication().RevokeApplicationSecret(context.Background(), "id1", "my-secret")
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	require.Equal(t, "secret-id", secrets[0].ID)
+	require.Equal(t, "remaining", secrets[0].Name)
+}
+
+func TestSSOApplicationRevokeSecretErrorEmptyID(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	secrets, err := mgmt.SSOApplication().RevokeApplicationSecret(context.Background(), "", "my-secret")
+	require.Error(t, err)
+	require.Nil(t, secrets)
+}
+
+func TestSSOApplicationRevokeSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	secrets, err := mgmt.SSOApplication().RevokeApplicationSecret(context.Background(), "test", "my-secret")
+	require.Error(t, err)
+	require.Nil(t, secrets)
+}
+
 func TestSSOApplicationCreateOIDCApplicationWithDedicatedClientConfig(t *testing.T) {
 	response := map[string]any{"id": "qux"}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {

--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -147,6 +147,77 @@ func (s *thirdPartyApplication) GetApplicationSecret(ctx context.Context, id str
 	return res.Cleartext, nil
 }
 
+func (s *thirdPartyApplication) AddApplicationSecret(ctx context.Context, id string, name string, expireTime int32) (*descope.ClientSecretMeta, string, error) {
+	if id == "" {
+		return nil, "", utils.NewInvalidArgumentError("id")
+	}
+	if name == "" {
+		return nil, "", utils.NewInvalidArgumentError("name")
+	}
+	req := map[string]any{
+		"id":         id,
+		"name":       name,
+		"expireTime": expireTime,
+	}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementThirdPartyApplicationSecretAdd(), req, nil, "")
+	if err != nil {
+		return nil, "", err
+	}
+	res := struct {
+		Meta      *descope.ClientSecretMeta `json:"meta"`
+		Cleartext string                    `json:"cleartext"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return nil, "", err
+	}
+	return res.Meta, res.Cleartext, nil
+}
+
+func (s *thirdPartyApplication) RevealApplicationSecret(ctx context.Context, id string, secretName string) (string, error) {
+	if id == "" {
+		return "", utils.NewInvalidArgumentError("id")
+	}
+	queryParams := map[string]string{"id": id}
+	if secretName != "" {
+		queryParams["secretName"] = secretName
+	}
+	req := &api.HTTPRequest{
+		QueryParams: queryParams,
+	}
+	httpRes, err := s.client.DoGetRequest(ctx, api.Routes.ManagementThirdPartyApplicationSecret(), req, "")
+	if err != nil {
+		return "", err
+	}
+	res := struct {
+		Cleartext string `json:"cleartext"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return "", err
+	}
+	return res.Cleartext, nil
+}
+
+func (s *thirdPartyApplication) RevokeApplicationSecret(ctx context.Context, id string, name string) ([]*descope.ClientSecretMeta, error) {
+	if id == "" {
+		return nil, utils.NewInvalidArgumentError("id")
+	}
+	req := map[string]any{
+		"id":   id,
+		"name": name,
+	}
+	httpRes, err := s.client.DoPostRequest(ctx, api.Routes.ManagementThirdPartyApplicationSecretRevoke(), req, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	res := struct {
+		Secrets []*descope.ClientSecretMeta `json:"secrets"`
+	}{}
+	if err = utils.Unmarshal([]byte(httpRes.BodyStr), &res); err != nil {
+		return nil, err
+	}
+	return res.Secrets, nil
+}
+
 func (s *thirdPartyApplication) RotateApplicationSecret(ctx context.Context, id string) (string, error) {
 	if id == "" {
 		return "", utils.NewInvalidArgumentError("id")

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -226,6 +226,131 @@ func TestThirdPartyApplicationRotateSecretError(t *testing.T) {
 	require.Empty(t, res)
 }
 
+func TestThirdPartyApplicationAddSecretSuccess(t *testing.T) {
+	response := map[string]any{
+		"meta": map[string]any{
+			"id":          "secret-id",
+			"name":        "my-secret",
+			"status":      "active",
+			"expireTime":  1234,
+			"createdTime": 5678,
+		},
+		"cleartext": "secret-123",
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "id1", req["id"])
+		require.Equal(t, "my-secret", req["name"])
+		require.EqualValues(t, 1234, req["expireTime"])
+	}, response))
+	meta, cleartext, err := mgmt.ThirdPartyApplication().AddApplicationSecret(context.Background(), "id1", "my-secret", 1234)
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", cleartext)
+	require.NotNil(t, meta)
+	require.Equal(t, "secret-id", meta.ID)
+	require.Equal(t, "my-secret", meta.Name)
+	require.Equal(t, "active", meta.Status)
+	require.EqualValues(t, 1234, meta.ExpireTime)
+	require.EqualValues(t, 5678, meta.CreatedTime)
+}
+
+func TestThirdPartyApplicationAddSecretErrorEmptyID(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	meta, cleartext, err := mgmt.ThirdPartyApplication().AddApplicationSecret(context.Background(), "", "my-secret", 0)
+	require.Error(t, err)
+	require.Nil(t, meta)
+	require.Empty(t, cleartext)
+}
+
+func TestThirdPartyApplicationAddSecretErrorEmptyName(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	meta, cleartext, err := mgmt.ThirdPartyApplication().AddApplicationSecret(context.Background(), "id1", "", 0)
+	require.Error(t, err)
+	require.Nil(t, meta)
+	require.Empty(t, cleartext)
+}
+
+func TestThirdPartyApplicationAddSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	meta, cleartext, err := mgmt.ThirdPartyApplication().AddApplicationSecret(context.Background(), "id1", "my-secret", 0)
+	require.Error(t, err)
+	require.Nil(t, meta)
+	require.Empty(t, cleartext)
+}
+
+func TestThirdPartyApplicationRevealSecretSuccess(t *testing.T) {
+	response := map[string]any{"cleartext": "secret-123"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		require.Equal(t, "id1", r.URL.Query().Get("id"))
+		require.Equal(t, "my-secret", r.URL.Query().Get("secretName"))
+	}, response))
+	res, err := mgmt.ThirdPartyApplication().RevealApplicationSecret(context.Background(), "id1", "my-secret")
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", res)
+}
+
+func TestThirdPartyApplicationRevealSecretEmptyName(t *testing.T) {
+	response := map[string]any{"cleartext": "secret-123"}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, "id1", r.URL.Query().Get("id"))
+		require.Empty(t, r.URL.Query().Get("secretName"))
+	}, response))
+	res, err := mgmt.ThirdPartyApplication().RevealApplicationSecret(context.Background(), "id1", "")
+	require.NoError(t, err)
+	require.Equal(t, "secret-123", res)
+}
+
+func TestThirdPartyApplicationRevealSecretErrorEmptyID(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	res, err := mgmt.ThirdPartyApplication().RevealApplicationSecret(context.Background(), "", "my-secret")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestThirdPartyApplicationRevealSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	res, err := mgmt.ThirdPartyApplication().RevealApplicationSecret(context.Background(), "test", "my-secret")
+	require.Error(t, err)
+	require.Empty(t, res)
+}
+
+func TestThirdPartyApplicationRevokeSecretSuccess(t *testing.T) {
+	response := map[string]any{
+		"secrets": []map[string]any{
+			{"id": "secret-id", "name": "remaining", "status": "active", "expireTime": 0, "createdTime": 5678},
+		},
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "id1", req["id"])
+		require.Equal(t, "my-secret", req["name"])
+	}, response))
+	secrets, err := mgmt.ThirdPartyApplication().RevokeApplicationSecret(context.Background(), "id1", "my-secret")
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	require.Equal(t, "secret-id", secrets[0].ID)
+	require.Equal(t, "remaining", secrets[0].Name)
+}
+
+func TestThirdPartyApplicationRevokeSecretErrorEmptyID(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
+	secrets, err := mgmt.ThirdPartyApplication().RevokeApplicationSecret(context.Background(), "", "my-secret")
+	require.Error(t, err)
+	require.Nil(t, secrets)
+}
+
+func TestThirdPartyApplicationRevokeSecretError(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	secrets, err := mgmt.ThirdPartyApplication().RevokeApplicationSecret(context.Background(), "test", "my-secret")
+	require.Error(t, err)
+	require.Nil(t, secrets)
+}
+
 func TestThirdPartyApplicationDeleteSuccess(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -752,12 +752,12 @@ func (u *user) RemoveTOTPSeed(ctx context.Context, loginID string) error {
 	return err
 }
 
-func (u *user) RemoveRecoveryCodes(ctx context.Context, loginID string) error {
-	if loginID == "" {
-		return utils.NewInvalidArgumentError("loginID")
+func (u *user) RemoveRecoveryCodes(ctx context.Context, loginIDOrUserID string) error {
+	if loginIDOrUserID == "" {
+		return utils.NewInvalidArgumentError("loginIDOrUserID")
 	}
 
-	req := map[string]any{"loginId": loginID}
+	req := map[string]any{"loginId": loginIDOrUserID}
 	_, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserRemoveRecoveryCodes(), req, nil, "")
 	return err
 }

--- a/descope/internal/mgmt/user.go
+++ b/descope/internal/mgmt/user.go
@@ -752,6 +752,16 @@ func (u *user) RemoveTOTPSeed(ctx context.Context, loginID string) error {
 	return err
 }
 
+func (u *user) RemoveRecoveryCodes(ctx context.Context, loginID string) error {
+	if loginID == "" {
+		return utils.NewInvalidArgumentError("loginID")
+	}
+
+	req := map[string]any{"loginId": loginID}
+	_, err := u.client.DoPostRequest(ctx, api.Routes.ManagementUserRemoveRecoveryCodes(), req, nil, "")
+	return err
+}
+
 type userTrustedDeviceRaw struct {
 	ID                    string `json:"id,omitempty"`
 	Name                  string `json:"name,omitempty"`

--- a/descope/internal/mgmt/user_test.go
+++ b/descope/internal/mgmt/user_test.go
@@ -2158,6 +2158,30 @@ func TestUserTOTPSeedError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUserRemoveRecoveryCodesSuccess(t *testing.T) {
+	response := map[string]any{}
+	m := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "abc", req["loginId"])
+	}, response))
+	err := m.User().RemoveRecoveryCodes(context.Background(), "abc")
+	require.NoError(t, err)
+}
+
+func TestUserRemoveRecoveryCodesBadInput(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoOk(nil))
+	err := m.User().RemoveRecoveryCodes(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestUserRemoveRecoveryCodesError(t *testing.T) {
+	m := newTestMgmt(nil, helpers.DoBadRequest(nil))
+	err := m.User().RemoveRecoveryCodes(context.Background(), "abc")
+	require.Error(t, err)
+}
+
 func TestUserProviderTokenSuccess(t *testing.T) {
 	response := map[string]any{
 		"provider":    "pro",

--- a/descope/sdk/auth.go
+++ b/descope/sdk/auth.go
@@ -366,6 +366,13 @@ type Authentication interface {
 	// returns true upon success or false, the updated session token and an error upon failure.
 	RefreshSessionWithTokenAndWriter(ctx context.Context, refreshToken string, w http.ResponseWriter) (bool, *descope.Token, error)
 
+	// RefreshSessionInfoWithToken - Use to refresh an expired session with a given refresh token,
+	// returning the full authentication info rather than only the session token.
+	// When refresh token rotation is enabled for the project, the rotated refresh token is
+	// returned in AuthenticationInfo.RefreshToken and must be used for subsequent refreshes.
+	// returns true upon success or false, the authentication info and an error upon failure.
+	RefreshSessionInfoWithToken(ctx context.Context, refreshToken string) (bool, *descope.AuthenticationInfo, error)
+
 	// ValidateAndRefreshSessionWithRequest - Use to validate a session of a given request.
 	// Should be called before any private API call that requires authorization.
 	// In case the request cookie can be renewed an automatic renewal is called and returns a new set of cookies to use.

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -177,6 +177,22 @@ type SSOApplication interface {
 	// Only relevant for OIDC apps configured with dedicated client credentials (ClientType "confidential").
 	GetApplicationSecret(ctx context.Context, id string) (string, error)
 
+	// Add a new client secret to an SSO application.
+	// name is a human-readable UI label used to identify the secret; the returned cleartext is the
+	// actual authentication credential and is only exposed here, so store it securely.
+	// expireTime is the secret's expiration as epoch seconds; 0 means the secret never expires.
+	// Returns the new secret's metadata together with its cleartext value.
+	AddApplicationSecret(ctx context.Context, id string, name string, expireTime int32) (meta *descope.ClientSecretMeta, cleartext string, err error)
+
+	// Reveal the cleartext value of an SSO application client secret, selecting it by its UI label name.
+	// When secretName is empty the backend returns the application's single secret, or errors if more
+	// than one secret exists.
+	RevealApplicationSecret(ctx context.Context, id string, secretName string) (string, error)
+
+	// Revoke a client secret of an SSO application, selecting it by its UI label name.
+	// Returns the metadata of the application's remaining secrets.
+	RevokeApplicationSecret(ctx context.Context, id string, name string) (secrets []*descope.ClientSecretMeta, err error)
+
 	// Rotate the dedicated OIDC client secret of an SSO application by its id, returning the new cleartext secret.
 	RotateApplicationSecret(ctx context.Context, id string) (string, error)
 
@@ -1207,6 +1223,22 @@ type ThirdPartyApplication interface {
 
 	// Get a third party application by the application id.
 	GetApplicationSecret(ctx context.Context, id string) (string, error)
+
+	// Add a new client secret to a third party (inbound) application.
+	// name is a human-readable UI label used to identify the secret; the returned cleartext is the
+	// actual authentication credential and is only exposed here, so store it securely.
+	// expireTime is the secret's expiration as epoch seconds; 0 means the secret never expires.
+	// Returns the new secret's metadata together with its cleartext value.
+	AddApplicationSecret(ctx context.Context, id string, name string, expireTime int32) (meta *descope.ClientSecretMeta, cleartext string, err error)
+
+	// Reveal the cleartext value of a third party application client secret, selecting it by its UI label name.
+	// When secretName is empty the backend returns the application's single secret, or errors if more
+	// than one secret exists.
+	RevealApplicationSecret(ctx context.Context, id string, secretName string) (string, error)
+
+	// Revoke a client secret of a third party application, selecting it by its UI label name.
+	// Returns the metadata of the application's remaining secrets.
+	RevokeApplicationSecret(ctx context.Context, id string, name string) (secrets []*descope.ClientSecretMeta, err error)
 
 	// Rotate the application secret for a third party application by the application id.
 	RotateApplicationSecret(ctx context.Context, id string) (string, error)

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -482,8 +482,8 @@ type User interface {
 	// methods or a verified email/phone.
 	RemoveTOTPSeed(ctx context.Context, loginID string) error
 
-	// Removes all recovery codes for the user with the given login ID.
-	RemoveRecoveryCodes(ctx context.Context, loginID string) error
+	// Removes all recovery codes for the user with the given login ID or user ID.
+	RemoveRecoveryCodes(ctx context.Context, loginIDOrUserID string) error
 
 	// Get the provider token for the given login ID.
 	// Only users that sign-in using social providers will have token.

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -482,6 +482,9 @@ type User interface {
 	// methods or a verified email/phone.
 	RemoveTOTPSeed(ctx context.Context, loginID string) error
 
+	// Removes all recovery codes for the user with the given login ID.
+	RemoveRecoveryCodes(ctx context.Context, loginID string) error
+
 	// Get the provider token for the given login ID.
 	// Only users that sign-in using social providers will have token.
 	// Note: The 'Manage tokens from provider' setting must be enabled.

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -884,14 +884,29 @@ type Group interface {
 	// Load all groups for a specific tenant id.
 	LoadAllGroups(ctx context.Context, tenantID string) ([]*descope.Group, error)
 
+	// Load all groups for a specific tenant id, scoped to a single SSO configuration.
+	//
+	// ssoID returns only groups that came from the given SSO configuration (the ssoId used at
+	// SCIM provisioning or JIT login). Use the reserved id "default_ssoid" for the tenant's
+	// default SSO configuration; an empty ssoID behaves like LoadAllGroups.
+	LoadAllGroupsWithSSOID(ctx context.Context, tenantID, ssoID string) ([]*descope.Group, error)
+
 	// Load all groups for the provided user IDs or login IDs.
 	//
 	// userIDs have a format of "U2J5ES9S8TkvCgOvcrkpzUgVTEBM" (example), which can be found on the user's JWT.
 	// loginID is how the user identifies when logging in.
 	LoadAllGroupsForMembers(ctx context.Context, tenantID string, userIDs, loginIDs []string) ([]*descope.Group, error)
 
+	// Load all groups for the provided user IDs or login IDs, scoped to a single SSO
+	// configuration (see LoadAllGroupsWithSSOID for the ssoID semantics).
+	LoadAllGroupsForMembersWithSSOID(ctx context.Context, tenantID string, userIDs, loginIDs []string, ssoID string) ([]*descope.Group, error)
+
 	// Load all members of the provided group id.
 	LoadAllGroupMembers(ctx context.Context, tenantID, groupID string) ([]*descope.Group, error)
+
+	// Load all members of the provided group id, returning the group only if it came from the
+	// given SSO configuration (see LoadAllGroupsWithSSOID for the ssoID semantics).
+	LoadAllGroupMembersWithSSOID(ctx context.Context, tenantID, groupID, ssoID string) ([]*descope.Group, error)
 }
 
 // Provides functions for flow and theme management including export and import by ID.

--- a/descope/tests/mocks/auth/authenticationmock.go
+++ b/descope/tests/mocks/auth/authenticationmock.go
@@ -660,6 +660,11 @@ type MockSession struct {
 	RefreshSessionWithTokenAndWriterResponse *descope.Token
 	RefreshSessionWithTokenAndWriterFailure  bool
 
+	RefreshSessionInfoWithTokenAssert   func(refreshToken string)
+	RefreshSessionInfoWithTokenError    error
+	RefreshSessionInfoWithTokenResponse *descope.AuthenticationInfo
+	RefreshSessionInfoWithTokenFailure  bool
+
 	ExchangeAccessKeyAssert          func(accessKey string, loginOptions *descope.AccessKeyLoginOptions)
 	ExchangeAccessKeyError           error
 	ExchangeAccessKeyResponse        *descope.Token
@@ -790,6 +795,18 @@ func (m *MockSession) RefreshSessionWithTokenAndWriter(_ context.Context, refres
 	}
 
 	return !m.RefreshSessionWithTokenAndWriterFailure, m.RefreshSessionWithTokenAndWriterResponse, m.RefreshSessionWithTokenAndWriterError
+}
+
+func (m *MockSession) RefreshSessionInfoWithToken(_ context.Context, refreshToken string) (bool, *descope.AuthenticationInfo, error) {
+	if m.RefreshSessionInfoWithTokenFailure {
+		return false, nil, m.RefreshSessionInfoWithTokenError
+	}
+
+	if m.RefreshSessionInfoWithTokenAssert != nil {
+		m.RefreshSessionInfoWithTokenAssert(refreshToken)
+	}
+
+	return !m.RefreshSessionInfoWithTokenFailure, m.RefreshSessionInfoWithTokenResponse, m.RefreshSessionInfoWithTokenError
 }
 
 func (m *MockSession) ValidateAndRefreshSessionWithRequest(r *http.Request, w http.ResponseWriter) (bool, *descope.Token, error) {

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -569,6 +569,9 @@ type MockUser struct {
 	RemoveTOTPSeedAssert func(loginID string)
 	RemoveTOTPSeedError  error
 
+	RemoveRecoveryCodesAssert func(loginID string)
+	RemoveRecoveryCodesError  error
+
 	ListTrustedDevicesAssert   func(loginIDsOrUserIDs []string)
 	ListTrustedDevicesResponse []*descope.UserTrustedDevice
 	ListTrustedDevicesError    error
@@ -980,6 +983,13 @@ func (m *MockUser) RemoveTOTPSeed(_ context.Context, loginID string) error {
 		m.RemoveTOTPSeedAssert(loginID)
 	}
 	return m.RemoveTOTPSeedError
+}
+
+func (m *MockUser) RemoveRecoveryCodes(_ context.Context, loginID string) error {
+	if m.RemoveRecoveryCodesAssert != nil {
+		m.RemoveRecoveryCodesAssert(loginID)
+	}
+	return m.RemoveRecoveryCodesError
 }
 
 func (m *MockUser) ListTrustedDevices(_ context.Context, loginIDsOrUserIDs []string) ([]*descope.UserTrustedDevice, error) {

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1341,6 +1341,16 @@ type MockSSOApplication struct {
 	GetApplicationSecretAssert      func(id string)
 	GetApplicationSecretResponse    string
 	GetApplicationSecretError       error
+	AddApplicationSecretAssert      func(id string, name string, expireTime int32)
+	AddApplicationSecretMeta        *descope.ClientSecretMeta
+	AddApplicationSecretResponse    string
+	AddApplicationSecretError       error
+	RevealApplicationSecretAssert   func(id string, secretName string)
+	RevealApplicationSecretResponse string
+	RevealApplicationSecretError    error
+	RevokeApplicationSecretAssert   func(id string, name string)
+	RevokeApplicationSecretResponse []*descope.ClientSecretMeta
+	RevokeApplicationSecretError    error
 	RotateApplicationSecretAssert   func(id string)
 	RotateApplicationSecretResponse string
 	RotateApplicationSecretError    error
@@ -1416,6 +1426,27 @@ func (m *MockSSOApplication) GetApplicationSecret(_ context.Context, id string) 
 		m.GetApplicationSecretAssert(id)
 	}
 	return m.GetApplicationSecretResponse, m.GetApplicationSecretError
+}
+
+func (m *MockSSOApplication) AddApplicationSecret(_ context.Context, id string, name string, expireTime int32) (*descope.ClientSecretMeta, string, error) {
+	if m.AddApplicationSecretAssert != nil {
+		m.AddApplicationSecretAssert(id, name, expireTime)
+	}
+	return m.AddApplicationSecretMeta, m.AddApplicationSecretResponse, m.AddApplicationSecretError
+}
+
+func (m *MockSSOApplication) RevealApplicationSecret(_ context.Context, id string, secretName string) (string, error) {
+	if m.RevealApplicationSecretAssert != nil {
+		m.RevealApplicationSecretAssert(id, secretName)
+	}
+	return m.RevealApplicationSecretResponse, m.RevealApplicationSecretError
+}
+
+func (m *MockSSOApplication) RevokeApplicationSecret(_ context.Context, id string, name string) ([]*descope.ClientSecretMeta, error) {
+	if m.RevokeApplicationSecretAssert != nil {
+		m.RevokeApplicationSecretAssert(id, name)
+	}
+	return m.RevokeApplicationSecretResponse, m.RevokeApplicationSecretError
 }
 
 func (m *MockSSOApplication) RotateApplicationSecret(_ context.Context, id string) (string, error) {
@@ -2287,6 +2318,19 @@ type MockThirdPartyApplication struct {
 	GetApplicationSecretResponse string
 	GetApplicationSecretError    error
 
+	AddApplicationSecretAssert   func(id string, name string, expireTime int32)
+	AddApplicationSecretMeta     *descope.ClientSecretMeta
+	AddApplicationSecretResponse string
+	AddApplicationSecretError    error
+
+	RevealApplicationSecretAssert   func(id string, secretName string)
+	RevealApplicationSecretResponse string
+	RevealApplicationSecretError    error
+
+	RevokeApplicationSecretAssert   func(id string, name string)
+	RevokeApplicationSecretResponse []*descope.ClientSecretMeta
+	RevokeApplicationSecretError    error
+
 	RotateApplicationSecretAssert   func(id string)
 	RotateApplicationSecretResponse string
 	RotateApplicationSecretError    error
@@ -2358,6 +2402,27 @@ func (m *MockThirdPartyApplication) GetApplicationSecret(_ context.Context, id s
 		m.GetApplicationSecretAssert(id)
 	}
 	return m.GetApplicationSecretResponse, m.GetApplicationSecretError
+}
+
+func (m *MockThirdPartyApplication) AddApplicationSecret(_ context.Context, id string, name string, expireTime int32) (*descope.ClientSecretMeta, string, error) {
+	if m.AddApplicationSecretAssert != nil {
+		m.AddApplicationSecretAssert(id, name, expireTime)
+	}
+	return m.AddApplicationSecretMeta, m.AddApplicationSecretResponse, m.AddApplicationSecretError
+}
+
+func (m *MockThirdPartyApplication) RevealApplicationSecret(_ context.Context, id string, secretName string) (string, error) {
+	if m.RevealApplicationSecretAssert != nil {
+		m.RevealApplicationSecretAssert(id, secretName)
+	}
+	return m.RevealApplicationSecretResponse, m.RevealApplicationSecretError
+}
+
+func (m *MockThirdPartyApplication) RevokeApplicationSecret(_ context.Context, id string, name string) ([]*descope.ClientSecretMeta, error) {
+	if m.RevokeApplicationSecretAssert != nil {
+		m.RevokeApplicationSecretAssert(id, name)
+	}
+	return m.RevokeApplicationSecretResponse, m.RevokeApplicationSecretError
 }
 
 func (m *MockThirdPartyApplication) RotateApplicationSecret(_ context.Context, id string) (string, error) {

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -1631,13 +1631,25 @@ type MockGroup struct {
 	LoadAllGroupsResponse []*descope.Group
 	LoadAllGroupsError    error
 
+	LoadAllGroupsWithSSOIDAssert   func(tenantID, ssoID string)
+	LoadAllGroupsWithSSOIDResponse []*descope.Group
+	LoadAllGroupsWithSSOIDError    error
+
 	LoadAllGroupsForMembersAssert   func(tenantID string, userIDs, loginIDs []string)
 	LoadAllGroupsForMembersResponse []*descope.Group
 	LoadAllGroupsForMembersError    error
 
+	LoadAllGroupsForMembersWithSSOIDAssert   func(tenantID string, userIDs, loginIDs []string, ssoID string)
+	LoadAllGroupsForMembersWithSSOIDResponse []*descope.Group
+	LoadAllGroupsForMembersWithSSOIDError    error
+
 	LoadAllGroupMembersAssert   func(tenantID, groupID string)
 	LoadAllGroupMembersResponse []*descope.Group
 	LoadAllGroupMembersError    error
+
+	LoadAllGroupMembersWithSSOIDAssert   func(tenantID, groupID, ssoID string)
+	LoadAllGroupMembersWithSSOIDResponse []*descope.Group
+	LoadAllGroupMembersWithSSOIDError    error
 }
 
 func (m *MockGroup) LoadAllGroups(_ context.Context, tenantID string) ([]*descope.Group, error) {
@@ -1647,6 +1659,13 @@ func (m *MockGroup) LoadAllGroups(_ context.Context, tenantID string) ([]*descop
 	return m.LoadAllGroupsResponse, m.LoadAllGroupsError
 }
 
+func (m *MockGroup) LoadAllGroupsWithSSOID(_ context.Context, tenantID, ssoID string) ([]*descope.Group, error) {
+	if m.LoadAllGroupsWithSSOIDAssert != nil {
+		m.LoadAllGroupsWithSSOIDAssert(tenantID, ssoID)
+	}
+	return m.LoadAllGroupsWithSSOIDResponse, m.LoadAllGroupsWithSSOIDError
+}
+
 func (m *MockGroup) LoadAllGroupsForMembers(_ context.Context, tenantID string, userIDs, loginIDs []string) ([]*descope.Group, error) {
 	if m.LoadAllGroupsForMembersAssert != nil {
 		m.LoadAllGroupsForMembersAssert(tenantID, userIDs, loginIDs)
@@ -1654,11 +1673,25 @@ func (m *MockGroup) LoadAllGroupsForMembers(_ context.Context, tenantID string, 
 	return m.LoadAllGroupsForMembersResponse, m.LoadAllGroupsForMembersError
 }
 
+func (m *MockGroup) LoadAllGroupsForMembersWithSSOID(_ context.Context, tenantID string, userIDs, loginIDs []string, ssoID string) ([]*descope.Group, error) {
+	if m.LoadAllGroupsForMembersWithSSOIDAssert != nil {
+		m.LoadAllGroupsForMembersWithSSOIDAssert(tenantID, userIDs, loginIDs, ssoID)
+	}
+	return m.LoadAllGroupsForMembersWithSSOIDResponse, m.LoadAllGroupsForMembersWithSSOIDError
+}
+
 func (m *MockGroup) LoadAllGroupMembers(_ context.Context, tenantID, groupID string) ([]*descope.Group, error) {
 	if m.LoadAllGroupMembersAssert != nil {
 		m.LoadAllGroupMembersAssert(tenantID, groupID)
 	}
 	return m.LoadAllGroupMembersResponse, m.LoadAllGroupMembersError
+}
+
+func (m *MockGroup) LoadAllGroupMembersWithSSOID(_ context.Context, tenantID, groupID, ssoID string) ([]*descope.Group, error) {
+	if m.LoadAllGroupMembersWithSSOIDAssert != nil {
+		m.LoadAllGroupMembersWithSSOIDAssert(tenantID, groupID, ssoID)
+	}
+	return m.LoadAllGroupMembersWithSSOIDResponse, m.LoadAllGroupMembersWithSSOIDError
 }
 
 // Mock Flows

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -569,7 +569,7 @@ type MockUser struct {
 	RemoveTOTPSeedAssert func(loginID string)
 	RemoveTOTPSeedError  error
 
-	RemoveRecoveryCodesAssert func(loginID string)
+	RemoveRecoveryCodesAssert func(loginIDOrUserID string)
 	RemoveRecoveryCodesError  error
 
 	ListTrustedDevicesAssert   func(loginIDsOrUserIDs []string)
@@ -985,9 +985,9 @@ func (m *MockUser) RemoveTOTPSeed(_ context.Context, loginID string) error {
 	return m.RemoveTOTPSeedError
 }
 
-func (m *MockUser) RemoveRecoveryCodes(_ context.Context, loginID string) error {
+func (m *MockUser) RemoveRecoveryCodes(_ context.Context, loginIDOrUserID string) error {
 	if m.RemoveRecoveryCodesAssert != nil {
-		m.RemoveRecoveryCodesAssert(loginID)
+		m.RemoveRecoveryCodesAssert(loginIDOrUserID)
 	}
 	return m.RemoveRecoveryCodesError
 }

--- a/descope/types.go
+++ b/descope/types.go
@@ -1181,6 +1181,10 @@ type Group struct {
 	Members []GroupMember `json:"members,omitempty"`
 	// Source is the origin of the group: "scim" or "jit" (SSO SAML/OIDC assertion groups).
 	Source string `json:"source,omitempty"`
+	// SSOID is the SSO configuration the group came from (the ssoId bound to the SCIM token that
+	// created it, or the SSO configuration used at the JIT login that persisted it). Groups from
+	// the tenant's default SSO configuration report the reserved id "default_ssoid".
+	SSOID string `json:"ssoId,omitempty"`
 }
 
 type FlowList struct {

--- a/descope/types.go
+++ b/descope/types.go
@@ -926,6 +926,19 @@ type SSOApplicationCustomAttributeOption struct {
 	Value string `json:"value,omitempty"`
 }
 
+// ClientSecretMeta describes a single client secret of an SSO or third party (inbound)
+// application, without the secret value itself. Name is a human-readable UI label used to
+// identify the secret; the actual authentication credential is the cleartext returned only
+// when the secret is added or revealed. Status is one of "active", "disabled" or "expired".
+// ExpireTime and CreatedTime are epoch seconds; an ExpireTime of 0 means the secret never expires.
+type ClientSecretMeta struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	ExpireTime  int32  `json:"expireTime"`
+	CreatedTime int32  `json:"createdTime"`
+}
+
 type OIDCApplicationRequest struct {
 	ID                   string             `json:"id"`
 	Name                 string             `json:"name"`

--- a/descope/types.go
+++ b/descope/types.go
@@ -29,6 +29,7 @@ type AuthenticationInfo struct {
 	User         *UserResponse `json:"user,omitempty"`
 	FirstSeen    bool          `json:"firstSeen,omitempty"`
 	IDPResponse  *IDPResponse  `json:"idpResponse,omitempty"`
+	TenantSSOID  string        `json:"tenantSSOID,omitempty"` // the id of the tenant SSO configuration that performed the authentication (populated on SSO exchange)
 }
 
 // IDPResponse contains IDP groups, SAML attributes, and OIDC claims returned from SSO authentication.
@@ -435,6 +436,7 @@ type JWTResponse struct {
 	User             *UserResponse `json:"user,omitempty"`
 	FirstSeen        bool          `json:"firstSeen,omitempty"`
 	IDPResponse      *IDPResponse  `json:"idpResponse,omitempty"`
+	TenantSSOID      string        `json:"tenantSSOID,omitempty"`
 }
 
 type EnchantedLinkResponse struct {
@@ -458,6 +460,7 @@ func NewAuthenticationInfo(jRes *JWTResponse, sessionToken, refreshToken *Token)
 		User:         jRes.User,
 		FirstSeen:    jRes.FirstSeen,
 		IDPResponse:  jRes.IDPResponse,
+		TenantSSOID:  jRes.TenantSSOID,
 	}
 }
 

--- a/descope/types.go
+++ b/descope/types.go
@@ -1115,9 +1115,9 @@ type CustomAttributeOption struct {
 // CustomAttributes map is an optional filter for custom attributes:
 // where the keys are the attribute names and the values are either a value we are searching for or list of these values in a slice.
 // We currently support string, int and bool values
-// FromCreatedTime - only include users created on or after this time (Unix epoch milliseconds). Leave at 0 to disable.
+// FromCreatedTime - only include users created after this time (Unix epoch milliseconds). Leave at 0 to disable.
 // ToCreatedTime - only include users created on or before this time (Unix epoch milliseconds). Leave at 0 to disable.
-// FromModifiedTime - only include users modified on or after this time (Unix epoch milliseconds). Leave at 0 to disable.
+// FromModifiedTime - only include users modified after this time (Unix epoch milliseconds). Leave at 0 to disable.
 // ToModifiedTime - only include users modified on or before this time (Unix epoch milliseconds). Leave at 0 to disable.
 type UserSearchOptions struct {
 	Page              int32

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/descope/go-sdk
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Fixes wording in FromCreatedTime/FromModifiedTime doc comments to correctly reflect that these bounds are exclusive (strictly after), not inclusive (on or before), matching the backend's actual SQL comparison operators. Same fix already applied to descope-php, descope-ruby-sdk, and node-sdk in this PR series.

Also merges in the latest main, since this branch had fallen behind and direct updates are blocked by branch protection.

Merging into feature/9538-search-user-time-params directly is blocked by branch protection requiring PR-mediated changes, hence this small PR targeting the feature branch rather than main.