### PR TITLE
feat(xaa): expose the read-only project-level audience on the XAA load response

### DIFF
--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -1569,6 +1569,7 @@ func TestLoadXAASettingsSuccess(t *testing.T) {
 		"groupPriorityEnabled": true,
 		"allowOverrideRoles":   true,
 		"providerID":           "prov1",
+		"audience":             "https://api.descope.com/v1/apps/P1",
 	}
 	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(func(r *http.Request) {
 		require.Equal(t, r.Header.Get("Authorization"), "Bearer a:key")
@@ -1594,6 +1595,8 @@ func TestLoadXAASettingsSuccess(t *testing.T) {
 	assert.True(t, res.GroupPriorityEnabled)
 	assert.True(t, res.AllowOverrideRoles)
 	assert.EqualValues(t, "prov1", res.ProviderID)
+	// Read-only, project-level: no tenant segment - the tenant travels in the aud_tenant claim.
+	assert.EqualValues(t, "https://api.descope.com/v1/apps/P1", res.Audience)
 }
 
 func TestLoadXAASettingsErrorMissingTenantID(t *testing.T) {

--- a/descope/types.go
+++ b/descope/types.go
@@ -1744,6 +1744,10 @@ type SSOXAASettingsResponse struct {
 	GroupPriorityEnabled bool                        `json:"groupPriorityEnabled,omitempty"`
 	AllowOverrideRoles   bool                        `json:"allowOverrideRoles,omitempty"`
 	ProviderID           string                      `json:"providerID,omitempty"` // selected IdP provider template id (display metadata; mirrors SSOSAMLSettings providerID)
+	// Audience is read-only: the project-level audience a requesting application must present in its
+	// ID-JAG token. It carries no tenant segment - it equals the issuer the project publishes - so the
+	// identity provider must send the tenant id in the token's aud_tenant claim.
+	Audience string `json:"audience,omitempty"`
 }
 
 type SSOXAAAllSettingsResponse struct {


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/18013

## Related PRs
### Upstream PRs
- https://github.com/descope/backend/pull/2378

### Related PRs
- https://github.com/descope/console-app/pull/5734
- https://github.com/descope/descope-apps/pull/864
- https://github.com/descope/content/pull/2273
- https://github.com/descope/node-sdk/pull/801
- https://github.com/descope/python-sdk/pull/1677
- https://github.com/descope/integrationtests/pull/14790

## In a Nutshell
- Read-only `audience` on the XAA load response

## Description
Loading Cross-App Access settings now also returns the audience a requesting application has to present in its ID-JAG token, so callers read the same value the console shows instead of building it themselves. It has no tenant in it - the identity provider sends the tenant in the token's `aud_tenant` claim.

## Must
- [x] Tests
- [ ] Documentation (if applicable)
