### PR TITLE
fix(mgmt): send only the set fields on an inbound app patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1955,6 +1955,11 @@ appID, secret, err = descopeClient.Management.ThirdPartyApplication().CreateAppl
 // Update will override all fields as is. Use carefully.
 err = tc.DescopeClient().Management.ThirdPartyApplication().UpdateApplication(context.TODO(), &descope.ThirdPartyApplicationRequest{ID: "my-id", Name: "my new name"})
 
+// Patch a third party application by id
+// Only the fields that are set are sent. Anything left nil keeps its current value.
+newName := "my new name"
+err = tc.DescopeClient().Management.ThirdPartyApplication().PatchApplication(context.TODO(), &descope.PatchThirdPartyApplicationRequest{ID: "my-id", Name: &newName})
+
 // Load third party application by id
 app, err = tc.DescopeClient().Management.ThirdPartyApplication().LoadApplication(context.Background(), "appId")
 

--- a/descope/internal/mgmt/third_party_application.go
+++ b/descope/internal/mgmt/third_party_application.go
@@ -54,7 +54,7 @@ func (s *thirdPartyApplication) UpdateApplication(ctx context.Context, appReques
 	return err
 }
 
-func (s *thirdPartyApplication) PatchApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error {
+func (s *thirdPartyApplication) PatchApplication(ctx context.Context, appRequest *descope.PatchThirdPartyApplicationRequest) error {
 	if appRequest == nil {
 		return utils.NewInvalidArgumentError("appRequest")
 	}
@@ -62,7 +62,7 @@ func (s *thirdPartyApplication) PatchApplication(ctx context.Context, appRequest
 		return utils.NewInvalidArgumentError("appRequest.id")
 	}
 
-	req := makeCreateUpdateThirdPartyApplicationRequest(appRequest)
+	req := makePatchThirdPartyApplicationRequest(appRequest)
 	_, err := s.client.DoPostRequest(ctx, api.Routes.ManagementThirdPartyApplicationPatch(), req, nil, "")
 	return err
 }
@@ -308,6 +308,53 @@ func makeCreateUpdateThirdPartyApplicationRequest(appRequest *descope.ThirdParty
 		"clientType":           appRequest.ClientType,
 		"forceDpop":            appRequest.ForceDpop,
 	}
+}
+
+// makePatchThirdPartyApplicationRequest sends only the fields the caller set.
+func makePatchThirdPartyApplicationRequest(appRequest *descope.PatchThirdPartyApplicationRequest) map[string]any {
+	res := map[string]any{
+		"id": appRequest.ID,
+	}
+	if appRequest.Name != nil {
+		res["name"] = *appRequest.Name
+	}
+	if appRequest.Description != nil {
+		res["description"] = *appRequest.Description
+	}
+	if appRequest.Logo != nil {
+		res["logo"] = *appRequest.Logo
+	}
+	if appRequest.LoginPageURL != nil {
+		res["loginPageUrl"] = *appRequest.LoginPageURL
+	}
+	if appRequest.ApprovedCallbackUrls != nil {
+		res["approvedCallbackUrls"] = *appRequest.ApprovedCallbackUrls
+	}
+	if appRequest.PermissionsScopes != nil {
+		res["permissionsScopes"] = *appRequest.PermissionsScopes
+	}
+	if appRequest.ScopeClaimMapping != nil {
+		res["scopeClaimMapping"] = *appRequest.ScopeClaimMapping
+	}
+	if appRequest.JWTBearerSettings != nil {
+		res["jwtBearerSettings"] = appRequest.JWTBearerSettings
+	}
+	if appRequest.CustomAttributes != nil {
+		res["customAttributes"] = appRequest.CustomAttributes
+	}
+	if appRequest.ForcePkce != nil {
+		res["forcePkce"] = *appRequest.ForcePkce
+	}
+	if appRequest.DefaultAudience != nil {
+		res["defaultAudience"] = *appRequest.DefaultAudience
+	}
+	if appRequest.ClientType != nil {
+		res["clientType"] = *appRequest.ClientType
+	}
+	if appRequest.ForceDpop != nil {
+		res["forceDpop"] = *appRequest.ForceDpop
+	}
+	return res
 }
 
 func unmarshalLoadThirdPartyApplicationResponse(res *api.HTTPResponse) (*descope.ThirdPartyApplication, error) {

--- a/descope/internal/mgmt/third_party_application_test.go
+++ b/descope/internal/mgmt/third_party_application_test.go
@@ -155,11 +155,14 @@ func TestThirdPartyApplicationPatchSuccess(t *testing.T) {
 		require.Equal(t, []any{map[string]any{"scope": "scope2", "description": "desc2", "claims": map[string]any{"email": "{{user.email}}"}}}, req["scopeClaimMapping"])
 	}, response))
 
