### PR TITLE
feat(sso): add ConfigureAuthType to enable or disable an SSO configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,13 @@ createdSSOSettings, err := descopeClient.Management.SSO().NewSettings(context.Ba
 // To delete SSO settings, call the following method
 // You can pass ssoID in case using multi SSO and you want to delete specific SSO configuration
 err := descopeClient.Management.SSO().DeleteSettings(context.Background(), "tenant-id")
+
+// To disable an SSO configuration without deleting it, set its auth type to none. Its settings,
+// mappings and domains are kept, so re-enabling it needs no payload.
+// You can pass ssoID in case using multi SSO and you want to disable a specific SSO configuration
+err := descopeClient.Management.SSO().ConfigureAuthType(context.Background(), "tenant-id", descope.SSOAuthTypeNone, ssoID)
+// Enable it again on the protocol it is configured for
+err = descopeClient.Management.SSO().ConfigureAuthType(context.Background(), "tenant-id", descope.SSOAuthTypeSaml, ssoID)
 ```
 
 Note: Certificates should have a similar structure to:

--- a/descope/api/client.go
+++ b/descope/api/client.go
@@ -183,6 +183,7 @@ var (
 			ssoLoadSettings:                            "mgmt/sso/settings",     // v2 only
 			ssoLoadAllSettings:                         "mgmt/sso/settings/all", // v2 only
 			ssoSettingsNew:                             "mgmt/sso/settings/new",
+			ssoAuthType:                                "mgmt/sso/settings/authtype",
 			ssoSAMLSettings:                            "mgmt/sso/saml",
 			ssoSAMLSettingsByMetadata:                  "mgmt/sso/saml/metadata",
 			ssoRedirectURL:                             "mgmt/sso/redirect",
@@ -531,6 +532,7 @@ type mgmtEndpoints struct {
 	ssoLoadSettings           string
 	ssoLoadAllSettings        string
 	ssoSettingsNew            string
+	ssoAuthType               string
 	ssoSAMLSettings           string
 	ssoSAMLSettingsByMetadata string
 	ssoRedirectURL            string
@@ -1298,6 +1300,10 @@ func (e *endpoints) ManagementSSOLoadAllSettings() string {
 
 func (e *endpoints) ManagementNewSSOSettings() string {
 	return path.Join(e.version, e.mgmt.ssoSettingsNew)
+}
+
+func (e *endpoints) ManagementSSOAuthType() string {
+	return path.Join(e.version, e.mgmt.ssoAuthType)
 }
 
 func (e *endpoints) ManagementSSOSAMLSettings() string {

--- a/descope/internal/mgmt/sso.go
+++ b/descope/internal/mgmt/sso.go
@@ -263,6 +263,27 @@ func (s *sso) DeleteSettings(ctx context.Context, tenantID string, ssoID string)
 	return nil
 }
 
+func (s *sso) ConfigureAuthType(ctx context.Context, tenantID string, authType descope.SSOAuthType, ssoID string) error {
+	if tenantID == "" {
+		return utils.NewInvalidArgumentError("tenantID")
+	}
+
+	if authType == "" {
+		return utils.NewInvalidArgumentError("authType")
+	}
+
+	req := map[string]any{
+		"tenantId": tenantID,
+		"authType": authType,
+	}
+	if len(ssoID) > 0 {
+		req["ssoId"] = ssoID
+	}
+
+	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementSSOAuthType(), req, nil, "")
+	return err
+}
+
 // * Deprecated (use ConfigureSAMLSettings() instead) *//
 func (s *sso) ConfigureSettings(ctx context.Context, tenantID, idpURL, idpCert, entityID, redirectURL string, domains []string) error {
 	if tenantID == "" {

--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -99,6 +99,51 @@ func TestDeleteSSOSettingsWithSSOIDSuccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSSOConfigureAuthTypeDisableWithSSOIDSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "abc", req["tenantId"])
+		require.Equal(t, "none", req["authType"])
+		require.Equal(t, "somessoid", req["ssoId"])
+	}))
+	err := mgmt.SSO().ConfigureAuthType(context.Background(), "abc", descope.SSOAuthTypeNone, "somessoid")
+	require.NoError(t, err)
+}
+
+func TestSSOConfigureAuthTypeDefaultConfigSuccess(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "abc", req["tenantId"])
+		require.Equal(t, "saml", req["authType"])
+		require.Empty(t, req["ssoId"])
+	}))
+	err := mgmt.SSO().ConfigureAuthType(context.Background(), "abc", descope.SSOAuthTypeSaml, "")
+	require.NoError(t, err)
+}
+
+func TestSSOConfigureAuthTypeMissingTenantID(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+	err := mgmt.SSO().ConfigureAuthType(context.Background(), "", descope.SSOAuthTypeNone, "")
+	require.Error(t, err)
+	require.False(t, called)
+}
+
+func TestSSOConfigureAuthTypeMissingAuthType(t *testing.T) {
+	called := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(_ *http.Request) {
+		called = true
+	}))
+	err := mgmt.SSO().ConfigureAuthType(context.Background(), "abc", "", "")
+	require.Error(t, err)
+	require.False(t, called)
+}
+
 func TestDeleteSSOSettingsError(t *testing.T) {
 	called := false
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(_ *http.Request) {

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -724,6 +724,17 @@ type SSO interface {
 	// ssoID (optional) - you can pass ssoID in case using multi SSO and you want to delete specific SSO configuration
 	DeleteSettings(ctx context.Context, tenantID string, ssoID string) error
 
+	// Set the authentication type of a single SSO configuration, leaving its stored SAML/OIDC
+	// settings, mappings and domains untouched.
+	//
+	// tenantID and authType are required.
+	//
+	// authType - descope.SSOAuthTypeNone disables the configuration without deleting it,
+	// descope.SSOAuthTypeSaml / descope.SSOAuthTypeOidc enable it on that protocol with its stored
+	// settings, so re-enabling needs no payload.
+	// ssoID (optional) - pass ssoID when using multi SSO to change a specific SSO configuration.
+	ConfigureAuthType(ctx context.Context, tenantID string, authType descope.SSOAuthType, ssoID string) error
+
 	// *** Deprecated ***
 
 	//* Deprecated (use LoadSettings() instead) *//

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -265,6 +265,9 @@ type MockSSO struct {
 	DeleteSettingsAssert func(tenantID string, ssoID string)
 	DeleteSettingsError  error
 
+	ConfigureAuthTypeAssert func(tenantID string, authType descope.SSOAuthType, ssoID string)
+	ConfigureAuthTypeError  error
+
 	GetSettingsAssert   func(tenantID string)
 	GetSettingsResponse *descope.SSOSettingsResponse
 	GetSettingsError    error
@@ -322,6 +325,13 @@ func (m *MockSSO) ConfigureOIDCSettings(_ context.Context, tenantID string, sett
 		m.ConfigureOIDCSettingsAssert(tenantID, settings, domains, ssoID)
 	}
 	return m.ConfigureOIDCSettingsError
+}
+
+func (m *MockSSO) ConfigureAuthType(_ context.Context, tenantID string, authType descope.SSOAuthType, ssoID string) error {
+	if m.ConfigureAuthTypeAssert != nil {
+		m.ConfigureAuthTypeAssert(tenantID, authType, ssoID)
+	}
+	return m.ConfigureAuthTypeError
 }
 
 func (m *MockSSO) ConfigureXAASettings(_ context.Context, tenantID string, settings *descope.SSOXAASettings, ssoID string) error {

--- a/descope/types.go
+++ b/descope/types.go
@@ -773,6 +773,15 @@ const RoleInheritanceDefault RoleInheritance = ""
 const RoleInheritanceNone RoleInheritance = "none"
 const RoleInheritanceUserOnly RoleInheritance = "userOnly"
 
+// SSOAuthType is the authentication type of an SSO configuration. None means the configuration is
+// disabled: it keeps its stored settings, mappings and domains, and serves no logins until it is
+// set back to Saml or Oidc.
+type SSOAuthType string
+
+const SSOAuthTypeNone SSOAuthType = "none"
+const SSOAuthTypeSaml SSOAuthType = "saml"
+const SSOAuthTypeOidc SSOAuthType = "oidc"
+
 type Tenant struct {
 	ID                      string          `json:"id"`
 	Name                    string          `json:"name"`


### PR DESCRIPTION
## Description

Wraps the new management endpoint `POST /v1/mgmt/sso/settings/authtype`

```go
// disable one connection of a multi-SSO tenant, keeping its configuration
err := descopeClient.Management.SSO().ConfigureAuthType(ctx, "tenant-id", descope.SSOAuthTypeNone, "conf1")
// enable it again on the protocol it is configured for
err = descopeClient.Management.SSO().ConfigureAuthType(ctx, "tenant-id", descope.SSOAuthTypeSaml, "conf1")
// omit ssoID to target the tenant's default configuration
err = descopeClient.Management.SSO().ConfigureAuthType(ctx, "tenant-id", descope.SSOAuthTypeNone, "")
```

**Why.** A customer running their own admin UI on the management APIs needs to temporarily disable one SSO connection of a multi-SSO tenant. Until now the only per-connection off switch was `DeleteSettings`, which drops the connection: re-enabling meant `NewSettings` plus a full `ConfigureSAMLSettings` / `ConfigureOIDCSettings` replay, with the caller storing the mappings, the domains and the OIDC client secret (never returned on read). For SAML it was worse, since a recreated connection gets a new ACS URL and the tenant's IdP admin has to reconfigure. `ConfigureAuthType` leaves the stored configuration intact, so re-enabling needs no payload.

Adds `descope.SSOAuthType` with `SSOAuthTypeNone` / `SSOAuthTypeSaml` / `SSOAuthTypeOidc`, following the existing `RoleInheritance` / `AuthFactor` constant pattern.

## Tests

`descope/internal/mgmt/sso_test.go` — the request body with an `ssoID`, the default-configuration call that omits it, and both missing-argument guards. `MockSSO.ConfigureAuthType` added for consumers. Full suite green.
