### PR TITLE
fix(mgmt): support ForceDPoP

### DIFF
--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -292,7 +292,7 @@ func (s *thirdPartyApplication) SearchConsents(ctx context.Context, consentReque
 }
 
 func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdPartyApplicationRequest) map[string]any {
-	return map[string]any{
+	req := map[string]any{
 		"id":                   appRequest.ID,
 		"name":                 appRequest.Name,
 		"description":          appRequest.Description,
@@ -306,6 +306,15 @@ func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdParty
 		"forcePkce":            appRequest.ForcePkce,
 		"defaultAudience":      appRequest.DefaultAudience,
 	}
+	if appRequest.ClientType != "" {
+		req["clientType"] = appRequest.ClientType
+	}
+	// Sent only when specified: a patch carrying forceDpop=false turns the requirement off, so an
+	// unspecified value must stay out of the body entirely.
+	if appRequest.ForceDpop != nil {
+		req["forceDpop"] = *appRequest.ForceDpop
+	}
+	return req
 }
 
 func unmarshalLoadThirdPartyApplicationResponse(res *api.HTTPResponse) (*descope.ThirdPartyApplication, error) {

--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -292,7 +292,7 @@ func (s *thirdPartyApplication) SearchConsents(ctx context.Context, consentReque
 }
 
 func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdPartyApplicationRequest) map[string]any {
-	req := map[string]any{
+	return map[string]any{
 		"id":                   appRequest.ID,
 		"name":                 appRequest.Name,
 		"description":          appRequest.Description,
@@ -305,16 +305,9 @@ func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdParty
 		"customAttributes":     appRequest.CustomAttributes,
 		"forcePkce":            appRequest.ForcePkce,
 		"defaultAudience":      appRequest.DefaultAudience,
+		"clientType":           appRequest.ClientType,
+		"forceDpop":            appRequest.ForceDpop,
 	}
-	if appRequest.ClientType != "" {
-		req["clientType"] = appRequest.ClientType
-	}
-	// Sent only when specified: a patch carrying forceDpop=false turns the requirement off, so an
-	// unspecified value must stay out of the body entirely.
-	if appRequest.ForceDpop != nil {
-		req["forceDpop"] = *appRequest.ForceDpop
-	}
-	return req
 }
 
 func unmarshalLoadThirdPartyApplicationResponse(res *api.HTTPResponse) (*descope.ThirdPartyApplication, error) {

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -37,7 +37,6 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		require.Equal(t, true, req["forceDpop"])
 	}, response))
 
-	forceDpop := true
 	id, secret, err := mgmt.ThirdPartyApplication().CreateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
 		ID:              "id1",
 		Name:            "abc",
@@ -47,7 +46,7 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		ForcePkce:       true,
 		DefaultAudience: "clientId",
 		ClientType:      "confidential",
-		ForceDpop:       &forceDpop,
+		ForceDpop:       true,
 		JWTBearerSettings: &descope.JWTBearerSettings{
 			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {
@@ -641,15 +640,15 @@ func TestDeleteThirdPartyApplicationBatchError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// A patch that does not mention forceDpop must not carry it: the API treats an explicit
-// false as "turn the requirement off", so sending one would silently disable DPoP.
-func TestThirdPartyApplicationPatchOmitsUnsetForceDpop(t *testing.T) {
+// Every field is sent on a patch, including the two DPoP-related ones, so a caller that does
+// not carry them over turns the requirement and the client type off.
+func TestThirdPartyApplicationPatchAlwaysSendsForceDpop(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "id1", req["id"])
-		require.NotContains(t, req, "forceDpop")
-		require.NotContains(t, req, "clientType")
+		require.Equal(t, false, req["forceDpop"])
+		require.Equal(t, "", req["clientType"])
 	}))
 	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
 		ID:   "id1",
