### PR TITLE
feat(dpop): create DPoP proofs so the SDK can act as an OAuth client

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,41 @@ if authorized, sessionToken, err := descopeClient.Auth.ValidateSessionWithReques
 
 Token validation without an `http.Request` (`ValidateSessionWithToken`, `ValidateAndRefreshSessionWithTokens`) does **not** validate the DPoP proof, since the HTTP request context is unavailable. Use the request-based variants whenever DPoP enforcement is required.
 
+##### Acting as a DPoP client
+
+The section above covers the server side. To call an OAuth application that *requires* DPoP — for example a Descope inbound app with "Require DPoP" enabled — use `descope/dpop` to hold the proof-of-possession key and sign the outgoing requests:
+
+```go
+key, err := dpop.NewKey() // ES256, accepted in every configuration including FAPI 2.0
+httpClient := &http.Client{Transport: &dpop.Transport{Key: key}}
+```
+
+Use that client for both the token endpoint and every resource request made with the resulting token. The transport mints a fresh single-use proof per request, adds the `ath` claim and the `DPoP` authorization scheme whenever the request carries an access token, and answers the `DPoP-Nonce` challenge: Descope's token endpoint always requires a nonce, so the first request comes back as `400 use_dpop_nonce` and the transport retries it with the nonce from the response.
+
+At `/authorize`, `/par`, the device endpoint or the CIBA endpoint, send the key thumbprint so the authorization code is bound to the key up front:
+
+```go
+params.Set("dpop_jkt", key.Thumbprint()) // equals the cnf.jkt claim of the issued token
+```
+
+The key must outlive the tokens bound to it — a DPoP-bound refresh token cannot be used without it. Persist it like a client secret:
+
+```go
+stored, err := json.Marshal(key) // private JWK
+key, err = dpop.ParseKey(stored)
+```
+
+To sign a request the transport does not own (a custom client, a signed URL, a test), call `key.Proof` directly:
+
+```go
+proof, err := key.Proof(http.MethodGet, "https://api.example.com/data",
+    dpop.WithAccessToken(accessToken), // ath claim, required at a resource server
+    dpop.WithNonce(nonce))             // when the server issued one
+req.Header.Set(dpop.HeaderProof, proof)
+```
+
+`dpop.NewKeyFromRaw` wraps an existing `*ecdsa.PrivateKey`, `*rsa.PrivateKey` or `ed25519.PrivateKey`; RSA keys sign with `PS256`, since FAPI 2.0 rejects `RS*` proofs.
+
 Refreshed sessions return the same response as is returned when users first sign up / log in,
 Make sure to return the session token from the response to the client if tokens are validated directly.
 