-	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
+	description := "desc"
+	callbackUrls := []string{"http://dummy.com/callback"}
+	scopeClaimMapping := []*descope.ThirdPartyApplicationScopeClaimMapping{{Scope: "scope2", Description: "desc2", Claims: map[string]string{"email": "{{user.email}}"}}}
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.PatchThirdPartyApplicationRequest{
 		ID:                   "id1",
-		Description:          "desc",
-		ApprovedCallbackUrls: []string{"http://dummy.com/callback"},
-		ScopeClaimMapping:    []*descope.ThirdPartyApplicationScopeClaimMapping{{Scope: "scope2", Description: "desc2", Claims: map[string]string{"email": "{{user.email}}"}}},
+		Description:          &description,
+		ApprovedCallbackUrls: &callbackUrls,
+		ScopeClaimMapping:    &scopeClaimMapping,
 	})
 	require.NoError(t, err)
 }
@@ -172,7 +175,7 @@ func TestThirdPartyApplicationPatchError(t *testing.T) {
 	require.Error(t, err)
 
 	// Empty application ID
-	err = mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{})
+	err = mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.PatchThirdPartyApplicationRequest{})
 	require.Error(t, err)
 }
 
@@ -640,17 +643,97 @@ func TestDeleteThirdPartyApplicationBatchError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestThirdPartyApplicationPatchAlwaysSendsForceDpop(t *testing.T) {
+// A rename must not carry any other field, so the app keeps its login page URL,
+// client type, PKCE and DPoP settings.
+func TestThirdPartyApplicationPatchSendsOnlyFieldsThatAreSet(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, map[string]any{"id": "id1", "name": "renamed"}, req)
+	}))
+	name := "renamed"
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.PatchThirdPartyApplicationRequest{
+		ID:   "id1",
+		Name: &name,
+	})
+	require.NoError(t, err)
+}
+
+func TestThirdPartyApplicationPatchSendsEveryFieldThatIsSet(t *testing.T) {
 	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
 		req := map[string]any{}
 		require.NoError(t, helpers.ReadBody(r, &req))
 		require.Equal(t, "id1", req["id"])
-		require.Equal(t, false, req["forceDpop"])
-		require.Equal(t, "", req["clientType"])
+		require.Equal(t, "renamed", req["name"])
+		require.Equal(t, "desc", req["description"])
+		require.Equal(t, "logo", req["logo"])
+		require.Equal(t, "http://dummy.com/login", req["loginPageUrl"])
+		require.Equal(t, []any{"http://dummy.com/callback"}, req["approvedCallbackUrls"])
+		require.Equal(t, []any{map[string]any{"name": "scope1", "description": "desc1", "values": nil}}, req["permissionsScopes"])
+		require.Equal(t, []any{map[string]any{"scope": "scope2", "description": "desc2", "claims": map[string]any{"email": "{{user.email}}"}}}, req["scopeClaimMapping"])
+		require.Equal(t, map[string]any{"issuers": map[string]any{"http://dummy.com": map[string]any{
+			"jwksUri":             "http://dummy.com/jwks",
+			"signAlgorithm":       "RS256",
+			"userInfoUri":         "http://dummy.com/userinfo",
+			"externalIdFieldName": "sub",
+		}}}, req["jwtBearerSettings"])
+		require.Equal(t, map[string]any{"k1": "v1"}, req["customAttributes"])
+		require.Equal(t, true, req["forcePkce"])
+		require.Equal(t, "clientId", req["defaultAudience"])
+		require.Equal(t, "confidential", req["clientType"])
+		require.Equal(t, true, req["forceDpop"])
 	}))