@@ -658,16 +657,18 @@ func TestThirdPartyApplicationPatchOmitsUnsetForceDpop(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestThirdPartyApplicationPatchTurnsOffForceDpop(t *testing.T) {
-	forceDpop := false
+func TestThirdPartyApplicationPatchKeepsForceDpopWhenCarried(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
-		require.Equal(t, false, req["forceDpop"])
+		require.Equal(t, true, req["forceDpop"])
+		require.Equal(t, "confidential", req["clientType"])
 	}))
 	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
-		ID:        "id1",
-		ForceDpop: &forceDpop,
+		ID:         "id1",
+		Name:       "renamed",
+		ClientType: "confidential",
+		ForceDpop:  true,
 	})
 	require.NoError(t, err)
 }
@@ -698,6 +699,6 @@ func TestThirdPartyApplicationLoadReturnsForceDpop(t *testing.T) {
 		ID:         res.ID,
 		Name:       res.Name,
 		ClientType: res.ClientType,
-		ForceDpop:  &res.ForceDpop,
+		ForceDpop:  res.ForceDpop,
 	}))
 }

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -640,8 +640,6 @@ func TestDeleteThirdPartyApplicationBatchError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// Every field is sent on a patch, including the two DPoP-related ones, so a caller that does
-// not carry them over turns the requirement and the client type off.
 func TestThirdPartyApplicationPatchAlwaysSendsForceDpop(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		req := map[string]any{}

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -33,8 +33,11 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		require.EqualValues(t, "sub", d["issuer1"].(map[string]any)["externalIdFieldName"])
 		require.Equal(t, true, req["forcePkce"])
 		require.Equal(t, "clientId", req["defaultAudience"])
+		require.Equal(t, "confidential", req["clientType"])
+		require.Equal(t, true, req["forceDpop"])
 	}, response))
 
+	forceDpop := true
 	id, secret, err := mgmt.ThirdPartyApplication().CreateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
 		ID:              "id1",
 		Name:            "abc",