--- a/descope/dpop/dpop.go
+++ b/descope/dpop/dpop.go
@@ -1,0 +1,227 @@
+// Package dpop creates DPoP proofs (RFC 9449) so a Go application can act as an
+// OAuth client of a Descope inbound application that requires DPoP.
+//
+// The SDK already validates incoming proofs at the resource server
+// (auth.ValidateSessionWithRequest); this package covers the client side: holding the
+// proof-of-possession key, minting proofs, and answering the DPoP-Nonce challenge that
+// Descope's token endpoint always issues.
+//
+//	key, _ := dpop.NewKey()
+//	httpClient := &http.Client{Transport: &dpop.Transport{Key: key}}
+//	// httpClient now signs every request; pass key.Thumbprint() as dpop_jkt at /authorize.
+package dpop
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+// Key is a DPoP proof-of-possession key. Safe for concurrent use.
+type Key struct {
+	priv jwk.Key
+	pub  jwk.Key
+	alg  jwa.SignatureAlgorithm
+	jkt  string
+}
+
+// NewKey generates an ephemeral ES256 DPoP key. ES256 is accepted by Descope in every
+// configuration, including FAPI 2.0, which rejects RS* proofs.
+//
+// The key must outlive the tokens bound to it: a DPoP-bound refresh token is unusable
+// without it. Persist it with json.Marshal(key) and load it back with ParseKey.
+func NewKey() (*Key, error) {
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil { // notest
+		return nil, fmt.Errorf("generate DPoP key: %w", err)
+	}
+	return NewKeyFromRaw(raw)
+}
+
+// NewKeyFromRaw wraps an existing private key: *ecdsa.PrivateKey, *rsa.PrivateKey or
+// ed25519.PrivateKey.
+func NewKeyFromRaw(raw any) (*Key, error) {
+	priv, err := jwk.FromRaw(raw)
+	if err != nil {
+		return nil, fmt.Errorf("import DPoP key: %w", err)
+	}
+	return newKey(priv)
+}
+
+// ParseKey loads a key previously serialized with json.Marshal.
+func ParseKey(privateJWK []byte) (*Key, error) {
+	priv, err := jwk.ParseKey(privateJWK)
+	if err != nil {
+		return nil, fmt.Errorf("parse DPoP key: %w", err)
+	}
+	return newKey(priv)
+}
+
+func newKey(priv jwk.Key) (*Key, error) {
+	alg, err := algFor(priv)
+	if err != nil {
+		return nil, err
+	}
+	pub, err := priv.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("derive DPoP public key: %w", err)
+	}
+	// Only the key material belongs in the proof header; kid/use/alg would change the
+	// thumbprint input in some implementations and carry no meaning to the server.
+	for _, field := range []string{jwk.KeyIDKey, jwk.KeyUsageKey, jwk.AlgorithmKey, jwk.KeyOpsKey} {
+		_ = pub.Remove(field)
+	}
+	tp, err := pub.Thumbprint(crypto.SHA256)
+	if err != nil { // notest
+		return nil, fmt.Errorf("compute DPoP thumbprint: %w", err)
+	}
+	return &Key{priv: priv, pub: pub, alg: alg, jkt: base64.RawURLEncoding.EncodeToString(tp)}, nil
+}
+
+// algFor picks the proof signing algorithm for the key type. RSA keys get PS256 rather
+// than RS256 because FAPI 2.0 rejects RSASSA-PKCS1-v1_5 proofs.
+func algFor(key jwk.Key) (jwa.SignatureAlgorithm, error) {
+	if alg := key.Algorithm(); alg != nil && alg.String() != "" {
+		return jwa.SignatureAlgorithm(alg.String()), nil
+	}
+	switch key.KeyType() {
+	case jwa.OKP:
+		return jwa.EdDSA, nil
+	case jwa.RSA:
+		return jwa.PS256, nil
+	case jwa.EC:
+		ec, ok := key.(jwk.ECDSAPrivateKey)
+		if !ok {
+			return "", fmt.Errorf("DPoP key must be a private key")
+		}
+		switch string(ec.Crv().String()) {
+		case "P-256":
+			return jwa.ES256, nil
+		case "P-384":
+			return jwa.ES384, nil
+		case "P-521":
+			return jwa.ES512, nil
+		}
+		// notest — jwx only builds EC keys on P-256/384/521, so no other curve reaches here
+		return "", fmt.Errorf("unsupported DPoP curve %q", ec.Crv().String())
+	}
+	return "", fmt.Errorf("unsupported DPoP key type %q", key.KeyType())
+}
+
+// Thumbprint returns the base64url SHA-256 JWK thumbprint of the public key. This is the
+// value to send as the dpop_jkt parameter at /authorize, /par, /device or the CIBA
+// endpoint, and the value that appears as cnf.jkt in the issued access token.
+func (k *Key) Thumbprint() string {
+	return k.jkt
+}
+
+// Algorithm returns the JWS algorithm used to sign proofs.
+func (k *Key) Algorithm() string {
+	return k.alg.String()
+}
+
+// MarshalJSON serializes the private key as a JWK so it can be persisted. The output is
+// key material: store it the way you store a client secret.
+func (k *Key) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.priv)
+}
+
+type proofOptions struct {
+	accessToken string
+	nonce       string
+}
+
+// ProofOption customizes a generated proof.
+type ProofOption func(*proofOptions)
+
+// WithAccessToken adds the ath claim, binding the proof to an access token. Required for
+// every request to a resource server, and forbidden nowhere else, so pass it whenever the
+// request carries an access token.
+func WithAccessToken(accessToken string) ProofOption {
+	return func(o *proofOptions) { o.accessToken = accessToken }
+}
+
+// WithNonce adds the nonce claim. Descope's token endpoint always requires one; the first
+// request gets a 400 use_dpop_nonce carrying the nonce to use. Transport does this for you.
+func WithNonce(nonce string) ProofOption {
+	return func(o *proofOptions) { o.nonce = nonce }
+}
+
+// Proof mints a DPoP proof JWT for a single request. Proofs are single use: the server
+// rejects a replayed jti.
+func (k *Key) Proof(method, requestURL string, opts ...ProofOption) (string, error) {
+	var o proofOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	htu, err := htuFor(requestURL)
+	if err != nil {
+		return "", err
+	}
+
+	jti := make([]byte, 16)
+	if _, err := rand.Read(jti); err != nil { // notest
+		return "", fmt.Errorf("generate DPoP jti: %w", err)
+	}
+
+	token := jwt.New()
+	claims := map[string]any{
+		"jti": base64.RawURLEncoding.EncodeToString(jti),
+		"htm": method,
+		"htu": htu,
+		"iat": time.Now().Unix(),
+	}
+	if o.accessToken != "" {
+		hash := sha256.Sum256([]byte(o.accessToken))
+		claims["ath"] = base64.RawURLEncoding.EncodeToString(hash[:])
+	}
+	if o.nonce != "" {
+		claims["nonce"] = o.nonce
+	}
+	for name, value := range claims {
+		if err := token.Set(name, value); err != nil { // notest
+			return "", fmt.Errorf("set DPoP claim %s: %w", name, err)
+		}
+	}
+
+	headers := jws.NewHeaders()
+	if err := headers.Set(jws.TypeKey, "dpop+jwt"); err != nil { // notest
+		return "", err
+	}
+	if err := headers.Set(jws.JWKKey, k.pub); err != nil { // notest
+		return "", err
+	}
+
+	proof, err := jwt.Sign(token, jwt.WithKey(k.alg, k.priv, jws.WithProtectedHeaders(headers)))
+	if err != nil {
+		return "", fmt.Errorf("sign DPoP proof: %w", err)
+	}
+	return string(proof), nil
+}
+
+// htuFor strips the query and fragment, which RFC 9449 excludes from htu, and rejects a
+// relative URL: htu must be absolute for the server to compare it.
+func htuFor(requestURL string) (string, error) {
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return "", fmt.Errorf("parse DPoP request URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("DPoP request URL must be absolute, got %q", requestURL)
+	}
+	u.RawQuery, u.Fragment, u.User = "", "", nil
+	return u.String(), nil
+}