-	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
-		ID:   "id1",
-		Name: "renamed",
+	name, description, logo := "renamed", "desc", "logo"
+	loginPageURL, defaultAudience, clientType := "http://dummy.com/login", "clientId", "confidential"
+	callbackUrls := []string{"http://dummy.com/callback"}
+	permissionsScopes := []*descope.ThirdPartyApplicationScope{{Name: "scope1", Description: "desc1"}}
+	scopeClaimMapping := []*descope.ThirdPartyApplicationScopeClaimMapping{{Scope: "scope2", Description: "desc2", Claims: map[string]string{"email": "{{user.email}}"}}}
+	forcePkce, forceDpop := true, true
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.PatchThirdPartyApplicationRequest{
+		ID:                   "id1",
+		Name:                 &name,
+		Description:          &description,
+		Logo:                 &logo,
+		LoginPageURL:         &loginPageURL,
+		ApprovedCallbackUrls: &callbackUrls,
+		PermissionsScopes:    &permissionsScopes,
+		ScopeClaimMapping:    &scopeClaimMapping,
+		JWTBearerSettings: &descope.JWTBearerSettings{Issuers: map[string]*descope.IssuerSettings{
+			"http://dummy.com": {
+				JWKsURI:             "http://dummy.com/jwks",
+				SignAlgorithm:       "RS256",
+				UserInfoURI:         "http://dummy.com/userinfo",
+				ExternalIDFieldName: "sub",
+			},
+		}},
+		CustomAttributes: map[string]any{"k1": "v1"},
+		ForcePkce:        &forcePkce,
+		DefaultAudience:  &defaultAudience,
+		ClientType:       &clientType,
+		ForceDpop:        &forceDpop,
+	})
+	require.NoError(t, err)
+}
+
+// An explicitly set zero value is still sent, so a field can be cleared on purpose.
+func TestThirdPartyApplicationPatchSendsExplicitZeroValues(t *testing.T) {
+	mgmt := newTestMgmt(nil, helpers.DoOk(func(r *http.Request) {
+		req := map[string]any{}
+		require.NoError(t, helpers.ReadBody(r, &req))
+		require.Equal(t, map[string]any{
+			"id":           "id1",
+			"loginPageUrl": "",
+			"forceDpop":    false,
+			"forcePkce":    false,
+		}, req)
+	}))
+	loginPageURL := ""
+	forceDpop, forcePkce := false, false
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.PatchThirdPartyApplicationRequest{
+		ID:           "id1",
+		LoginPageURL: &loginPageURL,
+		ForceDpop:    &forceDpop,
+		ForcePkce:    &forcePkce,
 	})
 	require.NoError(t, err)
 }
@@ -662,11 +745,13 @@ func TestThirdPartyApplicationPatchKeepsForceDpopWhenCarried(t *testing.T) {
 		require.Equal(t, true, req["forceDpop"])
 		require.Equal(t, "confidential", req["clientType"])
 	}))
-	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.ThirdPartyApplicationRequest{
+	name, clientType := "renamed", "confidential"
+	forceDpop := true
+	err := mgmt.ThirdPartyApplication().PatchApplication(context.Background(), &descope.PatchThirdPartyApplicationRequest{
 		ID:         "id1",
-		Name:       "renamed",
-		ClientType: "confidential",
-		ForceDpop:  true,
+		Name:       &name,
+		ClientType: &clientType,
+		ForceDpop:  &forceDpop,
 	})
 	require.NoError(t, err)
 }

