### PR TITLE
feat(sso): allow disabling SAML AuthnRequest signing per SSO configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,11 @@ samlSettings := &descope.SSOSAMLSettingsByMetadata{
 // You can pass ssoID in case using multi SSO and you want to configure specific SSO configuration
 err = descopeClient.Management.SSO().ConfigureSAMLSettingsByMetadata(context.Background(), tenantID, samlSettings, redirectURL, domain)
 
+// Descope signs the SAML AuthnRequest it sends to the IdP. A few IdPs reject a signed request because
+// their trusted provider entry holds no signing certificate for Descope - set DisableSignRequest on the
+// settings (available on both variants above) to send the request unsigned for that configuration only.
+samlSettings.DisableSignRequest = true
+
 // You can create new SSO configuration (aka multi SSO)
 ssoID := "my-new-additional-sso-id"
 displayName := "My additional SSO configuration"

--- a/descope/internal/mgmt/sso.go
+++ b/descope/internal/mgmt/sso.go
@@ -90,6 +90,9 @@ func (s *sso) ConfigureSAMLSettings(ctx context.Context, tenantID string, settin
 			"spEntityId":       settings.SpEntityID,
 			"defaultSSORoles":  settings.DefaultSSORoles,
 			"groupsPriority":   settings.GroupsPriority,
+			// always sent: the server takes the settings object as a full replacement, so omitting the
+			// flag on an update would silently turn request signing back on
+			"disableSignRequest": settings.DisableSignRequest,
 		},
 		"redirectUrl": redirectURL,
 		"domains":     domains,
@@ -143,6 +146,9 @@ func (s *sso) ConfigureSAMLSettingsByMetadata(ctx context.Context, tenantID stri
 			"spEntityId":       settings.SpEntityID,
 			"defaultSSORoles":  settings.DefaultSSORoles,
 			"groupsPriority":   settings.GroupsPriority,
+			// always sent: the server takes the settings object as a full replacement, so omitting the
+			// flag on an update would silently turn request signing back on
+			"disableSignRequest": settings.DisableSignRequest,
 		},
 		"redirectUrl": redirectURL,
 		"domains":     domains,

--- a/descope/internal/mgmt/sso_test.go
+++ b/descope/internal/mgmt/sso_test.go
@@ -488,6 +488,7 @@ func TestLoadSettingsSuccess(t *testing.T) {
 			"configFGATenantIDResourcePrefix": "tenant_prefix_",
 			"configFGATenantIDResourceSuffix": "_tenant_suffix",
 			"lastSuccessTestTime":             777,
+			"disableSignRequest":              true,
 		},
 		"oidc": map[string]any{
 			"name":        "myName",
@@ -532,6 +533,7 @@ func TestLoadSettingsSuccess(t *testing.T) {
 	assert.EqualValues(t, "redirectURL", res.Saml.RedirectURL)
 	assert.EqualValues(t, []string{"defrole1", "defrole2"}, res.Saml.DefaultSSORoles)
 	assert.EqualValues(t, []string{"group1"}, res.Saml.GroupsPriority)
+	assert.True(t, res.Saml.DisableSignRequest)
 	assert.EqualValues(t, 2, len(res.Saml.FgaMappings))
 	assert.EqualValues(t, 2, len(res.Saml.FgaMappings["group1"].Relations))
 	assert.EqualValues(t, 1, len(res.Saml.FgaMappings["group2"].Relations))
@@ -874,6 +876,7 @@ func TestSSOConfigureSAMLSettingsSuccess(t *testing.T) {
 
 		require.Equal(t, "https://spacsurl.com", sett["spACSUrl"])
 		require.Equal(t, "spentityid", sett["spEntityId"])
+		require.Equal(t, false, sett["disableSignRequest"])
 
 		userAttrMappingMap, found := sett["attributeMapping"]
 		require.True(t, found)
@@ -923,6 +926,40 @@ func TestSSOConfigureSAMLSettingsSuccess(t *testing.T) {
 	}))
 	err := mgmt.SSO().ConfigureSAMLSettings(context.Background(), "abc", settings, "https://redirect", []string{"domain.com"}, "")
 	require.NoError(t, err)
+}
+
+func TestSSOConfigureSAMLSettingsDisableSignRequest(t *testing.T) {
+	// The settings object is a full replacement server side, so the flag is always sent - both to opt out
+	// of signing and to opt back in.
+	for _, disableSignRequest := range []bool{true, false} {
+		settings := &descope.SSOSAMLSettings{
+			IdpURL:             "http://idpURL",
+			IdpEntityID:        "entity",
+			IdpCert:            "mycert",
+			DisableSignRequest: disableSignRequest,
+		}
+		mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+			req := map[string]any{}
+			require.NoError(t, helpers.ReadBody(r, &req))
+			sett, ok := req["settings"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, disableSignRequest, sett["disableSignRequest"])
+		}))
+		require.NoError(t, mgmt.SSO().ConfigureSAMLSettings(context.Background(), "abc", settings, "", nil, ""))
+
+		metadataSettings := &descope.SSOSAMLSettingsByMetadata{
+			IdpMetadataURL:     "http://idpMetadataURL",
+			DisableSignRequest: disableSignRequest,
+		}
+		mgmt = newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+			req := map[string]any{}
+			require.NoError(t, helpers.ReadBody(r, &req))
+			sett, ok := req["settings"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, disableSignRequest, sett["disableSignRequest"])
+		}))
+		require.NoError(t, mgmt.SSO().ConfigureSAMLSettingsByMetadata(context.Background(), "abc", metadataSettings, "", nil, ""))
+	}
 }
 
 func TestSSOConfigureSAMLSettingsWithSSOIDSuccess(t *testing.T) {

--- a/descope/types.go
+++ b/descope/types.go
@@ -151,6 +151,7 @@ type SSOSAMLSettingsResponse struct {
 	ConfigFGATenantIDResourcePrefix string                      `json:"configFGATenantIDResourcePrefix,omitempty"`
 	ConfigFGATenantIDResourceSuffix string                      `json:"configFGATenantIDResourceSuffix,omitempty"`
 	LastSuccessTestTime             int32                       `json:"lastSuccessTestTime,omitempty"` // epoch seconds of the last successful SSO test login on this configuration (read-only)
+	DisableSignRequest              bool                        `json:"disableSignRequest,omitempty"`  // true when Descope sends the SAML AuthnRequest to this IdP unsigned
 }
 
 type SSOSAMLSettings struct {
@@ -164,6 +165,11 @@ type SSOSAMLSettings struct {
 	FgaMappings                     map[string]*FGAGroupMapping `json:"fgaMappings,omitempty"`
 	ConfigFGATenantIDResourcePrefix string                      `json:"configFGATenantIDResourcePrefix,omitempty"`
 	ConfigFGATenantIDResourceSuffix string                      `json:"configFGATenantIDResourceSuffix,omitempty"`
+
+	// DisableSignRequest leaves the SAML AuthnRequest Descope sends to the IdP unsigned. Set it only for
+	// IdPs that reject a signed request because their trusted provider entry holds no signing certificate
+	// for Descope. Defaults to false, i.e. requests are signed.
+	DisableSignRequest bool `json:"disableSignRequest,omitempty"`
 
 	// NOTICE - the following fields should be overridden only in case of SSO migration, otherwise, do not modify these fields
 	SpACSUrl   string `json:"spACSUrl,omitempty"`
@@ -180,6 +186,11 @@ type SSOSAMLSettingsByMetadata struct {
 	FgaMappings                     map[string]*FGAGroupMapping `json:"fgaMappings,omitempty"`
 	ConfigFGATenantIDResourcePrefix string                      `json:"configFGATenantIDResourcePrefix,omitempty"`
 	ConfigFGATenantIDResourceSuffix string                      `json:"configFGATenantIDResourceSuffix,omitempty"`
+
+	// DisableSignRequest leaves the SAML AuthnRequest Descope sends to the IdP unsigned. Set it only for
+	// IdPs that reject a signed request because their trusted provider entry holds no signing certificate
+	// for Descope. Defaults to false, i.e. requests are signed.
+	DisableSignRequest bool `json:"disableSignRequest,omitempty"`
 
 	// NOTICE - the following fields should be overridden only in case of SSO migration, otherwise, do not modify these fields
 	SpACSUrl   string `json:"spACSUrl,omitempty"`


### PR DESCRIPTION
## Description

Issue: https://github.com/descope/etc/issues/18144
node-sdk: https://github.com/descope/node-sdk/pull/805 · python-sdk: https://github.com/descope/python-sdk/pull/1684

Descope signs the SAML `AuthnRequest` it sends to a tenant's IdP. A few IdPs (NetIQ Access Manager among them) reject a signed request outright when their trusted-provider entry holds no signing certificate for Descope, and until now there was no way to opt out.

This exposes the new per-SSO-configuration flag:

- `DisableSignRequest` on `SSOSAMLSettings` and `SSOSAMLSettingsByMetadata`.
- `DisableSignRequest` on `SSOSAMLSettingsResponse`, so the stored value is readable.

The flag is always sent on configure, not omitted when false: the server treats the settings object as a full replacement, so omitting it on an update would silently turn signing back on.

Defaults to `false`, so existing callers keep signing exactly as they do today.