--- a/descope/dpop/dpop_test.go
+++ b/descope/dpop/dpop_test.go
@@ -1,0 +1,358 @@
+package dpop
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseProof verifies the proof against its own embedded key, the way a server does, and
+// returns the protected headers and claims.
+func parseProof(t *testing.T, proof string) (jws.Headers, jwt.Token) {
+	t.Helper()
+	msg, err := jws.Parse([]byte(proof))
+	require.NoError(t, err)
+	require.Len(t, msg.Signatures(), 1)
+	headers := msg.Signatures()[0].ProtectedHeaders()
+
+	embedded := headers.JWK()
+	require.NotNil(t, embedded, "proof must embed the public key")
+	_, err = jws.Verify([]byte(proof), jws.WithKey(headers.Algorithm(), embedded))
+	require.NoError(t, err, "proof signature must verify against the embedded key")
+
+	token, err := jwt.Parse([]byte(proof), jwt.WithVerify(false), jwt.WithValidate(false))
+	require.NoError(t, err)
+	return headers, token
+}
+
+func claim(t *testing.T, token jwt.Token, name string) string {
+	t.Helper()
+	raw, ok := token.Get(name)
+	require.True(t, ok, "claim %s must be present", name)
+	value, ok := raw.(string)
+	require.True(t, ok, "claim %s must be a string", name)
+	return value
+}
+
+func TestProofClaimsAndHeaders(t *testing.T) {
+	key, err := NewKey()
+	require.NoError(t, err)
+	assert.Equal(t, "ES256", key.Algorithm())
+
+	accessToken := "some.access.token"
+	proof, err := key.Proof(http.MethodPost, "https://api.descope.com/oauth2/v1/apps/token?x=1#frag",
+		WithAccessToken(accessToken), WithNonce("nonce-value"))
+	require.NoError(t, err)
+
+	headers, token := parseProof(t, proof)
+	assert.Equal(t, "dpop+jwt", headers.Type())
+	assert.Equal(t, "ES256", headers.Algorithm().String())
+
+	// The embedded key must be public only, and its thumbprint is the dpop_jkt value.
+	_, isPrivate := headers.JWK().(jwk.ECDSAPrivateKey)
+	assert.False(t, isPrivate, "proof must not embed the private key")
+
+	assert.Equal(t, http.MethodPost, claim(t, token, "htm"))
+	assert.Equal(t, "https://api.descope.com/oauth2/v1/apps/token", claim(t, token, "htu"), "query and fragment are excluded from htu")
+	assert.Equal(t, "nonce-value", claim(t, token, "nonce"))
+	assert.NotEmpty(t, claim(t, token, "jti"))
+	assert.False(t, token.IssuedAt().IsZero(), "iat is required")
+
+	hash := sha256.Sum256([]byte(accessToken))
+	assert.Equal(t, base64.RawURLEncoding.EncodeToString(hash[:]), claim(t, token, "ath"))
+}
+
+func TestProofIsSingleUse(t *testing.T) {
+	key, err := NewKey()
+	require.NoError(t, err)
+
+	first, err := key.Proof(http.MethodGet, "https://api.descope.com/oauth2/v1/apps/userinfo")
+	require.NoError(t, err)
+	second, err := key.Proof(http.MethodGet, "https://api.descope.com/oauth2/v1/apps/userinfo")
+	require.NoError(t, err)
+
+	_, firstToken := parseProof(t, first)
+	_, secondToken := parseProof(t, second)
+	assert.NotEqual(t, claim(t, firstToken, "jti"), claim(t, secondToken, "jti"), "each proof needs a fresh jti")
+}
+
+func TestProofOmitsAthAndNonceWhenUnset(t *testing.T) {
+	key, err := NewKey()
+	require.NoError(t, err)
+	proof, err := key.Proof(http.MethodPost, "https://api.descope.com/oauth2/v1/apps/token")
+	require.NoError(t, err)
+
+	_, token := parseProof(t, proof)
+	_, hasATH := token.Get("ath")
+	assert.False(t, hasATH)
+	_, hasNonce := token.Get("nonce")
+	assert.False(t, hasNonce)
+}
+
+func TestProofRejectsRelativeURL(t *testing.T) {
+	key, err := NewKey()
+	require.NoError(t, err)
+	_, err = key.Proof(http.MethodGet, "/oauth2/v1/apps/token")
+	require.ErrorContains(t, err, "must be absolute")
+}
+
+func TestKeySurvivesSerialization(t *testing.T) {
+	key, err := NewKey()
+	require.NoError(t, err)
+
+	serialized, err := json.Marshal(key)
+	require.NoError(t, err)
+	restored, err := ParseKey(serialized)
+	require.NoError(t, err)
+
+	// Same key means the same cnf.jkt, so tokens bound before a restart stay usable.
+	assert.Equal(t, key.Thumbprint(), restored.Thumbprint())
+	proof, err := restored.Proof(http.MethodPost, "https://api.descope.com/oauth2/v1/apps/token")
+	require.NoError(t, err)
+	parseProof(t, proof)
+}
+
+func TestThumbprintMatchesEmbeddedKey(t *testing.T) {
+	key, err := NewKey()
+	require.NoError(t, err)
+	proof, err := key.Proof(http.MethodPost, "https://api.descope.com/oauth2/v1/apps/token")
+	require.NoError(t, err)
+
+	headers, _ := parseProof(t, proof)
+	thumbprint, err := headers.JWK().Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	assert.Equal(t, key.Thumbprint(), base64.RawURLEncoding.EncodeToString(thumbprint))
+}
+
+// TestTransportNonceHandshake exercises the handshake Descope's token endpoint always
+// forces: reject the first proof with 400 use_dpop_nonce, then accept the retry.
+func TestTransportNonceHandshake(t *testing.T) {
+	type attempt struct {
+		nonce string
+		body  string
+		auth  string
+		ath   string
+	}
+	var attempts []attempt
+	var issued int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		_, token := parseProof(t, r.Header.Get(HeaderProof))
+		nonce, _ := token.Get("nonce")
+		ath, _ := token.Get("ath")
+		assert.Equal(t, r.Method, claim(t, token, "htm"))
+		attempts = append(attempts, attempt{
+			nonce: fmt.Sprint(nonce),
+			body:  string(body),
+			auth:  r.Header.Get("Authorization"),
+			ath:   fmt.Sprint(ath),
+		})
+
+		// Descope always requires a nonce, and rotates it on every response.
+		issued++
+		w.Header().Set(HeaderNonce, "nonce-"+fmt.Sprint(issued))
+		if nonce == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"use_dpop_nonce","error_description":"nonce required"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"at","token_type":"DPoP"}`))
+	}))
+	defer server.Close()
+
+	key, err := NewKey()
+	require.NoError(t, err)
+	client := &http.Client{Transport: &Transport{Key: key}}
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/oauth2/v1/apps/token", strings.NewReader("grant_type=client_credentials"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer existing-token")
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+	assert.Equal(t, http.StatusOK, res.StatusCode, "the retry must succeed")
+
+	require.Len(t, attempts, 2, "exactly one retry")
+	assert.Equal(t, "<nil>", attempts[0].nonce, "the first proof cannot know the nonce")
+	assert.Equal(t, "nonce-1", attempts[1].nonce, "the retry carries the server nonce")
+	assert.Equal(t, "grant_type=client_credentials", attempts[1].body, "the body is replayed")
+
+	// Bearer is rewritten to the DPoP scheme and bound with ath.
+	assert.Equal(t, "DPoP existing-token", attempts[1].auth)
+	hash := sha256.Sum256([]byte("existing-token"))
+	assert.Equal(t, base64.RawURLEncoding.EncodeToString(hash[:]), attempts[1].ath)
+
+	// The rotated nonce is reused, so a following request needs no retry.
+	attempts = nil
+	res2, err := client.Get(server.URL + "/oauth2/v1/apps/userinfo")
+	require.NoError(t, err)
+	defer func() { _ = res2.Body.Close() }()
+	require.Len(t, attempts, 1, "the cached nonce avoids a second handshake")
+	assert.Equal(t, "nonce-2", attempts[0].nonce)
+}
+
+func TestTransportReturnsNonNonceErrorsUntouched(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set(HeaderNonce, "fresh-nonce")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	}))
+	defer server.Close()
+
+	key, err := NewKey()
+	require.NoError(t, err)
+	client := &http.Client{Transport: &Transport{Key: key}}
+
+	res, err := client.Post(server.URL+"/oauth2/v1/apps/token", "application/x-www-form-urlencoded", strings.NewReader("grant_type=client_credentials"))
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "a non-nonce error must not be retried")
+	assert.JSONEq(t, `{"error":"invalid_client"}`, string(body), "the body stays readable")
+}
+
+func TestTransportRequiresKey(t *testing.T) {
+	_, err := (&Transport{}).RoundTrip(httptest.NewRequest(http.MethodGet, "https://api.descope.com/", nil))
+	require.ErrorContains(t, err, "Key is nil")
+}
+
+func TestKeyAlgorithmPerKeyType(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	_, ed25519Priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	p384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	p521, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+
+	// RSA gets PS256, never RS256: FAPI 2.0 rejects RSASSA-PKCS1-v1_5 proofs.
+	for _, tc := range []struct {
+		name string
+		raw  any
+		alg  string
+	}{
+		{"rsa", rsaKey, "PS256"},
+		{"ed25519", ed25519Priv, "EdDSA"},
+		{"p384", p384, "ES384"},
+		{"p521", p521, "ES512"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := NewKeyFromRaw(tc.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tc.alg, key.Algorithm())
+
+			proof, err := key.Proof(http.MethodPost, "https://api.descope.com/oauth2/v1/apps/token")
+			require.NoError(t, err)
+			headers, _ := parseProof(t, proof)
+			assert.Equal(t, tc.alg, headers.Algorithm().String())
+		})
+	}
+}
+
+func TestKeyHonorsExplicitAlgorithm(t *testing.T) {
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwkKey, err := jwk.FromRaw(raw)
+	require.NoError(t, err)
+	require.NoError(t, jwkKey.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	serialized, err := json.Marshal(jwkKey)
+	require.NoError(t, err)
+	key, err := ParseKey(serialized)
+	require.NoError(t, err)
+	assert.Equal(t, "ES256", key.Algorithm())
+}
+
+func TestKeyRejectsUnusableKeys(t *testing.T) {
+	publicOnly, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	_, err = NewKeyFromRaw(publicOnly.Public())
+	require.ErrorContains(t, err, "must be a private key")
+
+	// A symmetric key cannot prove possession: the server would need the secret to verify.
+	_, err = NewKeyFromRaw([]byte("not-an-asymmetric-key"))
+	require.ErrorContains(t, err, "unsupported DPoP key type")
+
+	_, err = ParseKey([]byte("not a jwk"))
+	require.ErrorContains(t, err, "parse DPoP key")
+}
+
+// TestTransportRetriesResourceServerChallenge covers the resource-server shape of the
+// challenge: 401 with a WWW-Authenticate: DPoP header instead of a JSON body.
+func TestTransportRetriesResourceServerChallenge(t *testing.T) {
+	var nonces []any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, token := parseProof(t, r.Header.Get(HeaderProof))
+		nonce, _ := token.Get("nonce")
+		nonces = append(nonces, nonce)
+		if len(nonces) == 1 {
+			w.Header().Set(HeaderNonce, "rs-nonce")
+			w.Header().Set("WWW-Authenticate", `DPoP error="use_dpop_nonce", error_description="nonce required"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"sub":"U1"}`))
+	}))
+	defer server.Close()
+
+	key, err := NewKey()
+	require.NoError(t, err)
+	client := &http.Client{Transport: &Transport{Key: key}}
+
+	res, err := client.Get(server.URL + "/oauth2/v1/apps/userinfo")
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	require.Len(t, nonces, 2)
+	assert.Equal(t, "rs-nonce", nonces[1])
+}
+
+// A server that issues no nonce still gets a proof, and nothing is cached for it.
+func TestTransportWithoutNonceHeader(t *testing.T) {
+	var proofs int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(HeaderProof) != "" {
+			proofs++
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	key, err := NewKey()
+	require.NoError(t, err)
+	transport := &Transport{Key: key}
+
+	res, err := (&http.Client{Transport: transport}).Get(server.URL + "/resource")
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+	assert.Equal(t, 1, proofs, "no nonce means no retry")
+	assert.Empty(t, transport.nonce(res.Request.URL.Host))
+}

--- a/descope/dpop/transport.go
+++ b/descope/dpop/transport.go
@@ -1,0 +1,174 @@
+package dpop
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const (
+	// HeaderProof carries the DPoP proof JWT (RFC 9449 §4).
+	HeaderProof = "DPoP"
+	// HeaderNonce carries the server-issued nonce (RFC 9449 §8).
+	HeaderNonce = "DPoP-Nonce"
+	// AuthorizationScheme replaces "Bearer" once a token is DPoP-bound (RFC 9449 §7.1).
+	AuthorizationScheme = "DPoP"
+
+	errUseDPoPNonce = "use_dpop_nonce"
+	maxChallengeGap = 4096 // bytes of an error body inspected for the nonce challenge
+)
+
+// Transport signs every outgoing request with a DPoP proof.
+//
+// It covers the three things a DPoP client has to get right:
+//   - a fresh single-use proof per request, bound to method and URL;
+//   - the ath claim and the DPoP Authorization scheme whenever the request carries an
+//     access token (Bearer is rewritten to DPoP);
+//   - the nonce handshake. Descope's token endpoint always requires a nonce, so the first
+//     request is answered with 400 use_dpop_nonce; Transport retries it once with the
+//     nonce from the response and caches the rotated nonce for later requests.
+//
+// Wrap it in an http.Client and use that client for the token endpoint and for every
+// resource request made with the resulting DPoP-bound access token.
+type Transport struct {
+	// Key signs the proofs. Required.
+	Key *Key
+	// Base is the underlying RoundTripper. Defaults to http.DefaultTransport.
+	Base http.RoundTripper
+
+	// ponytail: one nonce per host held in memory. A shared store only matters if several
+	// client instances must reuse one nonce, which the retry already recovers from.
+	mu     sync.Mutex
+	nonces map[string]string
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Key == nil {
+		return nil, fmt.Errorf("dpop: Transport.Key is nil")
+	}
+
+	// Buffer the body so the nonce retry can replay it.
+	body, err := bufferBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := t.attempt(req, body, t.nonce(req.URL.Host))
+	if err != nil {
+		return nil, err
+	}
+	t.rememberNonce(req.URL.Host, res.Header.Get(HeaderNonce))
+
+	nonce := res.Header.Get(HeaderNonce)
+	if nonce == "" || !isNonceChallenge(res) {
+		return res, nil
+	}
+
+	// A nonce challenge is expected on the first call, so drop this response and retry once.
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+	res, err = t.attempt(req, body, nonce)
+	if err != nil {
+		return nil, err
+	}
+	t.rememberNonce(req.URL.Host, res.Header.Get(HeaderNonce))
+	return res, nil
+}
+
+func (t *Transport) attempt(req *http.Request, body []byte, nonce string) (*http.Response, error) {
+	out := req.Clone(req.Context())
+	if body != nil {
+		out.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	opts := []ProofOption{}
+	if nonce != "" {
+		opts = append(opts, WithNonce(nonce))
+	}
+	// A request that carries an access token needs the ath claim, and the token must be
+	// presented under the DPoP scheme.
+	if scheme, token, ok := splitAuthorization(out.Header.Get("Authorization")); ok {
+		if scheme == "bearer" || scheme == "dpop" {
+			out.Header.Set("Authorization", AuthorizationScheme+" "+token)
+			opts = append(opts, WithAccessToken(token))
+		}
+	}
+
+	proof, err := t.Key.Proof(out.Method, out.URL.String(), opts...)
+	if err != nil {
+		return nil, err
+	}
+	out.Header.Set(HeaderProof, proof)
+
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(out)
+}
+
+func (t *Transport) nonce(host string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.nonces[host]
+}
+
+func (t *Transport) rememberNonce(host, nonce string) {
+	if nonce == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.nonces == nil {
+		t.nonces = map[string]string{}
+	}
+	t.nonces[host] = nonce
+}
+
+// isNonceChallenge reports whether res asks the client to retry with a nonce: a 400
+// use_dpop_nonce from the token endpoint, or a 401 DPoP challenge from a resource server.
+// The body is left readable for the caller when the answer is no.
+func isNonceChallenge(res *http.Response) bool {
+	if res.StatusCode != http.StatusBadRequest && res.StatusCode != http.StatusUnauthorized {
+		return false
+	}
+	if strings.Contains(res.Header.Get("WWW-Authenticate"), errUseDPoPNonce) {
+		return true
+	}
+	head, err := io.ReadAll(io.LimitReader(res.Body, maxChallengeGap))
+	if err != nil {
+		return false // notest
+	}
+	res.Body = readCloser{Reader: io.MultiReader(bytes.NewReader(head), res.Body), Closer: res.Body}
+	return strings.Contains(string(head), errUseDPoPNonce)
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// bufferBody reads the request body so it can be sent twice, returning nil for a bodyless
+// request.
+func bufferBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil
+	}
+	body, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("dpop: read request body: %w", err) // notest
+	}
+	return body, nil
+}
+
+func splitAuthorization(header string) (scheme, token string, ok bool) {
+	parts := strings.Fields(strings.TrimSpace(header))
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return strings.ToLower(parts[0]), parts[1], true
+}

--- a/descope/internal/auth/dpop_client_test.go
+++ b/descope/internal/auth/dpop_client_test.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/descope/go-sdk/descope/dpop"
+	"github.com/stretchr/testify/require"
+)
+
+// The two halves of the SDK must agree: a proof minted by the client package has to pass
+// the resource-server validation used by ValidateSessionWithRequest.
+func TestClientProofPassesResourceServerValidation(t *testing.T) {
+	key, err := dpop.NewKey()
+	require.NoError(t, err)
+
+	const accessToken = "access.token.value"
+	const requestURL = "https://rs.example.com/api/data?q=1"
+
+	proof, err := key.Proof(http.MethodGet, requestURL, dpop.WithAccessToken(accessToken))
+	require.NoError(t, err)
+
+	store := newDPoPJTIStore()
+	require.NoError(t, validateDPoPProof(proof, http.MethodGet, requestURL, accessToken, key.Thumbprint(), time.Now, store))
+
+	// The same proof twice is a replay.
+	require.Error(t, validateDPoPProof(proof, http.MethodGet, requestURL, accessToken, key.Thumbprint(), time.Now, store))
+
+	// A proof bound to a different access token must not be accepted.
+	other, err := key.Proof(http.MethodGet, requestURL, dpop.WithAccessToken("someone.elses.token"))
+	require.NoError(t, err)
+	require.Error(t, validateDPoPProof(other, http.MethodGet, requestURL, accessToken, key.Thumbprint(), time.Now, store))
+}


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/18335

## In a Nutshell
- New `descope/dpop` package: DPoP key, proof, `http.RoundTripper`
- Handles the `use_dpop_nonce` retry Descope's token endpoint always forces
- Rewrites `Bearer` to `DPoP` and adds `ath` when a request carries a token
- Key is serializable, so DPoP-bound refresh tokens survive a restart
- Interop test: an SDK-minted proof passes the SDK's own validation
- README section on acting as a DPoP client

## Description
The SDK could already check DPoP proofs sent by clients, but it could not create one, so an app built on it could not get a token from an inbound app with "Require DPoP" turned on. This adds the client half: `dpop.NewKey()` holds the key, `key.Proof(...)` signs one request, and `dpop.Transport` signs every request made through an `http.Client` and retries once with the nonce the server asks for.

## How to test end to end

An example app that runs every step against a live inbound app lives at `~/dev/dev tools/go-sdk-dpop-example` (its README has the details). Against the local stack it creates and deletes its own inbound app:

```bash
cd "~/dev/dev tools/go-sdk-dpop-example"
G=~/dev/go/src/github.com/descope/integrationtests/configs/dev/generated.env
go run . \
  -issuer-url https://localhost:8443/v1/apps/$(grep '^GLOBAL_PROJECT_ID=' $G | cut -d'"' -f2) \
  -base-url https://localhost:8443 -insecure \
  -management-key "$(grep '^GLOBAL_MANAGEMENT_KEY=' $G | cut -d'"' -f2)" \
  -scopes "openid read"