--- a/descope/sdk/mgmt.go
+++ b/descope/sdk/mgmt.go
@@ -1254,8 +1254,10 @@ type ThirdPartyApplication interface {
 
 	// Patch an existing third party application.
 	//
-	// ID is required to identify the application to be patched.
-	PatchApplication(ctx context.Context, appRequest *descope.ThirdPartyApplicationRequest) error
+	// ID is required to identify the application to be patched. Every other field is
+	// optional: only the fields that are set are sent, and any field left nil keeps
+	// its current value on the application.
+	PatchApplication(ctx context.Context, appRequest *descope.PatchThirdPartyApplicationRequest) error
 
 	// Delete an existing third party application.
 	//

--- a/descope/tests/mocks/mgmt/managementmock.go
+++ b/descope/tests/mocks/mgmt/managementmock.go
@@ -2373,7 +2373,7 @@ type MockThirdPartyApplication struct {
 	LoadApplicationResponse *descope.ThirdPartyApplication
 	LoadApplicationError    error
 
-	PatchApplicationAssert func(*descope.ThirdPartyApplicationRequest)
+	PatchApplicationAssert func(*descope.PatchThirdPartyApplicationRequest)
 	PatchApplicationError  error
 
 	GetApplicationSecretAssert   func(id string)
@@ -2452,7 +2452,7 @@ func (m *MockThirdPartyApplication) LoadAllApplications(_ context.Context, _ *de
 	return m.LoadAllApplicationsResponse, m.LoadAllApplicationsTotal, m.LoadAllApplicationsError
 }
 
-func (m *MockThirdPartyApplication) PatchApplication(_ context.Context, app *descope.ThirdPartyApplicationRequest) error {
+func (m *MockThirdPartyApplication) PatchApplication(_ context.Context, app *descope.PatchThirdPartyApplicationRequest) error {
 	if m.PatchApplicationAssert != nil {
 		m.PatchApplicationAssert(app)
 	}

--- a/descope/types.go
+++ b/descope/types.go
@@ -1832,6 +1832,35 @@ type ThirdPartyApplicationRequest struct {
 	ForceDpop bool `json:"forceDpop,omitempty"`
 }
 
+// PatchThirdPartyApplicationRequest updates only the fields that are set on it. Every
+// field is a pointer, so nil ("leave this alone") is distinct from a pointer to "" or
+// false ("set this to its zero value"). A nil field is omitted from the request and
+// keeps its current value.
+//
+// The list fields can be replaced but not emptied: the API reads an empty list as "not
+// given". Use UpdateApplication to clear one.
+type PatchThirdPartyApplicationRequest struct {
+	// ID identifies the application to patch. Required.
+	ID                   string                                     `json:"id"`
+	Name                 *string                                    `json:"name,omitempty"`
+	Description          *string                                    `json:"description,omitempty"`
+	Logo                 *string                                    `json:"logo,omitempty"`
+	LoginPageURL         *string                                    `json:"loginPageUrl,omitempty"`
+	ApprovedCallbackUrls *[]string                                  `json:"approvedCallbackUrls,omitempty"`
+	PermissionsScopes    *[]*ThirdPartyApplicationScope             `json:"permissionsScopes,omitempty"`
+	ScopeClaimMapping    *[]*ThirdPartyApplicationScopeClaimMapping `json:"scopeClaimMapping,omitempty"`
+	JWTBearerSettings    *JWTBearerSettings                         `json:"jwtBearerSettings,omitempty"`
+	CustomAttributes     map[string]any                             `json:"customAttributes,omitempty"`
+	// ForcePkce requires PKCE on the authorization-code flow in addition to client authentication.
+	ForcePkce *bool `json:"forcePkce,omitempty"`
+	// DefaultAudience controls the default aud of issued tokens: "projectId", "clientId", or "" (both).
+	DefaultAudience *string `json:"defaultAudience,omitempty"`
+	// ClientType sets the client authentication model: "confidential" or "public".
+	ClientType *string `json:"clientType,omitempty"`
+	// ForceDpop requires a valid DPoP proof at the token endpoint. Only a "confidential" or "public" ClientType may require it.
+	ForceDpop *bool `json:"forceDpop,omitempty"`
+}
+
 // Options for loading third party applications
 //
 // Page - allows to paginate over the results. Pages start at 0 and must be non-negative.


### PR DESCRIPTION
Fixes descope/etc#18443

## Description

`PatchApplication` was not a patch. It built its body with `makeCreateUpdateThirdPartyApplicationRequest`, the same helper create and update use, so all 14 fields went out whether the caller set them or not. The patch API writes every field it is given, so a patch that only renamed an application also cleared its login page URL, client type and DPoP requirement.

```
before: loginPageUrl='https://test.com' clientType='confidential' forceDpop=true
after:  loginPageUrl=''                 clientType=''             forceDpop=false
```

This adds `descope.PatchThirdPartyApplicationRequest` and a `makePatchThirdPartyApplicationRequest` builder that omits the fields the caller left alone.

### Why a new dedicated type `PatchThirdPartyApplicationRequest`

It mirrors the backend where dedicated patch endpoint was added https://github.com/descope/backend/pull/1701/changes#diff-4ab0cad398101f904b4bd320eff5f3206a7672d27d4ede694b168d289f3626b9R2069-R2090

## Must
- [x] Tests - `makePatchThirdPartyApplicationRequest` is at 100% statement coverage. Four cases: a rename sends only `id` + `name`; every field set sends all of them; explicitly set zero values (`loginPageUrl: ""`, `forceDpop: false`, `forcePkce: false`) are still sent; and loaded values carried into a patch are preserved. `TestThirdPartyApplicationPatchAlwaysSendsForceDpop`, which documented the old behavior, is replaced.
- [x] Documentation - godoc on the new type and on the interface method, plus a README example.