@@ -43,6 +46,8 @@ func TestThirdPartyApplicationCreateSuccess(t *testing.T) {
 		LoginPageURL:    "http://dummy.com",
 		ForcePkce:       true,
 		DefaultAudience: "clientId",
+		ClientType:      "confidential",
+		ForceDpop:       &forceDpop,
 		JWTBearerSettings: &descope.JWTBearerSettings{
 			Issuers: map[string]*descope.IssuerSettings{
 				"issuer1": {
@@ -634,4 +639,65 @@ func TestDeleteThirdPartyApplicationBatchError(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(nil))
 	err := mgmt.ThirdPartyApplication().DeleteApplicationBatch(context.Background(), nil)
 	require.Error(t, err)
+}
+
+// A patch that does not mention forceDpop must not carry it: the API treats an explicit
+// false as "turn the requirement off", so sending one would silently disable DPoP.
+func TestThirdPartyApplicationPatchOmitsUnsetForceDpop(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, "id1", req["id"])
+		require.NotContains(t, req, "forceDpop")
+		require.NotContains(t, req, "clientType")
+	}))
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
+		ID:   "id1",
+		Name: "renamed",
+	})
+	require.NoError(t, err)
+}
+
+func TestThirdPartyApplicationPatchTurnsOffForceDpop(t *testing.T) {
+	forceDpop := false
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, false, req["forceDpop"])
+	}))
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
+		ID:        "id1",
+		ForceDpop: &forceDpop,
+	})
+	require.NoError(t, err)
+}
+
+func TestThirdPartyApplicationLoadReturnsForceDpop(t *testing.T) {
+	response := map[string]any{
+		"id":         "id1",
+		"name":       "abc",
+		"clientType": "confidential",
+		"forceDpop":  true,
+	}
+	mgmt := newTestMgmt(nil, helpers.DoOkWithBody(nil, response))
+
+	res, err := mgmt.ThirdPartyApplication().LoadApplication(context.Background(), "id1")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "confidential", res.ClientType)
+	assert.True(t, res.ForceDpop, "a loaded application must report that it requires DPoP")
+
+	// Carrying the loaded values into an update keeps the requirement on.
+	mgmt = newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, true, req["forceDpop"])
+		require.Equal(t, "confidential", req["clientType"])
+	}))
+	require.NoError(t, mgmt.ThirdPartyApplication().UpdateApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
+		ID:         res.ID,
+		Name:       res.Name,
+		ClientType: res.ClientType,
+		ForceDpop:  &res.ForceDpop,
+	}))
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1249,15 +1249,18 @@ type ThirdPartyApplication interface {
 	// Update an existing third party application.
 	//
 	// IMPORTANT: All parameters are required and will override whatever value is currently
-	// set in the existing sso application. Use carefully. In particular, ClientType and ForceDpop
-	// are cleared unless passed, so read the application with LoadApplication first and carry
-	// those values over. Use PatchApplication to change one field and leave the rest alone.
+	// set in the existing sso application. Use carefully. ClientType and ForceDpop are no
+	// exception: read the application with LoadApplication first and carry over every value
+	// you are not changing.
 	UpdateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Patch an existing third party application.
 	//
 	// ID is required to identify the application to be patched.
-	// Fields left unset are not sent, so the application keeps its current values for them.
+	//
+	// Only ClientType and ForceDpop are omitted when left unset, so the application keeps its
+	// current values for those two. Every other field is always sent, and an empty one clears
+	// the current value, so carry over anything you are not changing here as well.
 	PatchApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Delete an existing third party application.

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1241,7 +1241,7 @@ type ThirdPartyApplication interface {
 	// ScopeClaimMapping: List of scope→claim mapping entries.
 	// JWTBearerSettings: Optional JWT Bearer settings which used to validate external token.
 	// ClientType: Optional client authentication model, "confidential" or "public".
-	// ForceDpop: Optional, requires a DPoP proof (RFC 9449) at the token endpoint. Needs a ClientType.
+	// ForceDpop: Optional, requires a DPoP proof at the token endpoint. Needs a ClientType.
 	//
 	// The argument appRequest.Name must be unique per project.
 	CreateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) (id string, secret string, err error)
@@ -1249,18 +1249,12 @@ type ThirdPartyApplication interface {
 	// Update an existing third party application.
 	//
 	// IMPORTANT: All parameters are required and will override whatever value is currently
-	// set in the existing sso application. Use carefully. ClientType and ForceDpop are no
-	// exception: read the application with LoadApplication first and carry over every value
-	// you are not changing, or the update turns off the client type and the DPoP requirement.
+	// set in the existing sso application. Use carefully.
 	UpdateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Patch an existing third party application.
 	//
 	// ID is required to identify the application to be patched.
-	//
-	// Every field is sent, including ClientType and ForceDpop, so an empty one clears the
-	// current value. Read the application with LoadApplication first and carry over everything
-	// you are not changing.
 	PatchApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Delete an existing third party application.

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1240,6 +1240,8 @@ type ThirdPartyApplication interface {
 	// PermissionsScopes: List of permissions scopes.
 	// ScopeClaimMapping: List of scope→claim mapping entries.
 	// JWTBearerSettings: Optional JWT Bearer settings which used to validate external token.
+	// ClientType: Optional client authentication model, "confidential" or "public".
+	// ForceDpop: Optional, requires a DPoP proof (RFC 9449) at the token endpoint. Needs a ClientType.
 	//
 	// The argument appRequest.Name must be unique per project.
 	CreateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) (id string, secret string, err error)
@@ -1247,12 +1249,15 @@ type ThirdPartyApplication interface {
 	// Update an existing third party application.
 	//
 	// IMPORTANT: All parameters are required and will override whatever value is currently
-	// set in the existing sso application. Use carefully.
+	// set in the existing sso application. Use carefully. In particular, ClientType and ForceDpop
+	// are cleared unless passed, so read the application with LoadApplication first and carry
+	// those values over. Use PatchApplication to change one field and leave the rest alone.
 	UpdateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Patch an existing third party application.
 	//
 	// ID is required to identify the application to be patched.
+	// Fields left unset are not sent, so the application keeps its current values for them.
 	PatchApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Delete an existing third party application.

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1251,16 +1251,16 @@ type ThirdPartyApplication interface {
 	// IMPORTANT: All parameters are required and will override whatever value is currently
 	// set in the existing sso application. Use carefully. ClientType and ForceDpop are no
 	// exception: read the application with LoadApplication first and carry over every value
-	// you are not changing.
+	// you are not changing, or the update turns off the client type and the DPoP requirement.
 	UpdateApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Patch an existing third party application.
 	//
 	// ID is required to identify the application to be patched.
 	//
-	// Only ClientType and ForceDpop are omitted when left unset, so the application keeps its
-	// current values for those two. Every other field is always sent, and an empty one clears
-	// the current value, so carry over anything you are not changing here as well.
+	// Every field is sent, including ClientType and ForceDpop, so an empty one clears the
+	// current value. Read the application with LoadApplication first and carry over everything
+	// you are not changing.
 	PatchApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
 
 	// Delete an existing third party application.

--- a/descope/types.go
+++ b/descope/types.go
@@ -1799,6 +1799,10 @@ type ThirdPartyApplication struct {
 	ForcePkce bool `json:"forcePkce,omitempty"`
 	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
 	DefaultAudience string `json:"defaultAudience,omitempty"`
+	// ClientType is the client authentication model: "confidential", "public", or "" for a legacy app.
+	ClientType string `json:"clientType,omitempty"`
+	// ForceDpop reports whether a valid DPoP proof (RFC 9449) is required at the token endpoint.
+	ForceDpop bool `json:"forceDpop,omitempty"`
 }
 
 type ThirdPartyApplicationRequest struct {
@@ -1816,6 +1820,16 @@ type ThirdPartyApplicationRequest struct {
 	ForcePkce bool `json:"forcePkce,omitempty"`
 	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
 	DefaultAudience string `json:"defaultAudience,omitempty"`
+	// ClientType sets the client authentication model: "confidential" or "public". Empty leaves the
+	// app as a legacy client on create, and clears the type on update.
+	ClientType string `json:"clientType,omitempty"`
+	// ForceDpop requires a valid DPoP proof (RFC 9449) at the token endpoint. Only a "confidential"
+	// or "public" ClientType may require it.
+	//
+	// nil means "not specified": PatchApplication leaves the current setting alone, while
+	// CreateApplication and UpdateApplication replace the whole application, so an update that
+	// leaves this nil turns the requirement off. Pass the value from LoadApplication to keep it.
+	ForceDpop *bool `json:"forceDpop,omitempty"`
 }
 
 // Options for loading third party applications

--- a/descope/types.go
+++ b/descope/types.go
@@ -1820,16 +1820,15 @@ type ThirdPartyApplicationRequest struct {
 	ForcePkce bool `json:"forcePkce,omitempty"`
 	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
 	DefaultAudience string `json:"defaultAudience,omitempty"`
-	// ClientType sets the client authentication model: "confidential" or "public". Empty leaves the
-	// app as a legacy client on create, and clears the type on update.
+	// ClientType sets the client authentication model: "confidential" or "public". Empty makes the
+	// application a legacy client.
 	ClientType string `json:"clientType,omitempty"`
 	// ForceDpop requires a valid DPoP proof (RFC 9449) at the token endpoint. Only a "confidential"
 	// or "public" ClientType may require it.
 	//
-	// nil means "not specified": PatchApplication leaves the current setting alone, while
-	// CreateApplication and UpdateApplication replace the whole application, so an update that
-	// leaves this nil turns the requirement off. Pass the value from LoadApplication to keep it.
-	ForceDpop *bool `json:"forceDpop,omitempty"`
+	// Like every other field here, this one is always sent, so a create, update or patch that
+	// leaves it false turns the requirement off. Pass the value from LoadApplication to keep it.
+	ForceDpop bool `json:"forceDpop,omitempty"`
 }
 
 // Options for loading third party applications

--- a/descope/types.go
+++ b/descope/types.go
@@ -1801,7 +1801,7 @@ type ThirdPartyApplication struct {
 	DefaultAudience string `json:"defaultAudience,omitempty"`
 	// ClientType is the client authentication model: "confidential", "public", or "" for a legacy app.
 	ClientType string `json:"clientType,omitempty"`
-	// ForceDpop reports whether a valid DPoP proof (RFC 9449) is required at the token endpoint.
+	// ForceDpop reports whether a valid DPoP proof is required at the token endpoint.
 	ForceDpop bool `json:"forceDpop,omitempty"`
 }
 
@@ -1820,14 +1820,9 @@ type ThirdPartyApplicationRequest struct {
 	ForcePkce bool `json:"forcePkce,omitempty"`
 	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
 	DefaultAudience string `json:"defaultAudience,omitempty"`
-	// ClientType sets the client authentication model: "confidential" or "public". Empty makes the
-	// application a legacy client.
+	// ClientType sets the client authentication model: "confidential" or "public".
 	ClientType string `json:"clientType,omitempty"`
-	// ForceDpop requires a valid DPoP proof (RFC 9449) at the token endpoint. Only a "confidential"
-	// or "public" ClientType may require it.
-	//
-	// Like every other field here, this one is always sent, so a create, update or patch that
-	// leaves it false turns the requirement off. Pass the value from LoadApplication to keep it.
+	// ForceDpop requires a valid DPoP proof at the token endpoint. Only a "confidential" or "public" ClientType may require it.
 	ForceDpop bool `json:"forceDpop,omitempty"`
 }
 


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/18444

Required for:
https://github.com/descope/etc/issues/18441

## Related PRs
### Downstream PRs
- https://github.com/descope/integrationtests/pull/14872

## In a Nutshell
- Adds `ForceDpop` and `ClientType` to the inbound app management API
- `LoadApplication` now reports both
- Both are sent on every request, like every other field
- Unit tests for create, patch and the read-modify-write path

## Description
The SDK could not set or read an inbound app's Require DPoP setting, so a customer who turned it on in the console could not manage that app from Go without losing it: the SDK's update sends the whole application, and anything missing from the body is written back as its zero value, which silently switched the requirement and the app's client type off. This adds both fields so the setting can be switched on, read back, and carried through an edit.

Both fields sit in the request body unconditionally, the same as `forcePkce` and the rest. That means an update or patch that leaves them unset clears them, so a caller has to read the application with `LoadApplication` and carry over what they are not changing. The doc comments on `UpdateApplication`, `PatchApplication` and the two fields say so.

## Verification
Reproduced against the local stack before the change by sending exactly the body the SDK builds: `forceDpop` went from true to false and `clientType` from `confidential` to empty. After the change, an app created through the SDK with `ClientType: "confidential"` and `ForceDpop: true` keeps the requirement across an SDK patch and update that carry the values, and the token endpoint rejects a proofless token request throughout. The integrationtests PR covers both directions end to end, including that an edit which drops the fields turns the requirement off.

Package coverage stays at 100% under `scripts/build/ci/build_test.sh`, and `golangci-lint` v1.64.7 with the repo config is clean.

## Notes for the reviewer
Because every field is always sent, `PatchApplication` behaves like a small update rather than a true patch. That is pre-existing for the other fields (a patch that only renames an app also wipes `loginPageUrl`, confirmed on the stack) and these two now follow the same rule. Making the body omit unset fields would change behavior for existing callers, so it is recorded in the issue as a follow-up along with the 12-of-29 field gap.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)