```

It checks, in order:

1. `dpop.NewKey()` gives an ES256 key and its thumbprint.
2. A proof with no nonce is refused: `400 use_dpop_nonce` plus a `DPoP-Nonce` header. This is the step the transport absorbs.
3. The token endpoint accepts the transport's retry and returns `token_type: DPoP`.
4. The token's `cnf.jkt` equals the key thumbprint.
5. Descope UserInfo accepts the bound token (skipped for `client_credentials`, which has no user).
6. The SDK's `ValidateSessionWithRequest` accepts a proof minted by the SDK's client side.
7. The same token with no proof is rejected.
8. A refreshed token is still bound to the same key.

Result of that run against the local stack: all checks passed. `-mode authcode` runs the browser flow instead, sending `dpop_jkt` at `/authorize`; the authorize leg was verified separately (303 to the consent flow, `dpop_jkt` accepted).

Unit tests cover the proof claims and headers, key types (RSA signs with `PS256`, since FAPI 2.0 rejects `RS*`), serialization, the nonce handshake in both its token-endpoint and resource-server shapes, and body replay on retry. Package coverage is 100% under the repo's coverage rules.

## Notes for the reviewer
Wiring DPoP into `api/client.go` was deliberately left out: Descope's management and auth APIs do not accept DPoP, only the inbound-app OAuth endpoints do, so a config option there would never be used.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)